### PR TITLE
Fix formatting of bullet point list in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,12 +7,13 @@ Contributing
 ---
 
 Contributing code to this project assumes that
-    - your contributions are not significant enough to claim copyright or
-      that you implicitly transfer the copyright of your contribution to
-      the PyAMG Developers
-    - you agree to the Developer Certificate of Origin for
-      your contributing portion as described here (and below):
-      http://developercertificate.org/
+
+- your contributions are not significant enough to claim copyright or
+  that you implicitly transfer the copyright of your contribution to
+  the PyAMG Developers
+- you agree to the Developer Certificate of Origin for
+  your contributing portion as described here (and below):
+  http://developercertificate.org/
 
 Certificate of Origin
 ---


### PR DESCRIPTION
Before, formatting in `CONTRIBUTING.md` was weird (see screenshot):

<img width="1019" alt="image" src="https://user-images.githubusercontent.com/14297653/158812181-ef3158de-dc32-4a6d-b563-1643d06de859.png">

This fixes the list of bullet points (see screenshot):

<img width="1007" alt="image" src="https://user-images.githubusercontent.com/14297653/158812302-e0261613-9861-4a29-b05d-8af9b9e384f4.png">
