### PR TITLE
isort, black

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,24 @@ name: CI
 on:
   push:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
-  Test:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v2
+      - name: isort
+        run: |
+          pip install isort
+          isort --check .
+      - name: black
+        run: |
+          pip install black
+          black --check .
 
+  Test:
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -16,18 +29,18 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install Dependencies
-      run: |
-        python -m pip install --upgrade pip
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Install
-      run: pip install -e .
-    - name: Test
-      run: |
-        pytest .
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install Dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Install
+        run: pip install -e .
+      - name: Test
+        run: |
+          pytest .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.isort]
+profile = "black"


### PR DESCRIPTION
The de-facto standard formatting for Python code is [black](https://github.com/psf/black). This PR applies [isort](https://github.com/PyCQA/isort) and black to one file, just to show what it'd look like.