### PR TITLE
CG symmetric smoothing warning

### DIFF
--- a/pyamg/multilevel.py
+++ b/pyamg/multilevel.py
@@ -380,6 +380,11 @@ class multilevel_solver:
 
         if accel is not None:
 
+            # Check for symmetric smoothing scheme when using CG
+            if (accel is 'cg') and (self.symmetric_smoothing == False):
+                warn('CG requires SPD matrix. Non-symmetric smoothing scheme '\
+                     'may significantly increase convergence factors.')
+
             # Check for AMLI compatability
             if (accel != 'fgmres') and (cycle == 'AMLI'):
                 raise ValueError('AMLI cycles require acceleration (accel) \

--- a/pyamg/multilevel.py
+++ b/pyamg/multilevel.py
@@ -382,8 +382,9 @@ class multilevel_solver:
 
             # Check for symmetric smoothing scheme when using CG
             if (accel is 'cg') and (self.symmetric_smoothing == False):
-                warn('CG requires SPD matrix. Non-symmetric smoothing scheme '\
-                     'may significantly increase convergence factors.')
+                warn('Incompatible non-symmetric multigrid preconditioner detected, '
+                     'due to presmoother/postsmoother combination. CG requires SPD '
+                     'preconditioner, not just SPD matrix.')
 
             # Check for AMLI compatability
             if (accel != 'fgmres') and (cycle == 'AMLI'):

--- a/pyamg/relaxation/smoothing.py
+++ b/pyamg/relaxation/smoothing.py
@@ -193,7 +193,11 @@ def change_smoothers(ml, presmoother, postsmoother):
                     sweep2 = 'symmetric'
                 else:
                     sweep2 = 'forward'
-            if (sweep1 != 'symmetric') or (sweep2 != 'symmetric'):
+            if  (sweep1 == 'forward' and sweep2 == 'backward') or \
+                (sweep1 == 'backward' and sweep2 == 'forward') or \
+                (sweep1 == 'symmetric' and sweep2 == 'symmetric'):
+                pass
+            else:
                 ml.symmetric_smoothing = False
 
     if len(presmoother) < len(postsmoother):
@@ -238,7 +242,11 @@ def change_smoothers(ml, presmoother, postsmoother):
                         sweep2 = 'symmetric'
                     else:
                         sweep2 = 'forward'
-                if (sweep1 != 'symmetric') or (sweep2 != 'symmetric'):
+                if  (sweep1 == 'forward' and sweep2 == 'backward') or \
+                    (sweep1 == 'backward' and sweep2 == 'forward') or \
+                    (sweep1 == 'symmetric' and sweep2 == 'symmetric'):
+                    pass
+                else:
                     ml.symmetric_smoothing = False
 
     elif len(presmoother) > len(postsmoother):
@@ -283,8 +291,12 @@ def change_smoothers(ml, presmoother, postsmoother):
                         sweep2 = 'symmetric'
                     else:
                         sweep2 = 'forward'
-                if (sweep1 != 'symmetric') or (sweep2 != 'symmetric'):
-                    ml.symmetric_smoothing = False     
+                if  (sweep1 == 'forward' and sweep2 == 'backward') or \
+                    (sweep1 == 'backward' and sweep2 == 'forward') or \
+                    (sweep1 == 'symmetric' and sweep2 == 'symmetric'):
+                    pass
+                else:
+                    ml.symmetric_smoothing = False
 
     else:  
         mid_len = min_len

--- a/pyamg/relaxation/smoothing.py
+++ b/pyamg/relaxation/smoothing.py
@@ -193,8 +193,7 @@ def change_smoothers(ml, presmoother, postsmoother):
                     sweep2 = 'symmetric'
                 else:
                     sweep2 = 'forward'
-
-             if (sweep1 != 'symmetric') or (sweep2 != 'symmetric'):
+            if (sweep1 != 'symmetric') or (sweep2 != 'symmetric'):
                 ml.symmetric_smoothing = False
 
     if len(presmoother) < len(postsmoother):
@@ -239,8 +238,7 @@ def change_smoothers(ml, presmoother, postsmoother):
                         sweep2 = 'symmetric'
                     else:
                         sweep2 = 'forward'
-
-                 if (sweep1 != 'symmetric') or (sweep2 != 'symmetric'):
+                if (sweep1 != 'symmetric') or (sweep2 != 'symmetric'):
                     ml.symmetric_smoothing = False
 
     elif len(presmoother) > len(postsmoother):
@@ -285,10 +283,9 @@ def change_smoothers(ml, presmoother, postsmoother):
                             sweep2 = 'symmetric'
                         else:
                             sweep2 = 'forward'
-
-                     if (sweep1 != 'symmetric') or (sweep2 != 'symmetric'):
+                    if (sweep1 != 'symmetric') or (sweep2 != 'symmetric'):
                         ml.symmetric_smoothing = False     
-                        
+
     else:  
         mid_len = min_len
 

--- a/pyamg/relaxation/smoothing.py
+++ b/pyamg/relaxation/smoothing.py
@@ -167,12 +167,34 @@ def change_smoothers(ml, presmoother, postsmoother):
         ml.levels[i].postsmoother = setup_postsmoother(ml.levels[i], **kwargs2)
 
         # Check if symmetric smoothing scheme
-        if (fn1 != fn2) or (kwargs1['iterations'] != kwargs2['iterations']):
+        try:
+            it1 = kwargs1['iterations']
+        except:
+            it1 = 1
+        try:
+            it2 = kwargs2['iterations']
+        except:
+            it2 = 1
+        if (fn1 != fn2) or (it1 != it2):
             ml.symmetric_smoothing = False
         elif (fn1 != 'jacobi') and (fn1 != 'richardson') and \
              (fn1 != 'block_jacobi') and (fn1 != 'jacobi_ne'):
-             if (kwargs1['sweep'] != 'symmetric') or \
-                (kwargs2['sweep'] != 'symmetric'):
+            try:
+                sweep1 = kwargs1['sweep']
+            except:
+                if (fn1 == 'strength_based_schwarz') or (fn1 == 'schwarz'):
+                    sweep1 = 'symmetric'
+                else:
+                    sweep1 = 'forward'
+            try:
+                sweep2 = kwargs2['sweep']
+            except:
+                if (fn2 == 'strength_based_schwarz') or (fn2 == 'schwarz'):
+                    sweep2 = 'symmetric'
+                else:
+                    sweep2 = 'forward'
+
+             if (sweep1 != 'symmetric') or (sweep2 != 'symmetric'):
                 ml.symmetric_smoothing = False
 
     if len(presmoother) < len(postsmoother):
@@ -191,12 +213,34 @@ def change_smoothers(ml, presmoother, postsmoother):
             ml.levels[i].postsmoother = setup_postsmoother(ml.levels[i], **kwargs2)
 
             # Check if symmetric smoothing scheme
-            if (fn1 != fn2) or (kwargs1['iterations'] != kwargs2['iterations']):
+            try:
+                it1 = kwargs1['iterations']
+            except:
+                it1 = 1
+            try:
+                it2 = kwargs2['iterations']
+            except:
+                it2 = 1
+            if (fn1 != fn2) or (it1 != it2):
                 ml.symmetric_smoothing = False
             elif (fn1 != 'jacobi') and (fn1 != 'richardson') and \
                  (fn1 != 'block_jacobi') and (fn1 != 'jacobi_ne'):
-                 if (kwargs1['sweep'] != 'symmetric') or \
-                    (kwargs2['sweep'] != 'symmetric'):
+                try:
+                    sweep1 = kwargs1['sweep']
+                except:
+                    if (fn1 == 'strength_based_schwarz') or (fn1 == 'schwarz'):
+                        sweep1 = 'symmetric'
+                    else:
+                        sweep1 = 'forward'
+                try:
+                    sweep2 = kwargs2['sweep']
+                except:
+                    if (fn2 == 'strength_based_schwarz') or (fn2 == 'schwarz'):
+                        sweep2 = 'symmetric'
+                    else:
+                        sweep2 = 'forward'
+
+                 if (sweep1 != 'symmetric') or (sweep2 != 'symmetric'):
                     ml.symmetric_smoothing = False
 
     elif len(presmoother) > len(postsmoother):
@@ -215,14 +259,36 @@ def change_smoothers(ml, presmoother, postsmoother):
             ml.levels[i].postsmoother = setup_postsmoother(ml.levels[i], **kwargs2)
 
             # Check if symmetric smoothing scheme
-            if (fn1 != fn2) or (kwargs1['iterations'] != kwargs2['iterations']):
+            try:
+                it1 = kwargs1['iterations']
+            except:
+                it1 = 1
+            try:
+                it2 = kwargs2['iterations']
+            except:
+                it2 = 1
+            if (fn1 != fn2) or (it1 != it2):
                 ml.symmetric_smoothing = False
             elif (fn1 != 'jacobi') and (fn1 != 'richardson') and \
                  (fn1 != 'block_jacobi') and (fn1 != 'jacobi_ne'):
-                 if (kwargs1['sweep'] != 'symmetric') or \
-                    (kwargs2['sweep'] != 'symmetric'):
-                    ml.symmetric_smoothing = False       
+                try:
+                        sweep1 = kwargs1['sweep']
+                    except:
+                        if (fn1 == 'strength_based_schwarz') or (fn1 == 'schwarz'):
+                            sweep1 = 'symmetric'
+                        else:
+                            sweep1 = 'forward'
+                    try:
+                        sweep2 = kwargs2['sweep']
+                    except:
+                        if (fn2 == 'strength_based_schwarz') or (fn2 == 'schwarz'):
+                            sweep2 = 'symmetric'
+                        else:
+                            sweep2 = 'forward'
 
+                     if (sweep1 != 'symmetric') or (sweep2 != 'symmetric'):
+                        ml.symmetric_smoothing = False     
+                        
     else:  
         mid_len = min_len
 

--- a/pyamg/relaxation/smoothing.py
+++ b/pyamg/relaxation/smoothing.py
@@ -14,6 +14,13 @@ __docformat__ = "restructuredtext en"
 __all__ = ['change_smoothers']
 
 
+# Default relaxation parameters and list of by-definition
+# symmetric relaxation schemes, e.g. Jacobi.
+DEFAULT_SWEEP = 'forward'
+DEFAULT_NITER = 1
+SYMMETRIC_RELAXATION = ['jacobi', 'richardson', 'block_jacobi',
+                        'jacobi_ne', 'chebyshev', None ]
+
 def unpack_arg(v):
     if isinstance(v, tuple):
         return v[0], v[1]
@@ -58,8 +65,10 @@ def change_smoothers(ml, presmoother, postsmoother):
     Returns
     -------
     ml changed in place
-    ml.level[i].presmoother  <===  presmoother[i]
+    ml.level[i].presmoother   <===  presmoother[i]
     ml.level[i].postsmoother  <===  postsmoother[i]
+    ml.symmetric_smoothing is marked True/False depending on whether
+        the smoothing scheme is symmetric. 
 
     Notes
     -----
@@ -138,7 +147,6 @@ def change_smoothers(ml, presmoother, postsmoother):
     elif not isinstance(postsmoother, list):
         raise ValueError('Unrecognized postsmoother')
 
-
     # set ml.levels[i].presmoother = presmoother[i],
     #     ml.levels[i].postsmoother = postsmoother[i]
     fn1 = None      # Predefine to keep scope beyond first loop
@@ -177,23 +185,15 @@ def change_smoothers(ml, presmoother, postsmoother):
             it2 = 1
         if (fn1 != fn2) or (it1 != it2):
             ml.symmetric_smoothing = False
-        elif (fn1 != 'jacobi') and (fn1 != 'richardson') and \
-             (fn1 != 'block_jacobi') and (fn1 != 'jacobi_ne') and \
-             (fn1 != 'chebyshev') and (fn1 != None):
+        elif fn1 not in SYMMETRIC_RELAXATION:
             try:
                 sweep1 = kwargs1['sweep']
             except:
-                if (fn1 == 'strength_based_schwarz') or (fn1 == 'schwarz'):
-                    sweep1 = 'symmetric'
-                else:
-                    sweep1 = 'forward'
+                sweep1 = DEFAULT_SWEEP
             try:
                 sweep2 = kwargs2['sweep']
             except:
-                if (fn2 == 'strength_based_schwarz') or (fn2 == 'schwarz'):
-                    sweep2 = 'symmetric'
-                else:
-                    sweep2 = 'forward'
+                sweep2 = DEFAULT_SWEEP
             if  (sweep1 == 'forward' and sweep2 == 'backward') or \
                 (sweep1 == 'backward' and sweep2 == 'forward') or \
                 (sweep1 == 'symmetric' and sweep2 == 'symmetric'):
@@ -227,23 +227,15 @@ def change_smoothers(ml, presmoother, postsmoother):
                 it2 = 1
             if (fn1 != fn2) or (it1 != it2):
                 ml.symmetric_smoothing = False
-            elif (fn1 != 'jacobi') and (fn1 != 'richardson') and \
-                 (fn1 != 'block_jacobi') and (fn1 != 'jacobi_ne') and \
-                 (fn1 != 'chebyshev') and (fn1 != None):
+            elif fn1 not in SYMMETRIC_RELAXATION:
                 try:
                     sweep1 = kwargs1['sweep']
                 except:
-                    if (fn1 == 'strength_based_schwarz') or (fn1 == 'schwarz'):
-                        sweep1 = 'symmetric'
-                    else:
-                        sweep1 = 'forward'
+                    sweep1 = DEFAULT_SWEEP
                 try:
                     sweep2 = kwargs2['sweep']
                 except:
-                    if (fn2 == 'strength_based_schwarz') or (fn2 == 'schwarz'):
-                        sweep2 = 'symmetric'
-                    else:
-                        sweep2 = 'forward'
+                    sweep2 = DEFAULT_SWEEP
                 if  (sweep1 == 'forward' and sweep2 == 'backward') or \
                     (sweep1 == 'backward' and sweep2 == 'forward') or \
                     (sweep1 == 'symmetric' and sweep2 == 'symmetric'):
@@ -277,23 +269,15 @@ def change_smoothers(ml, presmoother, postsmoother):
                 it2 = 1
             if (fn1 != fn2) or (it1 != it2):
                 ml.symmetric_smoothing = False
-            elif (fn1 != 'jacobi') and (fn1 != 'richardson') and \
-                 (fn1 != 'block_jacobi') and (fn1 != 'jacobi_ne') and \
-                 (fn1 != 'chebyshev') and (fn1 != None):
+            elif fn1 not in SYMMETRIC_RELAXATION:
                 try:
                     sweep1 = kwargs1['sweep']
                 except:
-                    if (fn1 == 'strength_based_schwarz') or (fn1 == 'schwarz'):
-                        sweep1 = 'symmetric'
-                    else:
-                        sweep1 = 'forward'
+                    sweep1 = DEFAULT_SWEEP
                 try:
                     sweep2 = kwargs2['sweep']
                 except:
-                    if (fn2 == 'strength_based_schwarz') or (fn2 == 'schwarz'):
-                        sweep2 = 'symmetric'
-                    else:
-                        sweep2 = 'forward'
+                    sweep2 = DEFAULT_SWEEP
                 if  (sweep1 == 'forward' and sweep2 == 'backward') or \
                     (sweep1 == 'backward' and sweep2 == 'forward') or \
                     (sweep1 == 'symmetric' and sweep2 == 'symmetric'):
@@ -459,13 +443,13 @@ def matrix_asformat(lvl, name, format, blocksize=None):
 """
 
 
-def setup_gauss_seidel(lvl, iterations=1, sweep='forward'):
+def setup_gauss_seidel(lvl, iterations=DEFAULT_NITER, sweep=DEFAULT_SWEEP):
     def smoother(A, x, b):
         relaxation.gauss_seidel(A, x, b, iterations=iterations, sweep=sweep)
     return smoother
 
 
-def setup_jacobi(lvl, iterations=1, omega=1.0, withrho=True):
+def setup_jacobi(lvl, iterations=DEFAULT_NITER, omega=1.0, withrho=True):
     if withrho:
         omega = omega/rho_D_inv_A(lvl.A)
 
@@ -474,8 +458,8 @@ def setup_jacobi(lvl, iterations=1, omega=1.0, withrho=True):
     return smoother
 
 
-def setup_schwarz(lvl, iterations=1, subdomain=None, subdomain_ptr=None,
-                  inv_subblock=None, inv_subblock_ptr=None, sweep='symmetric'):
+def setup_schwarz(lvl, iterations=DEFAULT_NITER, subdomain=None, subdomain_ptr=None,
+                  inv_subblock=None, inv_subblock_ptr=None, sweep=DEFAULT_SWEEP):
 
     matrix_asformat(lvl, 'A', 'csr')
     subdomain, subdomain_ptr, inv_subblock, inv_subblock_ptr = \
@@ -490,7 +474,7 @@ def setup_schwarz(lvl, iterations=1, subdomain=None, subdomain_ptr=None,
     return smoother
 
 
-def setup_strength_based_schwarz(lvl, iterations=1, sweep='symmetric'):
+def setup_strength_based_schwarz(lvl, iterations=DEFAULT_NITER, sweep=DEFAULT_SWEEP):
     # Use the overlapping regions defined by strength of connection matrix C
     # for the overlapping Schwarz method
     if not hasattr(lvl, 'C'):
@@ -505,8 +489,8 @@ def setup_strength_based_schwarz(lvl, iterations=1, sweep='symmetric'):
                          subdomain_ptr=subdomain_ptr, sweep=sweep)
 
 
-def setup_block_jacobi(lvl, iterations=1, omega=1.0, Dinv=None, blocksize=None,
-                       withrho=True):
+def setup_block_jacobi(lvl, iterations=DEFAULT_NITER, omega=1.0, Dinv=None,
+                       blocksize=None, withrho=True):
     # Determine Blocksize
     if blocksize is None and Dinv is None:
         if sp.sparse.isspmatrix_csr(lvl.A):
@@ -534,8 +518,8 @@ def setup_block_jacobi(lvl, iterations=1, omega=1.0, Dinv=None, blocksize=None,
         return smoother
 
 
-def setup_block_gauss_seidel(lvl, iterations=1, sweep='forward', Dinv=None,
-                             blocksize=None):
+def setup_block_gauss_seidel(lvl, iterations=DEFAULT_NITER, sweep=DEFAULT_SWEEP,
+                             Dinv=None, blocksize=None):
     # Determine Blocksize
     if blocksize is None and Dinv is None:
         if sp.sparse.isspmatrix_csr(lvl.A):
@@ -561,7 +545,7 @@ def setup_block_gauss_seidel(lvl, iterations=1, sweep='forward', Dinv=None,
         return smoother
 
 
-def setup_richardson(lvl, iterations=1, omega=1.0):
+def setup_richardson(lvl, iterations=DEFAULT_NITER, omega=1.0):
     omega = omega/approximate_spectral_radius(lvl.A)
 
     def smoother(A, x, b):
@@ -570,7 +554,7 @@ def setup_richardson(lvl, iterations=1, omega=1.0):
     return smoother
 
 
-def setup_sor(lvl, omega=0.5, iterations=1, sweep='forward'):
+def setup_sor(lvl, omega=0.5, iterations=DEFAULT_NITER, sweep=DEFAULT_SWEEP):
     def smoother(A, x, b):
         relaxation.sor(A, x, b, omega=omega, iterations=iterations,
                        sweep=sweep)
@@ -578,7 +562,7 @@ def setup_sor(lvl, omega=0.5, iterations=1, sweep='forward'):
 
 
 def setup_chebyshev(lvl, lower_bound=1.0/30.0, upper_bound=1.1, degree=3,
-                    iterations=1):
+                    iterations=DEFAULT_NITER):
     rho = approximate_spectral_radius(lvl.A)
     a = rho * lower_bound
     b = rho * upper_bound
@@ -591,7 +575,7 @@ def setup_chebyshev(lvl, lower_bound=1.0/30.0, upper_bound=1.1, degree=3,
     return smoother
 
 
-def setup_jacobi_ne(lvl, iterations=1, omega=1.0, withrho=True):
+def setup_jacobi_ne(lvl, iterations=DEFAULT_NITER, omega=1.0, withrho=True):
     matrix_asformat(lvl, 'A', 'csr')
     if withrho:
         omega = omega/rho_D_inv_A(lvl.Acsr)**2
@@ -602,7 +586,8 @@ def setup_jacobi_ne(lvl, iterations=1, omega=1.0, withrho=True):
     return smoother
 
 
-def setup_gauss_seidel_ne(lvl, iterations=1, sweep='forward', omega=1.0):
+def setup_gauss_seidel_ne(lvl, iterations=DEFAULT_NITER, sweep=DEFAULT_SWEEP,
+                          omega=1.0):
     matrix_asformat(lvl, 'A', 'csr')
 
     def smoother(A, x, b):
@@ -611,7 +596,8 @@ def setup_gauss_seidel_ne(lvl, iterations=1, sweep='forward', omega=1.0):
     return smoother
 
 
-def setup_gauss_seidel_nr(lvl, iterations=1, sweep='forward', omega=1.0):
+def setup_gauss_seidel_nr(lvl, iterations=DEFAULT_NITER, sweep=DEFAULT_SWEEP,
+                          omega=1.0):
     matrix_asformat(lvl, 'A', 'csc')
 
     def smoother(A, x, b):

--- a/pyamg/relaxation/smoothing.py
+++ b/pyamg/relaxation/smoothing.py
@@ -270,21 +270,21 @@ def change_smoothers(ml, presmoother, postsmoother):
             elif (fn1 != 'jacobi') and (fn1 != 'richardson') and \
                  (fn1 != 'block_jacobi') and (fn1 != 'jacobi_ne'):
                 try:
-                        sweep1 = kwargs1['sweep']
-                    except:
-                        if (fn1 == 'strength_based_schwarz') or (fn1 == 'schwarz'):
-                            sweep1 = 'symmetric'
-                        else:
-                            sweep1 = 'forward'
-                    try:
-                        sweep2 = kwargs2['sweep']
-                    except:
-                        if (fn2 == 'strength_based_schwarz') or (fn2 == 'schwarz'):
-                            sweep2 = 'symmetric'
-                        else:
-                            sweep2 = 'forward'
-                    if (sweep1 != 'symmetric') or (sweep2 != 'symmetric'):
-                        ml.symmetric_smoothing = False     
+                    sweep1 = kwargs1['sweep']
+                except:
+                    if (fn1 == 'strength_based_schwarz') or (fn1 == 'schwarz'):
+                        sweep1 = 'symmetric'
+                    else:
+                        sweep1 = 'forward'
+                try:
+                    sweep2 = kwargs2['sweep']
+                except:
+                    if (fn2 == 'strength_based_schwarz') or (fn2 == 'schwarz'):
+                        sweep2 = 'symmetric'
+                    else:
+                        sweep2 = 'forward'
+                if (sweep1 != 'symmetric') or (sweep2 != 'symmetric'):
+                    ml.symmetric_smoothing = False     
 
     else:  
         mid_len = min_len

--- a/pyamg/relaxation/smoothing.py
+++ b/pyamg/relaxation/smoothing.py
@@ -178,7 +178,8 @@ def change_smoothers(ml, presmoother, postsmoother):
         if (fn1 != fn2) or (it1 != it2):
             ml.symmetric_smoothing = False
         elif (fn1 != 'jacobi') and (fn1 != 'richardson') and \
-             (fn1 != 'block_jacobi') and (fn1 != 'jacobi_ne'):
+             (fn1 != 'block_jacobi') and (fn1 != 'jacobi_ne') and \
+             (fn1 != 'chebyshev') and (fn1 != None):
             try:
                 sweep1 = kwargs1['sweep']
             except:
@@ -227,7 +228,8 @@ def change_smoothers(ml, presmoother, postsmoother):
             if (fn1 != fn2) or (it1 != it2):
                 ml.symmetric_smoothing = False
             elif (fn1 != 'jacobi') and (fn1 != 'richardson') and \
-                 (fn1 != 'block_jacobi') and (fn1 != 'jacobi_ne'):
+                 (fn1 != 'block_jacobi') and (fn1 != 'jacobi_ne') and \
+                 (fn1 != 'chebyshev') and (fn1 != None):
                 try:
                     sweep1 = kwargs1['sweep']
                 except:
@@ -276,7 +278,8 @@ def change_smoothers(ml, presmoother, postsmoother):
             if (fn1 != fn2) or (it1 != it2):
                 ml.symmetric_smoothing = False
             elif (fn1 != 'jacobi') and (fn1 != 'richardson') and \
-                 (fn1 != 'block_jacobi') and (fn1 != 'jacobi_ne'):
+                 (fn1 != 'block_jacobi') and (fn1 != 'jacobi_ne') and \
+                 (fn1 != 'chebyshev') and (fn1 != None):
                 try:
                     sweep1 = kwargs1['sweep']
                 except:

--- a/pyamg/relaxation/tests/test_smoothing.py
+++ b/pyamg/relaxation/tests/test_smoothing.py
@@ -5,16 +5,16 @@ from pyamg.relaxation.smoothing import change_smoothers
 
 from numpy.testing import TestCase
 
-methods = ['gauss_seidel',
+methods = [('gauss_seidel', {'sweep' : 'symmetric'})
            'jacobi',
            'richardson',
-           'sor',
+           ('sor', {'sweep' : 'symmetric'})
            'chebyshev',
-           'gauss_seidel_ne',
+           ('gauss_seidel_ne', {'sweep' : 'symmetric'})
            'jacobi_ne',
-           'gauss_seidel_nr',
-           'schwarz',
-           'strength_based_schwarz']
+           ('gauss_seidel_nr', {'sweep' : 'symmetric'})
+           ('schwarz', {'sweep' : 'symmetric'})
+           ('strength_based_schwarz', {'sweep' : 'symmetric'})]
 
 methods2 = [('gauss_seidel', 'richardson'),
             ('gauss_seidel', 'jacobi'),
@@ -29,6 +29,33 @@ methods2 = [('gauss_seidel', 'richardson'),
               ('gmres', {'maxiter': 3})], None),
             (None, ['cg', 'cgnr', 'cgne'])]
 
+# Symmetric smoothing schemes
+methods3 = [ [[('gauss_seidel', {'sweep' : 'forward'}), None], 
+              [('gauss_seidel', {'sweep' : 'backward'}), None]], 
+             [[('gauss_seidel_nr', {'sweep' : 'backward'}), 'jacobi'], 
+              [('gauss_seidel_nr', {'sweep' : 'forward'}), 'jacobi']], 
+             [[('jacobi', {'iterations' : 2}), ('jacobi', {'iterations' : 1})], 
+              [('jacobi', {'iterations' : 2}), ('jacobi', {'iterations' : 1})]],
+             [[('gauss_seidel_ne', {'sweep' : 'forward'}), None], 
+              [('gauss_seidel_ne', {'sweep' : 'backward'}), None]], 
+             [[('block_gauss_seidel', {'sweep' : 'backward'}), 'jacobi'], 
+              [('block_gauss_seidel', {'sweep' : 'forward'}), 'jacobi']], 
+             [[('jacobi_ne', {'iterations' : 2}), ('block_jacobi', {'iterations' : 1})], 
+              [('jacobi_ne', {'iterations' : 2}), ('block_jacobi', {'iterations' : 1})]] ]
+
+# Non-symmetric smoothing schemes
+methods4 = [ [[('gauss_seidel', {'sweep' : 'forward'}), None], 
+              [('gauss_seidel', {'sweep' : 'forward'}), None]], 
+             [[('gauss_seidel_nr', {'sweep' : 'symmetric'}), 'jacobi'], 
+              [('gauss_seidel_nr', {'sweep' : 'backward'}), 'jacobi']], 
+             [[('jacobi', {'iterations' : 2}), ('jacobi', {'iterations' : 1})], 
+              [('jacobi', {'iterations' : 2}), ('jacobi', {'iterations' : 2})]],
+             [[('gauss_seidel_ne', {'sweep' : 'backward'}), None], 
+              [('gauss_seidel_ne', {'sweep' : 'backward'}), None]], 
+             [[('block_gauss_seidel', {'sweep' : 'backward'}), ('jacobi', {'iterations' : 1})], 
+              [('block_gauss_seidel', {'sweep' : 'forward'}), ('jacobi', {'iterations' : 2})]], 
+             [[('jacobi_ne', {'iterations' : 1}), ('block_jacobi', {'iterations' : 1})], 
+              [('jacobi_ne', {'iterations' : 2}), ('block_jacobi', {'iterations' : 1})]] ]
 
 class TestSmoothing(TestCase):
     def test_solver_parameters(self):
@@ -42,6 +69,7 @@ class TestSmoothing(TestCase):
 
             residuals = profile_solver(ml)
             assert((residuals[-1]/residuals[0])**(1.0/len(residuals)) < 0.95)
+            assert(ml.symmetric_smoothing)
 
         for method in methods2:
             ml = smoothed_aggregation_solver(A, max_coarse=10)
@@ -49,3 +77,14 @@ class TestSmoothing(TestCase):
 
             residuals = profile_solver(ml)
             assert((residuals[-1]/residuals[0])**(1.0/len(residuals)) < 0.95)
+            assert(not ml.symmetric_smoothing)
+
+        for method in methods3:
+            ml = smoothed_aggregation_solver(A, max_coarse=10)
+            change_smoothers(ml, presmoother=method[0], postsmoother=method[1])
+            assert(ml.symmetric_smoothing)
+
+        for method in methods4:
+            ml = smoothed_aggregation_solver(A, max_coarse=10)
+            change_smoothers(ml, presmoother=method[0], postsmoother=method[1])
+            assert(not ml.symmetric_smoothing)

--- a/pyamg/relaxation/tests/test_smoothing.py
+++ b/pyamg/relaxation/tests/test_smoothing.py
@@ -5,15 +5,15 @@ from pyamg.relaxation.smoothing import change_smoothers
 
 from numpy.testing import TestCase
 
-methods = [('gauss_seidel', {'sweep' : 'symmetric'})
+methods = [('gauss_seidel', {'sweep' : 'symmetric'}),
            'jacobi',
            'richardson',
-           ('sor', {'sweep' : 'symmetric'})
+           ('sor', {'sweep' : 'symmetric'}),
            'chebyshev',
-           ('gauss_seidel_ne', {'sweep' : 'symmetric'})
+           ('gauss_seidel_ne', {'sweep' : 'symmetric'}),
            'jacobi_ne',
-           ('gauss_seidel_nr', {'sweep' : 'symmetric'})
-           ('schwarz', {'sweep' : 'symmetric'})
+           ('gauss_seidel_nr', {'sweep' : 'symmetric'}),
+           ('schwarz', {'sweep' : 'symmetric'}),
            ('strength_based_schwarz', {'sweep' : 'symmetric'})]
 
 methods2 = [('gauss_seidel', 'richardson'),
@@ -79,6 +79,9 @@ class TestSmoothing(TestCase):
             assert((residuals[-1]/residuals[0])**(1.0/len(residuals)) < 0.95)
             assert(not ml.symmetric_smoothing)
 
+        import pdb
+        pdb.set_trace()
+        
         for method in methods3:
             ml = smoothed_aggregation_solver(A, max_coarse=10)
             change_smoothers(ml, presmoother=method[0], postsmoother=method[1])

--- a/pyamg/relaxation/tests/test_smoothing.py
+++ b/pyamg/relaxation/tests/test_smoothing.py
@@ -38,8 +38,8 @@ methods3 = [ [[('gauss_seidel', {'sweep' : 'forward'}), None],
               [('jacobi', {'iterations' : 2}), ('jacobi', {'iterations' : 1})]],
              [[('gauss_seidel_ne', {'sweep' : 'forward'}), None], 
               [('gauss_seidel_ne', {'sweep' : 'backward'}), None]], 
-             [[('block_gauss_seidel', {'sweep' : 'backward'}), 'jacobi'], 
-              [('block_gauss_seidel', {'sweep' : 'forward'}), 'jacobi']], 
+             [[('block_gauss_seidel', {'sweep' : 'backward'}), 'richardson'], 
+              [('block_gauss_seidel', {'sweep' : 'forward'}), 'richardson']], 
              [[('jacobi_ne', {'iterations' : 2}), ('block_jacobi', {'iterations' : 1})], 
               [('jacobi_ne', {'iterations' : 2}), ('block_jacobi', {'iterations' : 1})]] ]
 
@@ -48,8 +48,8 @@ methods4 = [ [[('gauss_seidel', {'sweep' : 'forward'}), None],
               [('gauss_seidel', {'sweep' : 'forward'}), None]], 
              [[('gauss_seidel_nr', {'sweep' : 'symmetric'}), 'jacobi'], 
               [('gauss_seidel_nr', {'sweep' : 'backward'}), 'jacobi']], 
-             [[('jacobi', {'iterations' : 2}), ('jacobi', {'iterations' : 1})], 
-              [('jacobi', {'iterations' : 2}), ('jacobi', {'iterations' : 2})]],
+             [[('jacobi', {'iterations' : 2}), ('richardson', {'iterations' : 1})], 
+              [('jacobi', {'iterations' : 2}), ('richardson', {'iterations' : 2})]],
              [[('gauss_seidel_ne', {'sweep' : 'backward'}), None], 
               [('gauss_seidel_ne', {'sweep' : 'backward'}), None]], 
              [[('block_gauss_seidel', {'sweep' : 'backward'}), ('jacobi', {'iterations' : 1})], 
@@ -79,9 +79,6 @@ class TestSmoothing(TestCase):
             assert((residuals[-1]/residuals[0])**(1.0/len(residuals)) < 0.95)
             assert(not ml.symmetric_smoothing)
 
-        import pdb
-        pdb.set_trace()
-        
         for method in methods3:
             ml = smoothed_aggregation_solver(A, max_coarse=10)
             change_smoothers(ml, presmoother=method[0], postsmoother=method[1])

--- a/pyamg/util/utils.py
+++ b/pyamg/util/utils.py
@@ -1178,7 +1178,7 @@ def relaxation_as_linear_operator(method, A, b):
     accepted_methods = ['gauss_seidel', 'block_gauss_seidel', 'sor',
                         'gauss_seidel_ne', 'gauss_seidel_nr', 'jacobi',
                         'block_jacobi', 'richardson', 'schwarz',
-                        'strength_based_schwarz']
+                        'strength_based_schwarz', 'jacobi_ne']
 
     b = np.array(b, dtype=A.dtype)
     fn, kwargs = unpack_arg(method)


### PR DESCRIPTION
Added warning to multilevel.solve() checking for symmetric smoothing scheme when using CG. This required a ml.symmetric_smoother flag, which is set in change_smoothers(). Also added jacobi_ne to possible smoothers in relaxation_as_linear_operator, as it was missing for unknown reasons. 

- Indexed GS is still missing a setup function as well as from relaxation_as_linear_operator. However, this is more complicated than jacobi_ne, because it needs indices on each level, so maybe this was intentional?

- Probably need to put in some unit tests. I ran about all possible tests I could think of to verify the warning came out when expected and didn't mess up the smoother initiation, but have not written actual unit tests. 