### PR TITLE
Add Lloyd aggregation with exact cluster centers

### DIFF
--- a/pyamg/amg_core/graph.h
+++ b/pyamg/amg_core/graph.h
@@ -328,111 +328,343 @@ T vertex_coloring_LDF(const I num_rows,
 
 
 /*
+ * Compute the incidence matrix for a clustering
+ *
+ *      I = Incidence matrix between nodes and clusters (num_nodes x num_clusters)
+ * I[i,a] = 1 if node i is in cluster a, otherwise 0
+ *
+ *     Cluster indexes: a,b,c in 1..num_clusters
+ * Global node indexes: i,j,k in 1..num_rows
+ *  Local node indexes: pair (a,m) where a is cluster and m in 1..num_nodes_in_cluster
+ *
+ * We store I in both CSC and CSR formats because we want to be able
+ * to map global <-> local node indexes. However, I in CSR format is
+ * simply the cm array, so we only need to compute CSC format.
+ *
+ * IC = (ICp,ICi)    = I in CSC format (don't store ICx because it's
+ *                     always 1).
+ *
+ * IR = (IRa) = (cm) = I in CSR format (don't store IRp because we
+ *                     have exactly one nonzero entry per row, and
+ *                     don't store IRx because it's always 1). This is
+ *                     just the cm array.
+ *
+ * Converting local (a,m) -> global i:   i = ICi[ICp[a] + m]
+ *
+ * Converting global i -> local (a,m):   a = cm[i]
+ *                                       m = L[i]
+ *
+ * L is an additional vector (length num_rows) to store local indexes.
+ *
+ *  Parameters
+ *      num_nodes         - (IN)  number of nodes
+ *      num_clusters      - (IN)  number of clusters
+ *     cm[num_nodes]      - (IN)  cluster index for each node
+ *    ICp[num_clusters+1] - (OUT) CSC column pointer array for I
+ *    ICi[num_nodes]      - (OUT) CSC column indexes for I
+ *      L[num_nodes]      - (OUT) Local index mapping
+ */
+template<class I, class T>
+void cluster_node_incidence(const I num_nodes,
+                            const I num_clusters,
+                            const I  cm[], const int  cm_size,
+                            const I ICp[], const int ICp_size,
+                            const I ICi[], const int ICi_size,
+                            const I   L[], const int L_size)
+{
+    // Construct the ICi index array. It will have one entry per node,
+    // giving the global node number, ordered so that all of the
+    // cluster-0 nodes are first, then all the cluster-1 nodes, etc.
+    for(I i = 0; i < num_nodes; i++){
+        ICi[i] = i;
+    }
+    std::sort(ICi.begin(), ICi.end(), [](const I& i, const I& j)
+    {
+        // sort first by cluster number, then by global node number
+        // within a cluster
+        return (cm[i] > cm[j]) || (cm[i] == cm[j] && i > j);
+    });
+
+    // Construct the ICp pointer array. This code assumes that every
+    // cluster contains at least one node (the cluster center).
+    ICp[0] = 0;
+    a = 0; // current cluster
+    for(I i = 0; i < num_nodes; i++){
+        if(cm[ICi[i]] != a){
+            a++;
+            assert(a < num_clusters);
+            ICp[a] = i;
+        }
+    }
+    a++;
+    assert(a == num_clusters); // all clusters were found
+    ICp[a] = num_nodes;
+
+    // Construct the local mapping vector L
+    i = 0; // global node number
+    for(I a = 0; a < num_clusters; a++){
+        const I N = ICp[a+1] - ICp[a]; // cluster size
+        for(I m = 0; m < N; m++){
+            L[i] = m;
+            i++;
+            assert(i <= num_nodes);
+        }
+    }
+    assert(i == num_nodes); // all nodes were assigned
+
+    ////////////////////////////////////////////////////////////
+    // asserts below for testing, could be deleted
+
+    // check that global -> local has a correct inverse
+    for(I i = 0; i < num_nodes; i++){
+        a = cm[i];
+        m = L[a];
+        assert(a >= 0 && a < num_clusters);
+        assert(m >= 0 && m < ICp[a+1] - ICp[a]);
+        assert(i == ICi[ICp[a] + m]);
+    }
+
+    // check that local -> global has a correct inverse
+    for(I a = 0; a < num_clusters; a++){
+        const I N = ICp[a]; // cluster size
+        for(I m = 0; m < N; m++){
+            const i = ICi[ICp[a] + m];
+            assert(i >= 0 && i < num_nodes);
+            assert(a == cm[i]);
+            assert(m == L[i]);
+        }
+    }
+}
+
+
+/*
+ * Apply Floyd–Warshall to cluster "a" and use the result to find the
+ * cluster center
+ *
+ *  Parameters
+ *      a                  - (IN) cluster index to find the center of
+ *      num_nodes          - (IN) number of nodes
+ *      num_clusters       - (IN) number of clusters
+ *      Ap[]               - (IN) CSR row pointer
+ *      Aj[]               - (IN) CSR index array
+ *      Ax[]               - (IN) CSR data array (edge lengths)
+ *     ICp[num_clusters+1] - (IN) CSC column pointer array for I
+ *     ICi[num_nodes]      - (IN) CSC column indexes for I
+ *       L[num_nodes]      - (IN) Local index mapping
+ *
+ *  Returns
+ *      i                  - global node index of center of cluster a
+ *
+ *  References:
+ *      https://en.wikipedia.org/wiki/Graph_center
+ *      https://en.wikipedia.org/wiki/Floyd–Warshall_algorithm
+ *      https://en.wikipedia.org/wiki/Distance_(graph_theory)
+ */
+template<class I, class T>
+I cluster_center(const I a,
+                 const I num_nodes,
+                 const I num_clusters,
+                 const I  Ap[], const int  Ap_size,
+                 const I  Aj[], const int  Aj_size,
+                 const T  Ax[], const int  Ax_size,
+                 const I ICp[], const int ICp_size,
+                 const I ICi[], const int ICi_size,
+                 const I   L[], const int   L_size)
+{
+    I N = ICp[a+1] - ICp[a]; // size of the cluster
+
+    // pairwise distances between all nodes in the cluster, in row-major order
+    std::vector<T> dist(N*N, std::numeric_limits<T>::max());
+
+    // Floyd-Warshall initialization
+    for(I m = 0; m < N; m++){
+        i = ICi[ICp[a] + m]; // local node index (a,m) -> global i
+        for(I jj = Ap[i]; jj < Ap[i+1]; jj++){ // all neighbors of i
+            const I j = Aj[jj]; // neighbor global node index
+            const T w = Ax[jj]; // edge weight
+
+            if (cm[j] == a) { // only use neighbors in the same cluster
+                const n = L[j]; // global node index j -> local (a,n)
+                assert(n >= 0 && n < N);
+                mn = m*N + n; // row-major index of (m,n)
+                dist[mn] = w;
+            }
+        }
+        dist[m,m] = 0;
+    }
+
+    // main Floyd-Warshall iteration - O(N^3)
+    for(I l = 0; l < N; l++){
+        for(I m = 0; m < N; m++){
+            for(I n = 0; n < N; n++){
+                const mn = m*N + n; // row-major index of (m,n)
+                const ml = m*N + l; // row-major index of (m,l)
+                const ln = l*N + n; // row-major index of (l,n)
+                dist[mn] = min(dist[mn], dist[ml] + dist[ln]);
+            }
+        }
+    }
+
+    // check that the cluster is connected
+    for(I i = 0; i < N*N; i++){
+        assert(dist[i] < std::numeric_limits<T>::max());
+    }
+
+    // compute eccentricity of each node in cluster (max distance to other nodes)
+    std::vector<T> ecc(N, 0);
+    for(I m = 0; m < N; m++){
+        for(I n = 0; n < N; n++){
+            const mn = m*N + n; // row-major index of (m,n)
+            ecc[m] = max(ecc[m], dist[mn]);
+        }
+    }
+
+    // graph center is the node with minimum eccentricity
+    m = std::min_element(ecc.begin(), ecc.end()) - ecc.begin();
+    i = ICi[ICp[a] + m]; // local node index (a,m) -> global i
+    return i;
+}
+
+
+/*
  * Apply one iteration of Bellman-Ford iteration on a distance
  * graph stored in CSR format.
  *
  *  Parameters
- *      num_rows   - number of rows in A (number of vertices)
- *      Ap[]       - CSR row pointer
- *      Aj[]       - CSR index array
- *      Ax[]       - CSR data array (edge lengths)
- *      x[]        - (current) distance to nearest center
- *     nc[]        - (current) index of nearest center
+ *      num_nodes - (IN)    number of nodes (number of rows in A)
+ *      Ap[]      - (IN)    CSR row pointer
+ *      Aj[]      - (IN)    CSR index array
+ *      Ax[]      - (IN)    CSR data array (edge lengths)
+ *      d[]       - (INOUT) distance to nearest center
+ *     cm[]       - (INOUT) cluster index for each node
  *
  *  References:
  *      http://en.wikipedia.org/wiki/Bellman-Ford_algorithm
  */
 template<class I, class T>
-void bellman_ford(const I num_rows,
+void bellman_ford(const I num_nodes,
                   const I Ap[], const int Ap_size,
                   const I Aj[], const int Aj_size,
                   const T Ax[], const int Ax_size,
-                        T  x[], const int  x_size,
-                        I nc[], const int nc_size)
+                        T  d[], const int  d_size,
+                        I cm[], const int cm_size)
 {
-    for(I i = 0; i < num_rows; i++){
-        T xi = x[i];
-        I nci = nc[i];
+    for(I i = 0; i < num_nodes; i++){
+        T xi = d[i];
+        I nci = cm[i];
         for(I jj = Ap[i]; jj < Ap[i+1]; jj++){
             const I j = Aj[jj];
-            const T d = Ax[jj] + x[j];
+            const T d = Ax[jj] + d[j];
             if(d < xi){
                 xi = d;
-                nci = nc[j];
+                nci = cm[j];
             }
         }
-        x[i] = xi;
-        nc[i] = nci;
+        d[i] = xi;
+        cm[i] = nci;
     }
 }
 
+
 /*
- * Apply one iteration of Bellman-Ford iteration on a distance
- * graph stored in CSR format.
+ * Apply Bellman-Ford with a heuristic to balance cluster sizes
  *
- * This version is modified to break ties by assigning to center
- * with fewest points in its cluster.
+ * This version is modified to break distance ties by assigning nodes
+ * to the cluster with the fewest points, while preserving cluster
+ * connectivity. This will hopefully result in more balanced cluster
+ * sizes.
  *
  *  Parameters
- *      num_rows   - number of rows in A (number of vertices)
- *      Ap[]       - CSR row pointer
- *      Aj[]       - CSR index array
- *      Ax[]       - CSR data array (edge lengths)
- *      x[]        - (current) distance to nearest center
- *     nc[]        - (current) index of nearest center
- *      c[]        - list of centers
+ *     num_nodes    - (IN)    number of nodes (vertices)
+ *     num_clusters - (IN)    number of clusters
+ *     Ap[]         - (IN)    CSR row pointer for adjacency matrix A
+ *     Aj[]         - (IN)    CSR index array
+ *     Ax[]         - (IN)    CSR data array (edge lengths)
+ *      d[]         - (INOUT) distance to nearest center
+ *     cm[]         - (INOUT) cluster index for each node
+ *      c[]         - (IN)    global node indexes of cluster centers
  *
  *  References:
  *      http://en.wikipedia.org/wiki/Bellman-Ford_algorithm
  */
 template<class I, class T>
-void bellman_ford_adv(const I num_rows,
-                      const I Ap[], const int Ap_size,
-                      const I Aj[], const int Aj_size,
-                      const T Ax[], const int Ax_size,
-                            T  x[], const int  x_size,
-                            I nc[], const int nc_size,
-                            I  c[], const int  c_size)
+void bellman_ford_balanced(const I num_nodes,
+                           const I num_clusters,
+                           const I Ap[], const int Ap_size,
+                           const I Aj[], const int Aj_size,
+                           const T Ax[], const int Ax_size,
+                                 T  d[], const int  d_size,
+                                 I cm[], const int cm_size,
+                                 I  c[], const int  c_size)
 {
-    std::vector<I> num_closest(c_size, 0);
-    for(I i=0; i < num_rows; i++){
-        if(nc[i] > -1){
-            num_closest[nc[i]]++;
+    assert(d_size == num_nodes);
+    assert(cm_size == num_nodes);
+    assert(c_size == num_clusters);
+
+    std::vector<I> predecessor(num_nodes, -1); // index of predecessor node
+    std::vector<I> pred_count(num_nodes, 0); // number of other nodes that we are the predecessor for
+
+    std::vector<I> cs(num_clusters, 0); // cluster sizes (number of nodes in each cluster)
+    for(I i = 0; i < num_nodes; i++){
+        if(cm[i] > -1){
+            cs[cm[i]]++;
         }
     }
 
-    for(I i = 0; i < num_rows; i++){
-        T xi = x[i];
-        I nci = nc[i];
-        for(I jj = Ap[i]; jj < Ap[i+1]; jj++){
-            const I j = Aj[jj];
-            const T d = Ax[jj] + x[j];
-            if((d < xi) || ((nci > -1) && (d == xi) && (num_closest[nc[j]] < num_closest[nci]))){
-                if (nci > -1){
-                    num_closest[nci]--;
+    bool change; // did we make any changes during this iteration?
+    I iteration = 0; // iteration count for safety check
+
+    do{
+        change = false;
+        for(I i = 0; i < num_nodes; i++){
+            for(I jj = Ap[i]; jj < Ap[i+1]; jj++){ // all neighbors of node i
+                const I j = Aj[jj];
+                const T new_d = Ax[jj] + d[j];
+                if((new_d < d[i]) || ((cm[i] > -1) && (new_d == d[i]) && (cs[cm[j]] < cs[cm[i]]) && (pred_count[i] == 0))){
+                    // switch distance/predecessor if the new distance
+                    // is strictly shorter, or if (distance is equal, the new
+                    // cluster is smaller, and we are not the
+                    // predecessor for anyone else)
+
+                    // update cluster sizes
+                    if(cm[i] > -1){
+                        cs[cm[i]]--;
+                        assert(cs[cm[i]] >= 0);
+                    }
+                    cs[cm[j]]++;
+
+                    // update predecessor assignments and counts
+                    if(predecessor[i] > -1){
+                        pred_count[predecessor[i]]--;
+                        assert(pred_count[predecessor[i]] >= 0);
+                    }
+                    predecessor[i] = j;
+                    pred_count[predecessor[i]]++;
+
+                    // switch to the new cluster
+                    d[i] = new_d;
+                    cm[i] = cm[j];
+                    change = true;
                 }
-                num_closest[nc[j]]++;
-                xi = d;
-                nci = nc[j];
             }
         }
-        x[i] = xi;
-        nc[i] = nci;
-    }
+        assert(++iteration < num_nodes*num_nodes*num_nodes); // safety check, regular unweighted BF is actually O(|V|.|E|)
+    } while(change);
 }
 
 
 /*
- * Perform Lloyd clustering on a distance graph
+ * Perform one iteration of Lloyd clustering on a distance graph
  *
  *  Parameters
- *      num_rows       - number of rows in A (number of vertices)
- *      Ap[]           - CSR row pointer
- *      Aj[]           - CSR index array
- *      Ax[]           - CSR data array (edge lengths)
- *      x[num_rows]    - distance to nearest seed
- *     cm[num_rows]    - cluster membership
- *      c[num_centers] - cluster centers
+ *      num_nodes       - (IN)  number of nodes (number of rows in A)
+ *      Ap[]            - (IN)  CSR row pointer for adjacency matrix A
+ *      Aj[]            - (IN)  CSR index array
+ *      Ax[]            - (IN)  CSR data array (edge lengths)
+ *      num_clusters    - (IN)  number of clusters (seeds)
+ *      d[num_nodes]    - (OUT) distance to nearest seed
+ *     cm[num_nodes]    - (OUT) cluster index for each node
+ *      c[num_clusters] - (IN)  cluster centers
  *
  *  References
  *      Nathan Bell
@@ -441,43 +673,43 @@ void bellman_ford_adv(const I num_rows,
  *
  */
 template<class I, class T>
-void lloyd_cluster(const I num_rows,
+void lloyd_cluster(const I num_nodes,
                    const I Ap[], const int Ap_size,
                    const I Aj[], const int Aj_size,
                    const T Ax[], const int Ax_size,
-                   const I num_seeds,
-                         T  x[], const int  x_size,
+                   const I num_clusters,
+                         T  d[], const int  d_size,
                          I cm[], const int cm_size,
                          I  c[], const int  c_size)
 {
-    for(I i = 0; i < num_rows; i++){
-        x[i] = std::numeric_limits<T>::max();
-       cm[i] = -1;
+    for(I i = 0; i < num_nodes; i++){
+        d[i] = std::numeric_limits<T>::max();
+        cm[i] = -1;
     }
-    for(I i = 0; i < num_seeds; i++){
-        I seed = c[i];
-        assert(seed >= 0 && seed < num_rows);
-        x[seed] = 0;
-       cm[seed] = i;
+    for(I a = 0; a < num_clusters; a++){
+        I i = c[a];
+        assert(i >= 0 && i < num_nodes);
+        d[i] = 0;
+        cm[i] = a;
     }
 
-    std::vector<T> old_distances(num_rows);
+    std::vector<T> old_distances(num_nodes);
 
     // propagate distances outward
     do{
-        std::copy(x, x+num_rows, old_distances.begin());
-        bellman_ford_adv(num_rows, Ap, Ap_size, Aj, Aj_size, Ax, Ax_size, x, x_size, cm, cm_size, c, c_size);
-    } while ( !std::equal( x, x+num_rows, old_distances.begin() ) );
+        std::copy(d, d+num_nodes, old_distances.begin());
+        bellman_ford(num_nodes, Ap, Ap_size, Aj, Aj_size, Ax, Ax_size, d, d_size, cm, cm_size, c, c_size);
+    } while ( !std::equal( d, d+num_nodes, old_distances.begin() ) );
 
     //find boundaries
-    for(I i = 0; i < num_rows; i++){
-        x[i] = std::numeric_limits<T>::max();
+    for(I i = 0; i < num_nodes; i++){
+        d[i] = std::numeric_limits<T>::max();
     }
-    for(I i = 0; i < num_rows; i++){
+    for(I i = 0; i < num_nodes; i++){
         for(I jj = Ap[i]; jj < Ap[i+1]; jj++){
             I j = Aj[jj];
             if( cm[i] != cm[j] ){
-                x[i] = 0;
+                d[i] = 0;
                 break;
             }
         }
@@ -485,26 +717,89 @@ void lloyd_cluster(const I num_rows,
 
     // propagate distances inward
     do{
-        std::copy(x, x+num_rows, old_distances.begin());
-        bellman_ford_adv(num_rows, Ap, Ap_size, Aj, Aj_size, Ax, Ax_size, x, x_size, cm, cm_size, c, c_size);
-    } while ( !std::equal( x, x+num_rows, old_distances.begin() ) );
+        std::copy(d, d+num_nodes, old_distances.begin());
+        bellman_ford(num_nodes, Ap, Ap_size, Aj, Aj_size, Ax, Ax_size, d, d_size, cm, cm_size, c, c_size);
+    } while ( !std::equal( d, d+num_nodes, old_distances.begin() ) );
 
 
     // compute new seeds
-    for(I i = 0; i < num_rows; i++){
-        const I seed = cm[i];
+    for(I i = 0; i < num_nodes; i++){
+        const I a = cm[i];
 
-        if (seed == -1) //node belongs to no cluster
+        if (a == -1) //node belongs to no cluster
             continue;
 
-        assert(seed >= 0 && seed < num_seeds);
+        assert(a >= 0 && a < num_clusters);
 
-        if( x[c[seed]] < x[i] )
-            c[seed] = i;
+        if( d[c[a]] < d[i] )
+            c[a] = i;
     }
 }
 
 
+/*
+ * Perform one iteration of Lloyd clustering on a distance graph using
+ * exact centers
+ *
+ * This version computes exact cluster centers with Floyd-Warshall and
+ * also uses a balanced version of Bellman-Ford to try and find
+ * nearly-equal-sized clusters.
+ *
+ *  Parameters
+ *      num_nodes       - (IN)  number of rows in A (number of vertices)
+ *      Ap[]            - (IN)  CSR row pointer
+ *      Aj[]            - (IN)  CSR index array
+ *      Ax[]            - (IN)  CSR data array (edge lengths)
+ *      num_clusters    - (IN)  number of clusters = number of seeds
+ *      d[num_nodes]    - (OUT) distance to nearest seed
+ *     cm[num_nodes]    - (OUT) cluster index for each node
+ *      c[num_clusters] - (IN)  cluster centers
+ *
+ *  References
+ *      Nathan Bell
+ *      Algebraic Multigrid for Discrete Differential Forms
+ *      PhD thesis (UIUC), August 2008
+ */
+template<class I, class T>
+void lloyd_cluster_exact(const I num_nodes,
+                         const I Ap[], const int Ap_size,
+                         const I Aj[], const int Aj_size,
+                         const T Ax[], const int Ax_size,
+                         const I num_clusters,
+                               T  d[], const int  d_size,
+                               I cm[], const int cm_size,
+                               I  c[], const int  c_size)
+{
+    assert(d_size == num_nodes);
+    assert(cm_size == num_nodes);
+    assert(c_size == num_clusters);
+
+    for(I i = 0; i < num_nodes; i++){
+        d[i] = std::numeric_limits<T>::max();
+        cm[i] = -1;
+    }
+    for(I a = 0; a < num_clusters; i++){
+        I i = c[a];
+        assert(i >= 0 && i < num_nodes);
+        d[i] = 0;
+        cm[i] = a;
+    }
+
+    // assign nodes to the nearest cluster center
+    bellman_ford_balanced(num_nodes, Ap, Ap_size, Aj, Aj_size, Ax, Ax_size, d, d_size, cm, cm_size, c, c_size);
+
+    // construct node-cluster incidence arrays
+    std::vector<I> ICp(num_nodes);
+    std::vector<I> ICi(num_nodes);
+    std::vector<I> L(num_nodes);
+    cluster_node_incidence(num_nodes, num_clusters, cm, cm_size, ICp, ICp_size, ICi, ICi_size, L, L_size);
+
+    // update cluster centers
+    for(I a = 0; a < num_clusters; a++){
+        c[a] = cluster_center(a, num_nodes, num_clusters, Ap, Ap_size, Aj, Aj_size, Ax, Ax_size, ICp, ICp_size, ICi, ICi_size, L, L_size);
+        assert(cm[c[a]] == a); // check new center is in cluster
+    }
+}
 
 
 /*


### PR DESCRIPTION
- Add a new `lloyd_cluster_exact()` that uses Floyd-Warshall to find the exact cluster centers and the "balanced" version of Bellman-Ford.

- Revert `lloyd_cluster()` to its original form, using the fast heuristic center-finder and plain Bellman-Ford.

- Rename `bellman_ford_adv()` to `bellman_ford_balanced()`.

- Fix `bellman_ford_balanced()` to ensure connectedness of the clusters.