### PR TITLE
Adjusted default parameters in RN, SA, RS

### DIFF
--- a/pyamg/aggregation/adaptive.py
+++ b/pyamg/aggregation/adaptive.py
@@ -113,7 +113,7 @@ def unpack_arg(v):
 def adaptive_sa_solver(A, initial_candidates=None, symmetry='hermitian',
                        pdef=True, num_candidates=1, candidate_iters=5,
                        improvement_iters=0, epsilon=0.1,
-                       max_levels=10, max_coarse=100, aggregate='standard',
+                       max_levels=10, max_coarse=10, aggregate='standard',
                        prepostsmoother=('gauss_seidel',
                                         {'sweep': 'symmetric'}),
                        smooth=('jacobi', {}), strength='symmetric',

--- a/pyamg/aggregation/aggregation.py
+++ b/pyamg/aggregation/aggregation.py
@@ -38,7 +38,7 @@ def smoothed_aggregation_solver(A, B=None, BH=None,
                                                     {'sweep': 'symmetric',
                                                      'iterations': 4}),
                                                     None],
-                                max_levels = 10, max_coarse = 500,
+                                max_levels = 10, max_coarse = 10,
                                 diagonal_dominance=False,
                                 keep=False, **kwargs):
     """

--- a/pyamg/aggregation/rootnode.py
+++ b/pyamg/aggregation/rootnode.py
@@ -34,10 +34,10 @@ def rootnode_solver(A, B=None, BH=None,
                                  {'sweep': 'symmetric'}),
                     postsmoother=('block_gauss_seidel',
                                   {'sweep': 'symmetric'}),
-                    improve_candidates=[('block_gauss_seidel',
+                    improve_candidates=('block_gauss_seidel',
                                         {'sweep': 'symmetric',
-                                         'iterations': 4}), None],
-                    max_levels = 10, max_coarse = 500,
+                                         'iterations': 4}),
+                    max_levels = 10, max_coarse = 10,
                     diagonal_dominance=False, keep=False, **kwargs):
     """
     Create a multilevel solver using root-node based Smoothed Aggregation (SA).

--- a/pyamg/aggregation/tests/test_aggregation.py
+++ b/pyamg/aggregation/tests/test_aggregation.py
@@ -405,8 +405,8 @@ class TestSolverPerformance(TestCase):
         for coarse1, coarse2 in coarse_solver_pairs:
             r1 = []
             r2 = []
-            sa1 = smoothed_aggregation_solver(A, coarse_solver=coarse1)
-            sa2 = smoothed_aggregation_solver(A, coarse_solver=coarse2)
+            sa1 = smoothed_aggregation_solver(A, coarse_solver=coarse1, max_coarse=500)
+            sa2 = smoothed_aggregation_solver(A, coarse_solver=coarse2, max_coarse=500)
             x1 = sa1.solve(b, residuals=r1)
             x2 = sa2.solve(b, residuals=r2)
             del x1, x2

--- a/pyamg/aggregation/tests/test_rootnode.py
+++ b/pyamg/aggregation/tests/test_rootnode.py
@@ -388,8 +388,8 @@ class TestSolverPerformance(TestCase):
         for coarse1, coarse2 in coarse_solver_pairs:
             r1 = []
             r2 = []
-            sa1 = rootnode_solver(A, coarse_solver=coarse1)
-            sa2 = rootnode_solver(A, coarse_solver=coarse2)
+            sa1 = rootnode_solver(A, coarse_solver=coarse1, max_coarse=500)
+            sa2 = rootnode_solver(A, coarse_solver=coarse2, max_coarse=500)
             x1 = sa1.solve(b, residuals=r1)
             x2 = sa2.solve(b, residuals=r2)
             del x1, x2

--- a/pyamg/classical/classical.py
+++ b/pyamg/classical/classical.py
@@ -24,7 +24,7 @@ def ruge_stuben_solver(A,
                        CF='RS',
                        presmoother=('gauss_seidel', {'sweep': 'symmetric'}),
                        postsmoother=('gauss_seidel', {'sweep': 'symmetric'}),
-                       max_levels=10, max_coarse=500, keep=False, **kwargs):
+                       max_levels=10, max_coarse=10, keep=False, **kwargs):
     """Create a multilevel solver using Classical AMG (Ruge-Stuben AMG)
 
     Parameters

--- a/pyamg/krylov/tests/test_simple_iterations.py
+++ b/pyamg/krylov/tests/test_simple_iterations.py
@@ -128,7 +128,7 @@ class TestSimpleIterations(TestCase):
         (x, flag) = steepest_descent(A, b, x0, tol=1e-8, maxiter=20,
                                      residuals=resvec, M=sa.aspreconditioner(),
                                      callback=callback)
-        assert(resvec[-1] < 1e-8)
+        assert(resvec[-1]/resvec[0] < 1e-8)
         for i in range(len(fvals)-1):
             assert(fvals[i+1] <= fvals[i])
 
@@ -177,6 +177,6 @@ class TestSimpleIterations(TestCase):
         (x, flag) = minimal_residual(A, b, x0, tol=1e-8, maxiter=20,
                                      residuals=resvec, M=sa.aspreconditioner(),
                                      callback=callback)
-        assert(resvec[-1] < 1e-8)
+        assert(resvec[-1]/resvec[0] < 1e-8)
         for i in range(len(fvals)-1):
             assert(fvals[i+1] <= fvals[i])


### PR DESCRIPTION
Root-node should improve candidates on all levels, not just the first. Not doing so can greatly degrade convergence. I also don't think the max_coarse size should be 500, it should be more on the order of 10-20, since the cost of a pseudoinverse solve is ~ 30n^3. 