### PR TITLE
Add version to the setup() call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -201,7 +201,8 @@ def setup_package():
             author=AUTHOR,
             author_email=AUTHOR_EMAIL,
             platforms=PLATFORMS,
-            configuration=configuration)
+            configuration=configuration,
+            version=VERSION)
     finally:
         del sys.path[0]
         os.chdir(old_path)


### PR DESCRIPTION
Otherwise, pip install fails with:
```
(testvenv2) Martins-iMac:Downloads martin$ pip install pyamg
Collecting pyamg
  Using cached pyamg-3.0.2.tar.gz
Installing collected packages: pyamg
  Running setup.py install for pyamg ... done
Successfully installed pyamg-0.0.0
(testvenv2) Martins-iMac:Downloads martin$
```