### PR TITLE
MNT call numpy instead of scipy for random module due to deprecation

### DIFF
--- a/pyamg/aggregation/adaptive.py
+++ b/pyamg/aggregation/adaptive.py
@@ -405,12 +405,12 @@ def initial_setup_stage(A, symmetry, pdef, candidate_iters, epsilon,
     # step 1
     A_l = A
     if initial_candidate is None:
-        x = sp.rand(A_l.shape[0], 1).astype(A_l.dtype)
+        x = np.random.rand(A_l.shape[0], 1).astype(A_l.dtype)
         # The following type check matches the usual 'complex' type,
         # but also numpy data types such as 'complex64', 'complex128'
         # and 'complex256'.
         if A_l.dtype.name.startswith('complex'):
-            x = x + 1.0j*sp.rand(A_l.shape[0], 1)
+            x = x + 1.0j*np.random.rand(A_l.shape[0], 1)
     else:
         x = np.array(initial_candidate, dtype=A_l.dtype)
 
@@ -606,9 +606,9 @@ def general_setup_stage(ml, symmetry, candidate_iters, prepostsmoother,
 
     levels = ml.levels
 
-    x = sp.rand(levels[0].A.shape[0], 1)
+    x = np.random.rand(levels[0].A.shape[0], 1)
     if levels[0].A.dtype.name.startswith('complex'):
-        x = x + 1.0j*sp.rand(levels[0].A.shape[0], 1)
+        x = x + 1.0j*np.random.rand(levels[0].A.shape[0], 1)
     b = np.zeros_like(x)
 
     x = ml.solve(b, x0=x, tol=float(np.finfo(np.float).tiny),

--- a/pyamg/aggregation/tests/test_adaptive.py
+++ b/pyamg/aggregation/tests/test_adaptive.py
@@ -21,7 +21,7 @@ class TestAdaptiveSA(TestCase):
         [asa, work] = adaptive_sa_solver(A, num_candidates=1)
         sa = smoothed_aggregation_solver(A, B=np.ones((A.shape[0], 1)))
 
-        b = sp.rand(A.shape[0])
+        b = np.random.rand(A.shape[0])
 
         residuals0 = []
         residuals1 = []
@@ -48,7 +48,7 @@ class TestAdaptiveSA(TestCase):
                                          prepostsmoother=smoother)
         sa = smoothed_aggregation_solver(A, B=B)
 
-        b = sp.rand(A.shape[0])
+        b = np.random.rand(A.shape[0])
 
         residuals0 = []
         residuals1 = []
@@ -96,7 +96,7 @@ class TestComplexAdaptiveSA(TestCase):
         # perturbed Laplacian
         A = poisson((50, 50), format='csr')
         Ai = A.copy()
-        Ai.data = Ai.data + 1e-5j * sp.rand(Ai.nnz)
+        Ai.data = Ai.data + 1e-5j * np.random.rand(Ai.nnz)
         cases.append((Ai, 0.25))
 
         # imaginary Laplacian
@@ -114,7 +114,8 @@ class TestComplexAdaptiveSA(TestCase):
             # sa = smoothed_aggregation_solver(A, B = np.ones((A.shape[0],1)) )
 
             b = np.zeros((A.shape[0],))
-            x0 = sp.rand(A.shape[0],) + 1.0j * sp.rand(A.shape[0],)
+            x0 = (np.random.rand(A.shape[0],)
+                  + 1.0j * np.random.rand(A.shape[0],))
 
             residuals0 = []
 

--- a/pyamg/aggregation/tests/test_rootnode.py
+++ b/pyamg/aggregation/tests/test_rootnode.py
@@ -29,8 +29,8 @@ class TestParameters(TestCase):
 
             np.random.seed(0)  # make tests repeatable
 
-            x = sp.rand(A.shape[0])
-            b = A * sp.rand(A.shape[0])
+            x = np.random.rand(A.shape[0])
+            b = A * np.random.rand(A.shape[0])
 
             residuals = []
             x_sol = ml.solve(b, x0=x, maxiter=30, tol=1e-10,
@@ -107,8 +107,8 @@ class TestComplexParameters(TestCase):
 
             np.random.seed(0)  # make tests repeatable
 
-            x = sp.rand(A.shape[0]) + 1.0j * sp.rand(A.shape[0])
-            b = A * sp.rand(A.shape[0])
+            x = np.random.rand(A.shape[0]) + 1.0j * np.random.rand(A.shape[0])
+            b = A * np.random.rand(A.shape[0])
             residuals = []
 
             x_sol = ml.solve(b, x0=x, maxiter=30, tol=1e-10,
@@ -198,8 +198,8 @@ class TestSolverPerformance(TestCase):
 
             np.random.seed(0)  # make tests repeatable
 
-            x = sp.rand(A.shape[0])
-            b = A * sp.rand(A.shape[0])
+            x = np.random.rand(A.shape[0])
+            b = A * np.random.rand(A.shape[0])
 
             residuals = []
             x_sol = ml.solve(b, x0=x, maxiter=20, tol=1e-10,
@@ -216,10 +216,12 @@ class TestSolverPerformance(TestCase):
     def test_DAD(self):
         A = poisson((50, 50), format='csr')
 
-        x = sp.rand(A.shape[0])
-        b = sp.rand(A.shape[0])
+        x = np.random.rand(A.shape[0])
+        b = np.random.rand(A.shape[0])
 
-        D = diag_sparse(1.0 / np.sqrt(10**(12 * sp.rand(A.shape[0]) - 6)))
+        D = diag_sparse(
+            1.0 / np.sqrt(10**(12 * np.random.rand(A.shape[0]) - 6))
+        )
         D = D.tocsr()
         D_inv = diag_sparse(1.0 / D.data)
 
@@ -262,8 +264,8 @@ class TestSolverPerformance(TestCase):
         cases.append((A_elas, B_elas, 0.9))
         for (A, B, rho_scale) in cases:
             last_rho = -1.0
-            x0 = sp.rand(A.shape[0], 1)
-            b = sp.rand(A.shape[0], 1)
+            x0 = np.random.rand(A.shape[0], 1)
+            b = np.random.rand(A.shape[0], 1)
             for improve_candidates in improve_candidates_list:
                 ml = rootnode_solver(A, B, max_coarse=10,
                                      improve_candidates=improve_candidates)
@@ -304,8 +306,8 @@ class TestSolverPerformance(TestCase):
                                      presmoother=smoother,
                                      postsmoother=smoother)
                 P = ml.aspreconditioner()
-                x = sp.rand(n,)
-                y = sp.rand(n,)
+                x = np.random.rand(n,)
+                y = np.random.rand(n,)
                 assert_approx_equal(np.dot(P * x, y), np.dot(x, P * y))
 
     def test_nonsymmetric(self):
@@ -314,8 +316,8 @@ class TestSolverPerformance(TestCase):
         A = data['A'].tocsr()
         B = data['B']
         np.random.seed(625)
-        x0 = sp.rand(A.shape[0])
-        b = A * sp.rand(A.shape[0])
+        x0 = np.random.rand(A.shape[0])
+        b = A * np.random.rand(A.shape[0])
         # solver parameters
         smooth = ('energy', {'krylov': 'gmres'})
         SA_build_args = {'max_coarse': 25, 'coarse_solver': 'pinv2',
@@ -375,7 +377,7 @@ class TestSolverPerformance(TestCase):
         # passed parameters
 
         A = poisson((30, 30), format='csr')
-        b = sp.rand(A.shape[0], 1)
+        b = np.random.rand(A.shape[0], 1)
 
         # for each pair, the first entry should yield an SA solver that
         # converges in fewer iterations for a basic Poisson problem
@@ -461,8 +463,8 @@ class TestComplexSolverPerformance(TestCase):
 
             np.random.seed(0)  # make tests repeatable
 
-            x = sp.rand(A.shape[0]) + 1.0j * sp.rand(A.shape[0])
-            b = A * sp.rand(A.shape[0])
+            x = np.random.rand(A.shape[0]) + 1.0j * np.random.rand(A.shape[0])
+            b = A * np.random.rand(A.shape[0])
             residuals = []
 
             x_sol = ml.solve(b, x0=x, maxiter=20, tol=1e-10,
@@ -483,8 +485,9 @@ class TestComplexSolverPerformance(TestCase):
         A = data['A'].tocsr()
         B = data['B']
         np.random.seed(625)
-        x0 = sp.rand(A.shape[0]) + 1.0j * sp.rand(A.shape[0])
-        b = A * sp.rand(A.shape[0]) + 1.0j * (A * sp.rand(A.shape[0]))
+        x0 = np.random.rand(A.shape[0]) + 1.0j * np.random.rand(A.shape[0])
+        b = (A * np.random.rand(A.shape[0])
+             + 1.0j * (A * np.random.rand(A.shape[0])))
         # solver parameters
         smooth = ('energy', {'krylov': 'gmres'})
         SA_build_args = {'max_coarse': 25, 'coarse_solver': 'pinv2',

--- a/pyamg/blackbox.py
+++ b/pyamg/blackbox.py
@@ -295,7 +295,7 @@ def solve(A, b, x0=None, tol=1e-5, maxiter=400, return_solver=False,
 
     # Initial guess
     if x0 is None:
-        x0 = np.array(sp.rand(A.shape[0],), dtype=A.dtype)
+        x0 = np.array(np.random.rand(A.shape[0],), dtype=A.dtype)
 
     # Callback function to print iteration number
     if verb:

--- a/pyamg/classical/split.py
+++ b/pyamg/classical/split.py
@@ -435,10 +435,11 @@ def preprocess(S, coloring_method=None):
     # weights -= T.diagonal()          # discount self loops
 
     if coloring_method is None:
-        weights = weights + sp.rand(len(weights))
+        weights = weights + np.random.rand(len(weights))
     else:
         coloring = vertex_coloring(G, coloring_method)
         num_colors = coloring.max() + 1
-        weights = weights + (sp.rand(len(weights)) + coloring)/num_colors
+        weights = (weights + (np.random.rand(len(weights)) + coloring)
+                   / num_colors)
 
     return (weights, G, S, T)

--- a/pyamg/classical/tests/test_classical.py
+++ b/pyamg/classical/tests/test_classical.py
@@ -22,7 +22,7 @@ class TestRugeStubenFunctions(TestCase):
         # random matrices
         np.random.seed(0)
         for N in [2, 3, 5]:
-            self.cases.append(csr_matrix(sp.rand(N, N)))
+            self.cases.append(csr_matrix(np.random.rand(N, N)))
 
         # Poisson problems in 1D and 2D
         for N in [2, 3, 5, 7, 10, 11, 19]:
@@ -128,8 +128,8 @@ class TestSolverPerformance(TestCase):
 
             np.random.seed(0)  # make tests repeatable
 
-            x = sp.rand(A.shape[0])
-            b = A*sp.rand(A.shape[0])  # zeros_like(x)
+            x = np.random.rand(A.shape[0])
+            b = A*np.random.rand(A.shape[0])  # zeros_like(x)
 
             ml = ruge_stuben_solver(A, max_coarse=50)
 

--- a/pyamg/gallery/demo.py
+++ b/pyamg/gallery/demo.py
@@ -13,7 +13,7 @@ def demo():
     """Outline basic demo."""
     A = poisson((100, 100), format='csr')  # 2D FD Poisson problem
     B = None                               # no near-null spaces guesses for SA
-    b = sp.rand(A.shape[0], 1)          # a random right-hand side
+    b = np.random.rand(A.shape[0], 1)      # a random right-hand side
 
     # use AMG based on Smoothed Aggregation (SA) and display info
     mls = smoothed_aggregation_solver(A, B=B)

--- a/pyamg/gallery/random_sparse.py
+++ b/pyamg/gallery/random_sparse.py
@@ -49,7 +49,7 @@ def sprand(m, n, density, format='csr'):
     A = _rand_sparse(m, n, density, format='csr')
 
     # replace data with random values
-    A.data = sp.rand(A.nnz)
+    A.data = np.random.rand(A.nnz)
 
     return A.asformat(format)
 
@@ -85,7 +85,7 @@ def sprand(m, n, density, format='csr'):
 #    # get sparsity pattern
 #    A = _rand_sparse(n, n, density, format='csr')
 #
-#    A.data = sp.rand(A.nnz)
+#    A.data = np.random.rand(A.nnz)
 #
 #    A = sp.sparse.tril(A, -1)
 #

--- a/pyamg/graph.py
+++ b/pyamg/graph.py
@@ -68,12 +68,12 @@ def maximal_independent_set(G, algo='serial', k=None):
             fn(N, G.indptr, G.indices, -1, 1, 0, mis)
         elif algo == 'parallel':
             fn = amg_core.maximal_independent_set_parallel
-            fn(N, G.indptr, G.indices, -1, 1, 0, mis, sp.rand(N), -1)
+            fn(N, G.indptr, G.indices, -1, 1, 0, mis, np.random.rand(N), -1)
         else:
             raise ValueError('unknown algorithm (%s)' % algo)
     else:
         fn = amg_core.maximal_independent_set_k_parallel
-        fn(N, G.indptr, G.indices, k, mis, sp.rand(N), -1)
+        fn(N, G.indptr, G.indices, k, mis, np.random.rand(N), -1)
 
     return mis
 
@@ -113,10 +113,10 @@ def vertex_coloring(G, method='MIS'):
         fn(N, G.indptr, G.indices, coloring)
     elif method == 'JP':
         fn = amg_core.vertex_coloring_jones_plassmann
-        fn(N, G.indptr, G.indices, coloring, sp.rand(N))
+        fn(N, G.indptr, G.indices, coloring, np.random.rand(N))
     elif method == 'LDF':
         fn = amg_core.vertex_coloring_LDF
-        fn(N, G.indptr, G.indices, coloring, sp.rand(N))
+        fn(N, G.indptr, G.indices, coloring, np.random.rand(N))
     else:
         raise ValueError('unknown method (%s)' % method)
 

--- a/pyamg/multilevel.py
+++ b/pyamg/multilevel.py
@@ -299,7 +299,7 @@ class multilevel_solver:
         >>> from scipy.sparse.linalg import cg
         >>> import scipy as sp
         >>> A = poisson((100, 100), format='csr')          # matrix
-        >>> b = sp.rand(A.shape[0])                        # random RHS
+        >>> b = np.random.rand(A.shape[0])                 # random RHS
         >>> ml = smoothed_aggregation_solver(A)            # AMG solver
         >>> M = ml.aspreconditioner(cycle='V')             # preconditioner
         >>> x, info = cg(A, b, tol=1e-8, maxiter=30, M=M)  # solve with CG

--- a/pyamg/tests/test_strength.py
+++ b/pyamg/tests/test_strength.py
@@ -287,11 +287,11 @@ class TestStrengthOfConnection(TestCase):
                       'proj': 'l2'})
 
         for ca in cases:
-            scipy.random.seed(0)  # make results deterministic
+            np.random.seed(0)  # make results deterministic
             result = evolution_soc(ca['A'], ca['B'], epsilon=ca['epsilon'],
                                    k=ca['k'], proj_type=ca['proj'],
                                    symmetrize_measure=False)
-            scipy.random.seed(0)  # make results deterministic
+            np.random.seed(0)  # make results deterministic
             expected = reference_evolution_soc(ca['A'], ca['B'],
                                                epsilon=ca['epsilon'],
                                                k=ca['k'], proj_type=ca['proj'])
@@ -300,7 +300,7 @@ class TestStrengthOfConnection(TestCase):
 
         # Test Scale Invariance for multiple near nullspace candidates
         (A, B) = linear_elasticity((5, 5), format='bsr')
-        scipy.random.seed(0)  # make results deterministic
+        np.random.seed(0)  # make results deterministic
         result_unscaled = evolution_soc(A, B, epsilon=4.0,
                                         k=2, proj_type="D_A",
                                         symmetrize_measure=False)
@@ -309,7 +309,7 @@ class TestStrengthOfConnection(TestCase):
                     [0], A.shape[0], A.shape[0], format='csr')
         Dinv = spdiags([1.0/arange(A.shape[0], 2*A.shape[0], dtype=float)],
                        [0], A.shape[0], A.shape[0], format='csr')
-        scipy.random.seed(0)  # make results deterministic
+        np.random.seed(0)  # make results deterministic
         result_scaled = evolution_soc((D*A*D).tobsr(blocksize=(2, 2)),
                                       Dinv*B, epsilon=4.0, k=2,
                                       proj_type="D_A",
@@ -389,11 +389,11 @@ class TestComplexStrengthOfConnection(TestCase):
                       'proj': 'l2'})
 
         for ca in cases:
-            scipy.random.seed(0)  # make results deterministic
+            np.random.seed(0)  # make results deterministic
             result = evolution_soc(ca['A'], ca['B'], epsilon=ca['epsilon'],
                                    k=ca['k'], proj_type=ca['proj'],
                                    symmetrize_measure=False)
-            scipy.random.seed(0)  # make results deterministic
+            np.random.seed(0)  # make results deterministic
             expected = reference_evolution_soc(ca['A'], ca['B'],
                                                epsilon=ca['epsilon'],
                                                k=ca['k'], proj_type=ca['proj'])
@@ -402,7 +402,7 @@ class TestComplexStrengthOfConnection(TestCase):
         # Test Scale Invariance for a single candidate
         A = 1.0j*poisson((5, 5), format='csr')
         B = 1.0j*arange(1, A.shape[0]+1, dtype=float).reshape(-1, 1)
-        scipy.random.seed(0)  # make results deterministic
+        np.random.seed(0)  # make results deterministic
         result_unscaled = evolution_soc(A, B, epsilon=4.0, k=2,
                                         proj_type="D_A",
                                         symmetrize_measure=False)
@@ -411,7 +411,7 @@ class TestComplexStrengthOfConnection(TestCase):
                     [0], A.shape[0], A.shape[0], format='csr')
         Dinv = spdiags([1.0/arange(A.shape[0], 2*A.shape[0], dtype=float)],
                        [0], A.shape[0], A.shape[0], format='csr')
-        scipy.random.seed(0)  # make results deterministic
+        np.random.seed(0)  # make results deterministic
         result_scaled = evolution_soc(D*A*D, Dinv*B, epsilon=4.0, k=2,
                                       proj_type="D_A",
                                       symmetrize_measure=False)
@@ -419,11 +419,11 @@ class TestComplexStrengthOfConnection(TestCase):
                                   result_unscaled.toarray(), decimal=2)
 
         # Test that the l2 and D_A are the same for the 1 candidate case
-        scipy.random.seed(0)  # make results deterministic
+        np.random.seed(0)  # make results deterministic
         resultDA = evolution_soc(D*A*D, Dinv*B, epsilon=4.0,
                                  k=2, proj_type="D_A",
                                  symmetrize_measure=False)
-        scipy.random.seed(0)  # make results deterministic
+        np.random.seed(0)  # make results deterministic
         resultl2 = evolution_soc(D*A*D, Dinv*B, epsilon=4.0,
                                  k=2, proj_type="l2",
                                  symmetrize_measure=False)
@@ -433,7 +433,7 @@ class TestComplexStrengthOfConnection(TestCase):
         (A, B) = linear_elasticity((5, 5), format='bsr')
         A = 1.0j*A
         B = 1.0j*B
-        scipy.random.seed(0)  # make results deterministic
+        np.random.seed(0)  # make results deterministic
         result_unscaled = evolution_soc(A, B, epsilon=4.0, k=2,
                                         proj_type="D_A",
                                         symmetrize_measure=False)
@@ -442,7 +442,7 @@ class TestComplexStrengthOfConnection(TestCase):
                     [0], A.shape[0], A.shape[0], format='csr')
         Dinv = spdiags([1.0/arange(A.shape[0], 2*A.shape[0], dtype=float)],
                        [0], A.shape[0], A.shape[0], format='csr')
-        scipy.random.seed(0)  # make results deterministic
+        np.random.seed(0)  # make results deterministic
         result_scaled = evolution_soc((D*A*D).tobsr(blocksize=(2, 2)), Dinv*B,
                                       epsilon=4.0, k=2, proj_type="D_A",
                                       symmetrize_measure=False)

--- a/pyamg/util/linalg.py
+++ b/pyamg/util/linalg.py
@@ -197,9 +197,9 @@ def _approximate_eigenvalues(A, tol, maxiter, symmetric=None,
     maxiter = min(A.shape[0], maxiter)
 
     if initial_guess is None:
-        v0 = sp.rand(A.shape[1], 1)
+        v0 = np.random.rand(A.shape[1], 1)
         if A.dtype == complex:
-            v0 = v0 + 1.0j * sp.rand(A.shape[1], 1)
+            v0 = v0 + 1.0j * np.random.rand(A.shape[1], 1)
     else:
         v0 = initial_guess
 
@@ -355,9 +355,9 @@ def approximate_spectral_radius(A, tol=0.01, maxiter=15, restart=5,
             raise ValueError('expected square A')
 
         if initial_guess is None:
-            v0 = sp.rand(A.shape[1], 1)
+            v0 = np.random.rand(A.shape[1], 1)
             if A.dtype == complex:
-                v0 = v0 + 1.0j * sp.rand(A.shape[1], 1)
+                v0 = v0 + 1.0j * np.random.rand(A.shape[1], 1)
         else:
             if initial_guess.shape[0] != A.shape[0]:
                 raise ValueError('initial_guess and A must have same shape')
@@ -538,11 +538,11 @@ def ishermitian(A, fast_check=True, tol=1e-6, verbose=False):
         A = np.asarray(A)
 
     if fast_check:
-        x = sp.rand(A.shape[0], 1)
-        y = sp.rand(A.shape[0], 1)
+        x = np.random.rand(A.shape[0], 1)
+        y = np.random.rand(A.shape[0], 1)
         if A.dtype == complex:
-            x = x + 1.0j*sp.rand(A.shape[0], 1)
-            y = y + 1.0j*sp.rand(A.shape[0], 1)
+            x = x + 1.0j*np.random.rand(A.shape[0], 1)
+            y = y + 1.0j*np.random.rand(A.shape[0], 1)
         xAy = np.dot((A.dot(x)).conjugate().T, y)
         xAty = np.dot(x.conjugate().T, A.dot(y))
         diff = float(np.abs(xAy - xAty) / np.sqrt(np.abs(xAy*xAty)))

--- a/pyamg/util/utils.py
+++ b/pyamg/util/utils.py
@@ -75,7 +75,7 @@ def profile_solver(ml, accel=None, **kwargs):
 
     """
     A = ml.levels[0].A
-    b = A * sp.rand(A.shape[0], 1)
+    b = A * np.random.rand(A.shape[0], 1)
     residuals = []
 
     if accel is None:


### PR DESCRIPTION
Scipy is deprecating the `scipy.random` module. Therefore, all the call to `scipy.random` are replaced by `numpy.random`.