### PR TITLE
Update solution vector inside inner iteration of GMRES

### DIFF
--- a/pyamg/krylov/_fgmres.py
+++ b/pyamg/krylov/_fgmres.py
@@ -114,7 +114,7 @@ def fgmres(A, b, x0=None, tol=1e-5, restrt=None, maxiter=None, xtype=None,
 
     # Ensure that warnings are always reissued from this function
     import warnings
-    warnings.filterwarnings('always', module='pyamg.krylov._fgmres')
+    warnings.filterwarnings('always', module='pyamg\.krylov\._fgmres')
 
     # Choose type
     if not hasattr(A, 'dtype'):
@@ -307,7 +307,9 @@ def fgmres(A, b, x0=None, tol=1e-5, restrt=None, maxiter=None, xtype=None,
 
                 # Allow user access to the iterates
                 if callback is not None:
-                    callback(x)
+                    y      = sp.linalg.solve(H[0:(inner+1), 0:(inner+1)], g[0:(inner+1)])
+                    update = np.dot(Z[:, 0:inner+1], y)
+                    callback(x+update)
                 if keep_r:
                     residuals.append(normr)
 

--- a/pyamg/krylov/_gmres_householder.py
+++ b/pyamg/krylov/_gmres_householder.py
@@ -108,7 +108,8 @@ def gmres_householder(A, b, x0=None, tol=1e-5, restrt=None, maxiter=None,
 
     # Ensure that warnings are always reissued from this function
     import warnings
-    warnings.filterwarnings('always', module='pyamg.krylov._gmres_householder')
+    warnings.filterwarnings('always',
+                            module='pyamg\.krylov\._gmres_householder')
 
     # Choose type
     if not hasattr(A, 'dtype'):
@@ -312,7 +313,11 @@ def gmres_householder(A, b, x0=None, tol=1e-5, restrt=None, maxiter=None,
 
                 # Allow user access to the iterates
                 if callback is not None:
-                    callback(x)
+                    y      = sp.linalg.solve(H[0:(inner+1), 0:(inner+1)], g[0:(inner+1)])
+                    update = np.zeros(x.shape, dtype=xtype)
+                    amg_core.householder_hornerscheme(update, np.ravel(W), np.ravel(y),
+                                                      dimen, inner, -1, -1)
+                    callback(x+update)
                 if keep_r:
                     residuals.append(normr)
 

--- a/pyamg/krylov/_gmres_mgs.py
+++ b/pyamg/krylov/_gmres_mgs.py
@@ -132,7 +132,7 @@ def gmres_mgs(A, b, x0=None, tol=1e-5, restrt=None, maxiter=None, xtype=None,
 
     # Ensure that warnings are always reissued from this function
     import warnings
-    warnings.filterwarnings('always', module='pyamg.krylov._gmres_mgs')
+    warnings.filterwarnings('always', module='pyamg\.krylov\._gmres_mgs')
 
     # Choose type
     if not hasattr(A, 'dtype'):
@@ -322,7 +322,9 @@ def gmres_mgs(A, b, x0=None, tol=1e-5, restrt=None, maxiter=None, xtype=None,
 
                 # Allow user access to the iterates
                 if callback is not None:
-                    callback(x)
+                    y      = sp.linalg.solve(H[0:inner+1, 0:inner+1].T, g[0:inner+1])
+                    update = np.ravel(np.mat(V[:inner+1, :]).T*y.reshape(-1, 1))
+                    callback(x+update)
                 if keep_r:
                     residuals.append(normr)
 
@@ -330,7 +332,7 @@ def gmres_mgs(A, b, x0=None, tol=1e-5, restrt=None, maxiter=None, xtype=None,
 
         # Find best update to x in Krylov Space V.  Solve inner x inner system.
         y = sp.linalg.solve(H[0:inner+1, 0:inner+1].T, g[0:inner+1])
-        update = np.ravel(V[:inner+1, :].T.dot(y.reshape(-1, 1)))
+        update = np.ravel(np.mat(V[:inner+1, :]).T*y.reshape(-1, 1))
         x = x + update
         r = b - np.ravel(A*x)
 


### PR DESCRIPTION
I need this feature to monitor convergence. This fix works for a simple Poisson example. 

```python
from pyamg.krylov import gmres, fgmres
from pyamg.util.linalg import norm
import numpy as np
from pyamg.gallery import poisson
import matplotlib.pyplot as plt

class CallBack(object):
    resid        = None
    A            = None
    b            = None
    def __init__(self, A, b):
        self.resid        = []
        self.A            = A
        self.b            = b
    def __call__(self, x=None):
        self.resid.append(norm(self.b-self.A*x))

A  = poisson((30,30))
b  = np.ones((A.shape[0],))
cb = CallBack(A,b)
(x,flag) = gmres(A,b, maxiter=200, tol=1e-8, callback=cb,  orthog='householder')
plt.semilogy(cb.resid, label='househodler', marker='o')
cb.resid = []
(x,flag) = gmres(A,b, maxiter=200, tol=1e-8, callback=cb,  orthog='mgs')
plt.semilogy(cb.resid, label='mgs', marker='x')

cb.resid = []
(x,flag) = fgmres(A,b, maxiter=200, tol=1e-8, callback=cb)
plt.semilogy(cb.resid,  marker='.')
```