### PR TITLE
Installreqs

### DIFF
--- a/pyamg/__init__.py
+++ b/pyamg/__init__.py
@@ -65,7 +65,10 @@ def test(verbose=False):
 
     """
     import sys     # pylint: disable=import-outside-toplevel
-    import pytest  # pylint: disable=import-outside-toplevel
+    try:
+        import pytest  # pylint: disable=import-outside-toplevel
+    except ModuleNotFoundError as e:
+        raise ModuleNotFoundError('pytest is not installed and is needed for test()') from e
 
     sysversion = sys.version.replace('\n', '')
     print(f'Python version: {sysversion}')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,4 +10,4 @@ requires = [
 [tool.setuptools_scm]
 version_scheme = "no-guess-dev"
 write_to = "pyamg/version.py"
-fallback_version = "v4.2.1"
+fallback_version = "v4.2.2"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,6 @@
+numpy
+scipy
+pytest
 pep8-naming
 flake8-quotes
 flake8-bugbear

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 numpy
 scipy
-pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ python_requires = >=3.6
 install_requires =
     numpy>=1.7.0
     scipy>=0.12.0
+tests_require =
     pytest>=2
 
 [options.packages.find]


### PR DESCRIPTION
This PR removes `pytest` from `install_requires` and adds it to `tests_require`.

If `pytest` is unavailable, then an exception is raise in `pyamg.test()`

This reduces the install footprint quite a bit.