### PR TITLE
MNT Removes usage of deprecated np.float, np.bool, np.int

### DIFF
--- a/pyamg/aggregation/adaptive.py
+++ b/pyamg/aggregation/adaptive.py
@@ -312,7 +312,7 @@ def adaptive_sa_solver(A, initial_candidates=None, symmetry='hermitian',
                                                 improve_candidates=None,
                                                 keep=True, **kwargs)
                 x = sa_temp.solve(b, x0=x0,
-                                  tol=float(np.finfo(np.float).tiny),
+                                  tol=float(np.finfo(float).tiny),
                                   maxiter=candidate_iters, cycle='V')
                 work[:] += 2 * sa_temp.operator_complexity() *\
                     sa_temp.levels[0].A.nnz * candidate_iters
@@ -611,7 +611,7 @@ def general_setup_stage(ml, symmetry, candidate_iters, prepostsmoother,
         x = x + 1.0j*np.random.rand(levels[0].A.shape[0], 1)
     b = np.zeros_like(x)
 
-    x = ml.solve(b, x0=x, tol=float(np.finfo(np.float).tiny),
+    x = ml.solve(b, x0=x, tol=float(np.finfo(float).tiny),
                  maxiter=candidate_iters)
     work[:] += ml.operator_complexity()*ml.levels[0].A.nnz*candidate_iters*2
 
@@ -703,7 +703,7 @@ def general_setup_stage(ml, symmetry, candidate_iters, prepostsmoother,
         change_smoothers(solver, presmoother=prepostsmoother,
                          postsmoother=prepostsmoother)
         x = solver.solve(np.zeros_like(x), x0=x,
-                         tol=float(np.finfo(np.float).tiny),
+                         tol=float(np.finfo(float).tiny),
                          maxiter=candidate_iters)
         work[:] += 2 * solver.operator_complexity() * solver.levels[0].A.nnz *\
             candidate_iters*2

--- a/pyamg/amg_core/tests/test_bind_examples.py
+++ b/pyamg/amg_core/tests/test_bind_examples.py
@@ -65,7 +65,7 @@ class TestVectors(TestCase):
 
     def test_10b(self):
         # bool, float32
-        J = np.array([1, 1, 1], dtype=np.bool)
+        J = np.array([1, 1, 1], dtype=bool)
         x = np.array([1.0, 2.0, 3.0], dtype=np.float32)
 
         assert g.test10(J, x) == 1

--- a/pyamg/graph_ref.py
+++ b/pyamg/graph_ref.py
@@ -30,7 +30,7 @@ def bellman_ford_reference(A, c):
     Nnode = A.shape[0]
     Ncluster = len(c)
     d = np.full((Nnode,), np.inf)
-    m = np.full((Nnode,), -1.0, dtype=np.int)
+    m = np.full((Nnode,), -1.0, dtype=int)
 
     d[c] = 0  # distance
     m[c] = c  # index

--- a/pyamg/krylov/_cg.py
+++ b/pyamg/krylov/_cg.py
@@ -94,7 +94,7 @@ def cg(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None,
 
     # choose tolerance for numerically zero values
     # t = A.dtype.char
-    # eps = np.finfo(np.float).eps
+    # eps = np.finfo(float).eps
     # feps = np.finfo(np.single).eps
     # geps = np.finfo(np.longfloat).eps
     # _array_precision = {'f': 0, 'd': 1, 'g': 2, 'F': 0, 'D': 1, 'G': 2}

--- a/pyamg/krylov/_cr.py
+++ b/pyamg/krylov/_cr.py
@@ -96,7 +96,7 @@ def cr(A, b, x0=None, tol=1e-5, maxiter=None, xtype=None, M=None,
 
     # choose tolerance for numerically zero values
     # t = A.dtype.char
-    # eps = np.finfo(np.float).eps
+    # eps = np.finfo(float).eps
     # feps = np.finfo(np.single).eps
     # geps = np.finfo(np.longfloat).eps
     # _array_precision = {'f': 0, 'd': 1, 'g': 2, 'F': 0, 'D': 1, 'G': 2}

--- a/pyamg/multilevel.py
+++ b/pyamg/multilevel.py
@@ -660,7 +660,7 @@ def coarse_grid_solver(solver):
 
         def solve(self, A, b):
             if 'tol' not in kwargs:
-                eps = np.finfo(np.float).eps
+                eps = np.finfo(float).eps
                 feps = np.finfo(np.single).eps
                 geps = np.finfo(np.longfloat).eps
                 _array_precision = {'f': 0, 'd': 1, 'g': 2,

--- a/pyamg/relaxation/relaxation.py
+++ b/pyamg/relaxation/relaxation.py
@@ -1064,7 +1064,7 @@ def schwarz_parameters(A, subdomain=None, subdomain_ptr=None,
                                    int(subdomain_ptr.shape[0]-1), A.shape[0])
         # Choose tolerance for which singular values are zero in *gelss below
         t = A.dtype.char
-        eps = np.finfo(np.float).eps
+        eps = np.finfo(float).eps
         feps = np.finfo(np.single).eps
         geps = np.finfo(np.longfloat).eps
         _array_precision = {'f': 0, 'd': 1, 'g': 2, 'F': 0, 'D': 1, 'G': 2}

--- a/pyamg/strength.py
+++ b/pyamg/strength.py
@@ -768,7 +768,7 @@ def evolution_strength_of_connection(A, B=None, epsilon=4.0, k=2,
 
         # Choose tolerance for dropping "numerically zero" values later
         t = Atilde.dtype.char
-        eps = np.finfo(np.float).eps
+        eps = np.finfo(float).eps
         feps = np.finfo(np.single).eps
         geps = np.finfo(np.longfloat).eps
         _array_precision = {'f': 0, 'd': 1, 'g': 2, 'F': 0, 'D': 1, 'G': 2}

--- a/pyamg/tests/test_strength.py
+++ b/pyamg/tests/test_strength.py
@@ -633,7 +633,7 @@ def reference_evolution_soc(A, B, epsilon=4.0, k=2, proj_type="l2"):
 
     # Choose tolerance for dropping "numerically zero" values later
     t = Atilde.dtype.char
-    eps = np.finfo(np.float).eps
+    eps = np.finfo(float).eps
     feps = np.finfo(np.single).eps
     geps = np.finfo(np.longfloat).eps
     _array_precision = {'f': 0, 'd': 1, 'g': 2, 'F': 0, 'D': 1, 'G': 2}
@@ -789,7 +789,7 @@ def reference_distance_soc(A, V, theta=2.0, relative_drop=True):
         for j in range(rowstart, rowend):
             if C.indices[j] == i:
                 # ignore the diagonal entry by making it large
-                C.data[j] = np.finfo(np.float).max
+                C.data[j] = np.finfo(float).max
             else:
                 # distance between entry j and i
                 pt_j = V[C.indices[j], :]

--- a/pyamg/util/linalg.py
+++ b/pyamg/util/linalg.py
@@ -184,7 +184,7 @@ def _approximate_eigenvalues(A, tol, maxiter, symmetric=None,
 
     # Choose tolerance for deciding if break-down has occurred
     t = A.dtype.char
-    eps = np.finfo(np.float).eps
+    eps = np.finfo(float).eps
     feps = np.finfo(np.single).eps
     geps = np.finfo(np.longfloat).eps
     _array_precision = {'f': 0, 'd': 1, 'g': 2, 'F': 0, 'D': 1, 'G': 2}
@@ -624,7 +624,7 @@ def pinv_array(a, cond=None):
         # Choose tolerance for which singular values are zero in *gelss below
         if cond is None:
             t = a.dtype.char
-            eps = np.finfo(np.float).eps
+            eps = np.finfo(float).eps
             feps = np.finfo(np.single).eps
             geps = np.finfo(np.longfloat).eps
             _array_precision = {'f': 0, 'd': 1, 'g': 2, 'F': 0, 'D': 1, 'G': 2}


### PR DESCRIPTION
Uses `float` instead of `np.float` to keep the same behavior.