### PR TITLE
Moved requirements into setup.py.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,20 @@
 [![Latest Version](https://pypip.in/version/pyamg/badge.svg?style=flat)](https://pypi.python.org/pypi/pyamg/)
 [![Downloads](https://pypip.in/download/pyamg/badge.svg?style=flat)](https://pypi.python.org/pypi/pyamg/)
 # Installation
-PyAMG requires `numpy` and `scipy` (see requirements.txt)
+PyAMG requires `numpy` and `scipy`
 
-      pip install -r requirements.txt
       pip install pyamg
 
 or
 
       python setup.py install
-      
+
 
 # Introduction
 
 PyAMG is a library of **Algebraic Multigrid (AMG)** solvers with a convenient Python interface.  
 
-![](Docs/logo/PyAMG_logo.png) 
+![](Docs/logo/PyAMG_logo.png)
 ![](Docs/logo/CS_logo.png)
 
 PyAMG is developed by **[Nathan Bell](http://graphics.cs.uiuc.edu/~wnbell/)**, **[Luke Olson](http://www.cs.uiuc.edu/homes/lukeo/)**, and **[Jacob Schroder](http://grandmaster.colorado.edu/~jacob/index.html)**, in the **[Deparment of Computer Science](http://www.cs.uiuc.edu)** at the **[University of Illinois at Urbana-Champaign](http://www.illinois.edu)**.  Portions of the project were partially supported by the [NSF](http://www.nsf.gov) under award DMS-0612448.
@@ -92,6 +91,6 @@ Program output:
         3         7825        70657 [ 2.58%]
         4         1937        17973 [ 0.66%]
         5          484         4728 [ 0.17%]
-    
+
     residual norm is 1.86112114946e-06
 </pre>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-nose
-numpy
-scipy

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ MINOR = 2
 MICRO = 0
 ISRELEASED = True
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
+INSTALL_REQUIRES=['nose', 'numpy', 'scipy']
 
 # Use NumPy/SciPy style versioning
 #
@@ -175,7 +176,10 @@ def setup_package():
     write_version_py()
 
     # Run build
-    from numpy.distutils.core import setup
+    try:
+        from numpy.distutils.core import setup
+    except ImportError:
+        from setuptools import setup
 
     try:
         setup(
@@ -191,7 +195,8 @@ def setup_package():
             author=AUTHOR,
             author_email=AUTHOR_EMAIL,
             platforms=PLATFORMS,
-            configuration=configuration)
+            configuration=configuration,
+            install_requires=INSTALL_REQUIRES)
     finally:
         del sys.path[0]
         os.chdir(old_path)


### PR DESCRIPTION
Hello,

I've moved pyamg's requirements into the setup.py file so that they are automatically installed when running `pip install pyamg`. This has been motivated by pyamg causing a failure when installing it from my own setup.py file – pyamg would attempt to install before numpy resulting in an import error.  

You can test this PR by executing the following:
```
virtualenv /tmp/pyamg-venv
source /tmp/pyamg-venv/bin/activate
pip install https://github.com/mfergie/pyamg/arc
hive/master.zip
nosetests pyamg
```

Note, I did receive two _known_ errors when running the tests, output below:
```
$ nosetests pyamg
./tmp/pyamg-venv2/lib/python2.7/site-packages/pyamg/aggregation/adaptive.py:227: SparseEfficiencyWarning: Implicit conversion of A to CSR
  scipy.sparse.SparseEfficiencyWarning)
..................................................................................EE..........................................................................................................
======================================================================
ERROR: test_gmres (test_krylov.TestKrylov)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/pyamg-venv2/lib/python2.7/site-packages/numpy/testing/decorators.py", line 213, in knownfailer
    raise KnownFailureTest(msg)
KnownFailureTest: This test is known to fail because of                               complex matrices and Housholder.

======================================================================
ERROR: test_krylov (test_krylov.TestKrylov)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/pyamg-venv2/lib/python2.7/site-packages/numpy/testing/decorators.py", line 213, in knownfailer
    raise KnownFailureTest(msg)
KnownFailureTest: This test is known to fail because of complex                               matrices and Housholder.

----------------------------------------------------------------------
Ran 191 tests in 30.281s

FAILED (errors=2)
```

If you are happy with this pull request, would you consider making a new release?

Thanks,
Martin