### PR TITLE
Omp

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,18 @@ conda search pyamg --channel conda-forge
 
 # OpenMP
 
-To enable OpenMP on macOS, `brew install libomp`
+- To enable OpenMP on macOS, `brew install libomp`
 
-Then `setup.py` will attempt to add `-Xclang -fopenmp` to the compiler and `-lomp` to the linker.
+- Then set environment variables, following https://scikit-learn.org/dev/developers/advanced_installation.html#macos-compilers-from-homebrew :
+```
+export CC=/usr/bin/clang
+export CXX=/usr/bin/clang++
+export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"
+export CFLAGS="$CFLAGS -I$(brew --prefix libomp)/include"
+export CXXFLAGS="$CXXFLAGS -I$(brew --prefix libomp)/include"
+export LDFLAGS="$LDFLAGS -Wl,-rpath,$(brew --prefix libomp)/lib -L$(brew --prefix libomp)/lib -lomp"
+```
+
+- Then `setup.py` will attempt to add `-Xpreprocessor -fopenmp` to the compiler and `-lomp` to the linker.
+
+- To test, try `export OMP_NUM_THREADS=4; python test_omp.py` in `scripts/`

--- a/README.md
+++ b/README.md
@@ -157,18 +157,28 @@ conda search pyamg --channel conda-forge
 
 # OpenMP
 
-- To enable OpenMP on macOS, `brew install libomp`
+PyAMG handles OpenMP in the following way
 
-- Then set environment variables, following https://scikit-learn.org/dev/developers/advanced_installation.html#macos-compilers-from-homebrew :
-```
-export CC=/usr/bin/clang
-export CXX=/usr/bin/clang++
-export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"
-export CFLAGS="$CFLAGS -I$(brew --prefix libomp)/include"
-export CXXFLAGS="$CXXFLAGS -I$(brew --prefix libomp)/include"
-export LDFLAGS="$LDFLAGS -Wl,-rpath,$(brew --prefix libomp)/lib -L$(brew --prefix libomp)/lib -lomp"
-```
+    - The `has_flag()` function of `pybind11` is called, with either `-fopenmp` (Linux) or `-Xpreprocessor -fopenmp` (MacOS).  Then added to the build if present.
 
-- Then `setup.py` will attempt to add `-Xpreprocessor -fopenmp` to the compiler and `-lomp` to the linker.
+    - Every instance of OpenMP is limited to `#pragma` or `#ifdef _OPENMP`.  Each kernel in `amg_core` that has OpenMP should be buildable without.
 
-- To test, try `export OMP_NUM_THREADS=4; python test_omp.py` in `scripts/`
+    - To test, try `export OMP_NUM_THREADS=4; python test_omp.py` in `scripts/`
+
+    - The AMG solve phase add threading by rewriting the sparse matrix-vector multiplications of `A`, `P`, and `R`, with `ml.solve(...., openmp=True)`.
+
+#### MacOS
+    - To enable OpenMP on macOS, `brew install libomp`
+
+    - Then set environment variables, following https://scikit-learn.org/dev/developers/advanced_installation.html#macos-compilers-from-homebrew :
+    ```
+    export CC=/usr/bin/clang
+    export CXX=/usr/bin/clang++
+    export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"
+    export CFLAGS="$CFLAGS -I$(brew --prefix libomp)/include"
+    export CXXFLAGS="$CXXFLAGS -I$(brew --prefix libomp)/include"
+    export LDFLAGS="$LDFLAGS -Wl,-rpath,$(brew --prefix libomp)/lib -L$(brew --prefix libomp)/lib -lomp"
+    ```
+
+    - Then `setup.py` will attempt to add `-Xpreprocessor -fopenmp` to the compiler and `-lomp` to the linker.
+

--- a/README.md
+++ b/README.md
@@ -154,3 +154,9 @@ It is possible to list all of the versions of `pyamg` available on your platform
 ```
 conda search pyamg --channel conda-forge
 ```
+
+# OpenMP
+
+To enable OpenMP on macOS, `brew install libomp`
+
+Then `setup.py` will attempt to add `-Xclang -fopenmp` to the compiler and `-lomp` to the linker.

--- a/pyamg/amg_core/__init__.py
+++ b/pyamg/amg_core/__init__.py
@@ -31,6 +31,8 @@ from .smoothed_aggregation import (symmetric_strength_of_connection, standard_ag
                                    satisfy_constraints_helper, calc_BtB,
                                    incomplete_mat_mult_bsr, truncate_rows_csr)
 
+from .sparse import csr_matvec
+
 __all__ = [
     'apply_absolute_distance_filter',
     'apply_distance_filter',
@@ -91,4 +93,6 @@ __all__ = [
     'calc_BtB',
     'incomplete_mat_mult_bsr',
     'truncate_rows_csr'
+    #
+    'csr_matvec'
 ]

--- a/pyamg/amg_core/__init__.py
+++ b/pyamg/amg_core/__init__.py
@@ -31,7 +31,7 @@ from .smoothed_aggregation import (symmetric_strength_of_connection, standard_ag
                                    satisfy_constraints_helper, calc_BtB,
                                    incomplete_mat_mult_bsr, truncate_rows_csr)
 
-from .sparse import csr_matvec
+from .sparse import csr_matvec, omp_info
 
 __all__ = [
     'apply_absolute_distance_filter',
@@ -94,5 +94,6 @@ __all__ = [
     'incomplete_mat_mult_bsr',
     'truncate_rows_csr'
     #
-    'csr_matvec'
+    'csr_matvec',
+    'omp_info'
 ]

--- a/pyamg/amg_core/generate.sh
+++ b/pyamg/amg_core/generate.sh
@@ -5,3 +5,4 @@
 ./bindthem.py relaxation.h
 ./bindthem.py ruge_stuben.h
 ./bindthem.py smoothed_aggregation.h
+./bindthem.py sparse.h

--- a/pyamg/amg_core/instantiate.yml
+++ b/pyamg/amg_core/instantiate.yml
@@ -98,6 +98,11 @@ instantiate:
   functions:
     - csr_matvec
 
+- types:
+    - None
+  functions:
+    - omp_info
+
 remaps:
     - fit_candidates_real: fit_candidates
     - fit_candidates_complex: fit_candidates

--- a/pyamg/amg_core/instantiate.yml
+++ b/pyamg/amg_core/instantiate.yml
@@ -98,11 +98,6 @@ instantiate:
   functions:
     - csr_matvec
 
-- types:
-    - None
-  functions:
-    - omp_info
-
 remaps:
     - fit_candidates_real: fit_candidates
     - fit_candidates_complex: fit_candidates

--- a/pyamg/amg_core/instantiate.yml
+++ b/pyamg/amg_core/instantiate.yml
@@ -89,6 +89,7 @@ instantiate:
     - rs_direct_interpolation_pass1
     - cluster_node_incidence
     - print_it
+    - omp_info
 
 - types:
     - [int, float]

--- a/pyamg/amg_core/sparse.h
+++ b/pyamg/amg_core/sparse.h
@@ -63,10 +63,10 @@ void omp_info()
 {
     int nthreads, tid;
 
-    #pragma ommp parallel private(nthreads, tid)
+    #pragma omp parallel private(nthreads, tid)
     {
         tid = omp_get_thread_num();
-        nthreads omp_get_num_threads();
-        printff("Thread %d of %d total threads", tid, nthreads);
+        nthreads = omp_get_num_threads();
+        printf("Thread %d of %d total threads\n", tid, nthreads);
     }
 }

--- a/pyamg/amg_core/sparse.h
+++ b/pyamg/amg_core/sparse.h
@@ -1,0 +1,46 @@
+//
+// Threaded SpMV
+//
+// y <- A * x
+//
+// Parameters
+// ----------
+// n_row, n_col : int
+//    dimensions of the n_row x n_col matrix A
+// Ap, Aj, Ax : array
+//    CSR pointer, index, and data vectors for matrix A
+// Xx : array
+//    input vector
+// Yy : array
+//    output vector (modified in-place)
+//
+// See Also
+// --------
+// csr_matvec
+//
+// Notes
+// -----
+// Requires GCC 4.9 for ivdep
+// Requires a compiler with OMP
+//
+template <class I, class T>
+void csr_matvec(const I n_row,
+                const I n_col,
+                const I Ap[], const int Ap_size,
+                const I Aj[], const int Aj_size,
+                const T Ax[], const int Ax_size,
+                const T Xx[], const int Xx_size,
+                      T Yx[], const int Yx_size)
+{
+    I i, jj;
+    T sum;
+    #pragma omp parallel for default(shared) schedule(static) private(i, sum, jj)
+    for(i = 0; i < n_row; i++){
+        sum = Yx[i];
+        #pragma GCC ivdep
+        for(jj = Ap[i]; jj < Ap[i+1]; jj++){
+            sum += Ax[jj] * Xx[Aj[jj]];
+        }
+        Yx[i] = sum;
+    }
+}

--- a/pyamg/amg_core/sparse.h
+++ b/pyamg/amg_core/sparse.h
@@ -1,4 +1,5 @@
 #include <complex>
+#include <omp.h>
 //
 // Threaded SpMV
 //
@@ -35,7 +36,17 @@ void csr_matvec(const I n_row,
 {
     I i, jj;
     T sum;
-    #pragma omp parallel for default(shared) schedule(static) private(i, sum, jj)
+    int tid;
+    #pragma omp parallel for default(shared) schedule(static) private(i, sum, jj, tid)
+    {
+        id = omp_get_thread_num();
+        printf("Hello World from thread = %d\n", tid);
+
+        if (tid == 0)
+        {
+            nthreads = omp_get_num_threads();
+            printf("Number of threads = %d\n", nthreads);
+        }
     for(i = 0; i < n_row; i++){
         sum = Yx[i];
         #pragma GCC ivdep
@@ -43,5 +54,6 @@ void csr_matvec(const I n_row,
             sum += Ax[jj] * Xx[Aj[jj]];
         }
         Yx[i] = sum;
+    }
     }
 }

--- a/pyamg/amg_core/sparse.h
+++ b/pyamg/amg_core/sparse.h
@@ -38,11 +38,27 @@ void csr_matvec(const I n_row,
     I i, jj;
     T sum;
     int nthreads, tid;
+
+    #pragma omp parallel private(nthreads, tid)
+      {
+
+      /* Obtain thread number */
+      tid = omp_get_thread_num();
+      std::cout << "Hello World from thread = " << tid << std::endl;
+
+      /* Only master thread does this */
+      if (tid == 0)
+        {
+        nthreads = omp_get_num_threads();
+        std::cout << "Number of threads = " << nthreads << std::endl;
+        }
+
+      }
     #pragma omp parallel for default(shared) schedule(static) private(i, sum, jj, nthreads, tid)
     for(i = 0; i < n_row; i++){
         nthreads = omp_get_num_threads();
         tid = omp_get_thread_num();
-        std::cout << "thread " << tid << " of " << nthreads << std::endl;
+        std::cout << "thread " << tid+1 << " of " << nthreads << std::endl;
         sum = Yx[i];
         #pragma GCC ivdep
         for(jj = Ap[i]; jj < Ap[i+1]; jj++){

--- a/pyamg/amg_core/sparse.h
+++ b/pyamg/amg_core/sparse.h
@@ -1,5 +1,6 @@
 #include <complex>
 #include <iostream>
+#include <stdio.h>
 #include <omp.h>
 //
 // Threaded SpMV
@@ -37,28 +38,14 @@ void csr_matvec(const I n_row,
 {
     I i, jj;
     T sum;
-    int nthreads, tid;
+    //int nthreads, tid;
+    //nthreads = omp_get_num_threads();
 
-    #pragma omp parallel private(nthreads, tid)
-      {
-
-      /* Obtain thread number */
-      tid = omp_get_thread_num();
-      std::cout << "Hello World from thread = " << tid << std::endl;
-
-      /* Only master thread does this */
-      if (tid == 0)
-        {
-        nthreads = omp_get_num_threads();
-        std::cout << "Number of threads = " << nthreads << std::endl;
-        }
-
-      }
-    #pragma omp parallel for default(shared) schedule(static) private(i, sum, jj, nthreads, tid)
+    #pragma omp parallel for default(shared) schedule(static) private(i, sum, jj)
     for(i = 0; i < n_row; i++){
-        nthreads = omp_get_num_threads();
-        tid = omp_get_thread_num();
-        std::cout << "thread " << tid+1 << " of " << nthreads << std::endl;
+        //tid = omp_get_thread_num();
+        //printf("row %d, thread %d\n", i, tid+1);
+        //std::cout << "thread " << tid+1 << " of " << nthreads << "     (row " << i << ")" << std::endl;
         sum = Yx[i];
         #pragma GCC ivdep
         for(jj = Ap[i]; jj < Ap[i+1]; jj++){

--- a/pyamg/amg_core/sparse.h
+++ b/pyamg/amg_core/sparse.h
@@ -1,3 +1,4 @@
+#include <complex>
 //
 // Threaded SpMV
 //

--- a/pyamg/amg_core/sparse.h
+++ b/pyamg/amg_core/sparse.h
@@ -1,4 +1,5 @@
 #include <complex>
+#include <iostream>
 #include <omp.h>
 //
 // Threaded SpMV
@@ -36,24 +37,17 @@ void csr_matvec(const I n_row,
 {
     I i, jj;
     T sum;
-    int tid;
-    #pragma omp parallel for default(shared) schedule(static) private(i, sum, jj, tid)
-    {
-        id = omp_get_thread_num();
-        printf("Hello World from thread = %d\n", tid);
-
-        if (tid == 0)
-        {
-            nthreads = omp_get_num_threads();
-            printf("Number of threads = %d\n", nthreads);
-        }
+    int nthreads, tid;
+    #pragma omp parallel for default(shared) schedule(static) private(i, sum, jj, nthreads, tid)
     for(i = 0; i < n_row; i++){
+        nthreads = omp_get_num_threads();
+        tid = omp_get_thread_num();
+        std::cout << "thread " << tid << " of " << nthreads << std::endl;
         sum = Yx[i];
         #pragma GCC ivdep
         for(jj = Ap[i]; jj < Ap[i+1]; jj++){
             sum += Ax[jj] * Xx[Aj[jj]];
         }
         Yx[i] = sum;
-    }
     }
 }

--- a/pyamg/amg_core/sparse.h
+++ b/pyamg/amg_core/sparse.h
@@ -54,3 +54,19 @@ void csr_matvec(const I n_row,
         Yx[i] = sum;
     }
 }
+
+
+//
+// OMP analytics
+//
+void omp_info()
+{
+    int nthreads, tid;
+
+    #pragma ommp parallel private(nthreads, tid)
+    {
+        tid = omp_get_thread_num();
+        nthreads omp_get_num_threads();
+        printff("Thread %d of %d total threads", tid, nthreads);
+    }
+}

--- a/pyamg/amg_core/sparse.h
+++ b/pyamg/amg_core/sparse.h
@@ -1,7 +1,11 @@
 #include <complex>
 #include <iostream>
 #include <stdio.h>
-#include <omp.h>
+
+#ifdef _OPENMP
+#   include <omp.h>
+#endif
+
 //
 // Threaded SpMV
 //
@@ -38,14 +42,9 @@ void csr_matvec(const I n_row,
 {
     I i, jj;
     T sum;
-    //int nthreads, tid;
-    //nthreads = omp_get_num_threads();
 
     #pragma omp parallel for default(shared) schedule(static) private(i, sum, jj)
     for(i = 0; i < n_row; i++){
-        //tid = omp_get_thread_num();
-        //printf("row %d, thread %d\n", i, tid+1);
-        //std::cout << "thread " << tid+1 << " of " << nthreads << "     (row " << i << ")" << std::endl;
         sum = Yx[i];
         #pragma GCC ivdep
         for(jj = Ap[i]; jj < Ap[i+1]; jj++){
@@ -59,14 +58,19 @@ void csr_matvec(const I n_row,
 //
 // OMP analytics
 //
-void omp_info()
+template <class I>
+void omp_info(const I m)
 {
-    int nthreads, tid;
+    I nthreads, tid;
 
     #pragma omp parallel private(nthreads, tid)
     {
+#ifdef _OPENMP
         tid = omp_get_thread_num();
         nthreads = omp_get_num_threads();
         printf("Thread %d of %d total threads\n", tid, nthreads);
+#else
+        printf("OpenMP not available.\n");
+#endif
     }
 }

--- a/pyamg/amg_core/sparse_bind.cpp
+++ b/pyamg/amg_core/sparse_bind.cpp
@@ -1,0 +1,90 @@
+// DO NOT EDIT: this file is generated
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#include <pybind11/complex.h>
+
+#include "sparse.h"
+
+namespace py = pybind11;
+
+template <class I, class T>
+void _csr_matvec(
+            const I n_row,
+            const I n_col,
+      py::array_t<I> & Ap,
+      py::array_t<I> & Aj,
+      py::array_t<T> & Ax,
+      py::array_t<T> & Xx,
+      py::array_t<T> & Yx
+                 )
+{
+    auto py_Ap = Ap.unchecked();
+    auto py_Aj = Aj.unchecked();
+    auto py_Ax = Ax.unchecked();
+    auto py_Xx = Xx.unchecked();
+    auto py_Yx = Yx.mutable_unchecked();
+    const I *_Ap = py_Ap.data();
+    const I *_Aj = py_Aj.data();
+    const T *_Ax = py_Ax.data();
+    const T *_Xx = py_Xx.data();
+    T *_Yx = py_Yx.mutable_data();
+
+    return csr_matvec <I, T>(
+                    n_row,
+                    n_col,
+                      _Ap, Ap.shape(0),
+                      _Aj, Aj.shape(0),
+                      _Ax, Ax.shape(0),
+                      _Xx, Xx.shape(0),
+                      _Yx, Yx.shape(0)
+                             );
+}
+
+PYBIND11_MODULE(sparse, m) {
+    m.doc() = R"pbdoc(
+    Pybind11 bindings for sparse.h
+
+    Methods
+    -------
+    csr_matvec
+    )pbdoc";
+
+    py::options options;
+    options.disable_function_signatures();
+
+    m.def("csr_matvec", &_csr_matvec<int, float>,
+        py::arg("n_row"), py::arg("n_col"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("Xx").noconvert(), py::arg("Yx").noconvert());
+    m.def("csr_matvec", &_csr_matvec<int, double>,
+        py::arg("n_row"), py::arg("n_col"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("Xx").noconvert(), py::arg("Yx").noconvert());
+    m.def("csr_matvec", &_csr_matvec<int, std::complex<float>>,
+        py::arg("n_row"), py::arg("n_col"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("Xx").noconvert(), py::arg("Yx").noconvert());
+    m.def("csr_matvec", &_csr_matvec<int, std::complex<double>>,
+        py::arg("n_row"), py::arg("n_col"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("Xx").noconvert(), py::arg("Yx").noconvert(),
+R"pbdoc(
+Threaded SpMV
+
+y <- A * x
+
+Parameters
+----------
+n_row, n_col : int
+   dimensions of the n_row x n_col matrix A
+Ap, Aj, Ax : array
+   CSR pointer, index, and data vectors for matrix A
+Xx : array
+   input vector
+Yy : array
+   output vector (modified in-place)
+
+See Also
+--------
+csr_matvec
+
+Notes
+-----
+Requires GCC 4.9 for ivdep
+Requires a compiler with OMP)pbdoc");
+
+}
+

--- a/pyamg/amg_core/sparse_bind.cpp
+++ b/pyamg/amg_core/sparse_bind.cpp
@@ -41,6 +41,15 @@ void _csr_matvec(
                              );
 }
 
+void _omp_info(
+
+               )
+{
+    return omp_info(
+
+                    );
+}
+
 PYBIND11_MODULE(sparse, m) {
     m.doc() = R"pbdoc(
     Pybind11 bindings for sparse.h
@@ -48,19 +57,20 @@ PYBIND11_MODULE(sparse, m) {
     Methods
     -------
     csr_matvec
+    omp_info
     )pbdoc";
 
     py::options options;
     options.disable_function_signatures();
 
-    m.def("csr_matvec", &_csr_matvec<int, float>,
-        py::arg("n_row"), py::arg("n_col"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("Xx").noconvert(), py::arg("Yx").noconvert());
-    m.def("csr_matvec", &_csr_matvec<int, double>,
-        py::arg("n_row"), py::arg("n_col"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("Xx").noconvert(), py::arg("Yx").noconvert());
-    m.def("csr_matvec", &_csr_matvec<int, std::complex<float>>,
-        py::arg("n_row"), py::arg("n_col"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("Xx").noconvert(), py::arg("Yx").noconvert());
-    m.def("csr_matvec", &_csr_matvec<int, std::complex<double>>,
-        py::arg("n_row"), py::arg("n_col"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("Xx").noconvert(), py::arg("Yx").noconvert(),
+    m.def("csr_matvec", &_csr_matvec<int, float>    ,
+    py::arg("n_row"), py::arg("n_col"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("Xx").noconvert(), py::arg("Yx").noconvert());
+    m.def("csr_matvec", &_csr_matvec<int, double>    ,
+    py::arg("n_row"), py::arg("n_col"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("Xx").noconvert(), py::arg("Yx").noconvert());
+    m.def("csr_matvec", &_csr_matvec<int, std::complex<float>>    ,
+    py::arg("n_row"), py::arg("n_col"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("Xx").noconvert(), py::arg("Yx").noconvert());
+    m.def("csr_matvec", &_csr_matvec<int, std::complex<double>>    ,
+    py::arg("n_row"), py::arg("n_col"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("Xx").noconvert(), py::arg("Yx").noconvert(),
 R"pbdoc(
 Threaded SpMV
 
@@ -85,6 +95,10 @@ Notes
 -----
 Requires GCC 4.9 for ivdep
 Requires a compiler with OMP)pbdoc");
+
+    m.def("omp_info", &_omp_info        ,
+R"pbdoc(
+OMP analytics)pbdoc");
 
 }
 

--- a/pyamg/amg_core/sparse_bind.cpp
+++ b/pyamg/amg_core/sparse_bind.cpp
@@ -41,15 +41,6 @@ void _csr_matvec(
                              );
 }
 
-void _omp_info(
-
-               )
-{
-    return omp_info(
-
-                    );
-}
-
 PYBIND11_MODULE(sparse, m) {
     m.doc() = R"pbdoc(
     Pybind11 bindings for sparse.h
@@ -63,14 +54,14 @@ PYBIND11_MODULE(sparse, m) {
     py::options options;
     options.disable_function_signatures();
 
-    m.def("csr_matvec", &_csr_matvec<int, float>    ,
-    py::arg("n_row"), py::arg("n_col"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("Xx").noconvert(), py::arg("Yx").noconvert());
-    m.def("csr_matvec", &_csr_matvec<int, double>    ,
-    py::arg("n_row"), py::arg("n_col"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("Xx").noconvert(), py::arg("Yx").noconvert());
-    m.def("csr_matvec", &_csr_matvec<int, std::complex<float>>    ,
-    py::arg("n_row"), py::arg("n_col"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("Xx").noconvert(), py::arg("Yx").noconvert());
-    m.def("csr_matvec", &_csr_matvec<int, std::complex<double>>    ,
-    py::arg("n_row"), py::arg("n_col"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("Xx").noconvert(), py::arg("Yx").noconvert(),
+    m.def("csr_matvec", &_csr_matvec<int, float>,
+        py::arg("n_row"), py::arg("n_col"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("Xx").noconvert(), py::arg("Yx").noconvert());
+    m.def("csr_matvec", &_csr_matvec<int, double>,
+        py::arg("n_row"), py::arg("n_col"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("Xx").noconvert(), py::arg("Yx").noconvert());
+    m.def("csr_matvec", &_csr_matvec<int, std::complex<float>>,
+        py::arg("n_row"), py::arg("n_col"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("Xx").noconvert(), py::arg("Yx").noconvert());
+    m.def("csr_matvec", &_csr_matvec<int, std::complex<double>>,
+        py::arg("n_row"), py::arg("n_col"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("Xx").noconvert(), py::arg("Yx").noconvert(),
 R"pbdoc(
 Threaded SpMV
 
@@ -95,10 +86,6 @@ Notes
 -----
 Requires GCC 4.9 for ivdep
 Requires a compiler with OMP)pbdoc");
-
-    m.def("omp_info", &_omp_info        ,
-R"pbdoc(
-OMP analytics)pbdoc");
 
 }
 

--- a/pyamg/amg_core/sparse_bind.cpp
+++ b/pyamg/amg_core/sparse_bind.cpp
@@ -41,6 +41,16 @@ void _csr_matvec(
                              );
 }
 
+template <class I>
+void _omp_info(
+                const I m
+               )
+{
+    return omp_info <I>(
+                        m
+                        );
+}
+
 PYBIND11_MODULE(sparse, m) {
     m.doc() = R"pbdoc(
     Pybind11 bindings for sparse.h
@@ -86,6 +96,11 @@ Notes
 -----
 Requires GCC 4.9 for ivdep
 Requires a compiler with OMP)pbdoc");
+
+    m.def("omp_info", &_omp_info<int>,
+        py::arg("m"),
+R"pbdoc(
+OMP analytics)pbdoc");
 
 }
 

--- a/pyamg/amg_core/try_sparse.py
+++ b/pyamg/amg_core/try_sparse.py
@@ -1,0 +1,16 @@
+import pyamg
+import numpy as np
+import sparse
+import os
+
+n = 16
+
+A = pyamg.gallery.poisson((n,), format='csr')
+
+exact = np.zeros((n,))
+exact[0] = 1
+exact[-1] = 1
+
+result = np.zeros((n,))
+other = np.ones((n,))
+sparse.csr_matvec(n,n, A.indptr, A.indices, A.data, other, result)

--- a/pyamg/multilevel.py
+++ b/pyamg/multilevel.py
@@ -338,8 +338,23 @@ class MultilevelSolver:
 
         return LinearOperator(shape, matvec, dtype=dtype)
 
+    def _enable_omp(self):
+        """Enable OpenMP (if available) by calling pyamg.amg_core.sparse.csr_matvec
+
+        See Also
+        --------
+        scipy.sparse.csr.csr_matvec, pyamg.amg_core.sparse.csr_matvec, pyamg.util.sparse.csr
+        """
+        import pyamg.util
+        for l in self.levels:
+            l.A = pyamg.util.sparse.csr(l.A)
+            if hasattr(l, 'P'):
+                l.P = pyamg.util.sparse.csr(l.P)
+            if hasattr(l, 'R'):
+                l.R = pyamg.util.sparse.csr(l.R)
+
     def solve(self, b, x0=None, tol=1e-5, maxiter=100, cycle='V', accel=None,
-              callback=None, residuals=None, return_info=False):
+              callback=None, residuals=None, return_info=False, openmp=False):
         """Execute multigrid cycling.
 
         Parameters
@@ -403,6 +418,9 @@ class MultilevelSolver:
         >>> x = ml.solve(b, tol=1e-12, residuals=residuals) # standalone solver
 
         """
+        if openmp:
+            self._enable_omp()
+
         if x0 is None:
             x = np.zeros_like(b)
         else:

--- a/pyamg/util/__init__.py
+++ b/pyamg/util/__init__.py
@@ -3,10 +3,11 @@
 from . import linalg
 from . import utils
 from . import params
+from . import sparse
 
 from .utils import make_system, upcast
 
-__all__ = ['linalg', 'utils', 'params', 'make_system', 'upcast']
+__all__ = ['linalg', 'utils', 'params', 'make_system', 'upcast', 'sparse']
 
 __doc__ += """
 linalg.py provides some linear algebra functionality not yet found in scipy.

--- a/pyamg/util/sparse.py
+++ b/pyamg/util/sparse.py
@@ -1,0 +1,30 @@
+import numpy as np
+from scipy.sparse import csr_matrix, _sparsetools
+from scipy.sparse.sputils import upcast_char
+import pyamg.amg_core
+
+
+class csr(csr_matrix):
+    """
+    New CSR class
+
+    The purpose of this class is to redefine the matvec in scipy.sparse
+    """
+    def _mul_vector(self, other):
+        """
+        Identical to scipy.sparse with an in internal call to
+        pyamg.amg_core.sparse.csr_matvec
+        """
+        M, N = self.shape
+
+        # output array
+        result = np.zeros(M, dtype=upcast_char(self.dtype.char,
+                                               other.dtype.char))
+
+        # csr_matvec or csc_matvec
+        sparse.csr_matvec(M, N, self.indptr, self.indices, self.data, other, result)
+
+        return result
+
+
+csr.__doc__ += csr_matrix.__doc__

--- a/pyamg/util/sparse.py
+++ b/pyamg/util/sparse.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy.sparse import csr_matrix, _sparsetools
+import scipy.sparse
 from scipy.sparse.sputils import upcast_char
 import pyamg.amg_core
 
@@ -21,8 +22,8 @@ class csr(csr_matrix):
         result = np.zeros(M, dtype=upcast_char(self.dtype.char,
                                                other.dtype.char))
 
-        # csr_matvec or csc_matvec
-        sparse.csr_matvec(M, N, self.indptr, self.indices, self.data, other, result)
+        #scipy.sparse._sparsetools.csr_matvec(M, N, self.indptr, self.indices, self.data, other, result)
+        pyamg.amg_core.sparse.csr_matvec(M, N, self.indptr, self.indices, self.data, other, result)
 
         return result
 

--- a/pyamg/util/sparse.py
+++ b/pyamg/util/sparse.py
@@ -1,7 +1,14 @@
 import numpy as np
 from scipy.sparse import csr_matrix, _sparsetools
 import scipy.sparse
-from scipy.sparse.sputils import upcast_char
+
+try:
+    # scipy >=1.8
+    from scipy.sparse._sputils import upcast_char
+except ImportError:
+    # scipy <1.8
+    from scipy.sparse.sputils import upcast_char
+
 import pyamg.amg_core
 
 

--- a/pyamg/util/tests/test_sparse.py
+++ b/pyamg/util/tests/test_sparse.py
@@ -1,32 +1,41 @@
 import numpy as np
 import pyamg.gallery
-import pyamg.sparse
+import pyamg.util
+import scipy.sparse
 
-from numpy.testing import TestCase, assert_almost_equal
+from numpy.testing import TestCase, assert_array_almost_equal
 
 class TestScipy(TestCase):
     def test_matvec(self):
 
         # initialize a seed
-        random.seed(678)
+        np.random.seed(678)
 
         # real
-        A = array([[100.0, 0, 0], [0, 101, 0], [0, 0, 99]]))
-        A2 = pyamg.sparse.csr(A)
+        A = np.array([[100.0, 0, 0], [0, 101, 0], [0, 0, 99]])
+        A = scipy.sparse.csr_matrix(A)
+        A2 = pyamg.util.sparse.csr(A)
         u = np.random.rand(A.shape[0])
 
         assert_array_almost_equal(A * u, A2 * u)
 
         # complex
-        A = array([[100+1.0j, 0, 0],
-                   [0, 101-1.0j, 0],
-                   [0, 0, 99+9.9j]]))
-        A2 = pyamg.sparse.csr(A)
-        u = np.random.rand(A.shape[0])
+        A = np.array([[100+1.0j, 0, 0],
+                      [0, 101-1.0j, 0],
+                      [0, 0, 99+9.9j]])
+        A = scipy.sparse.csr_matrix(A)
+        A2 = pyamg.util.sparse.csr(A)
+        u = np.random.rand(A.shape[0]) + 1j * np.random.rand(A.shape[0])
+
+        result = A2 * u
+
+        result = A * u
+
         assert_array_almost_equal(A * u, A2 * u)
 
         # random
-        A = pyamg.gallery.sprand(20, 20, 6 / 20.0)
-        A2 = pyamg.sparse.csr(A)
+        A = pyamg.gallery.sprand(20, 20, 6 / 20.0, format='csr')
+        A2 = pyamg.util.sparse.csr(A)
         u = np.random.rand(A.shape[0])
+
         assert_array_almost_equal(A * u, A2 * u)

--- a/pyamg/util/tests/test_sparse.py
+++ b/pyamg/util/tests/test_sparse.py
@@ -27,10 +27,6 @@ class TestScipy(TestCase):
         A2 = pyamg.util.sparse.csr(A)
         u = np.random.rand(A.shape[0]) + 1j * np.random.rand(A.shape[0])
 
-        result = A2 * u
-
-        result = A * u
-
         assert_array_almost_equal(A * u, A2 * u)
 
         # random

--- a/pyamg/util/tests/test_sparse.py
+++ b/pyamg/util/tests/test_sparse.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pyamg.gallery
+import pyamg.sparse
+
+from numpy.testing import TestCase, assert_almost_equal
+
+class TestScipy(TestCase):
+    def test_matvec(self):
+
+        # initialize a seed
+        random.seed(678)
+
+        # real
+        A = array([[100.0, 0, 0], [0, 101, 0], [0, 0, 99]]))
+        A2 = pyamg.sparse.csr(A)
+        u = np.random.rand(A.shape[0])
+
+        assert_array_almost_equal(A * u, A2 * u)
+
+        # complex
+        A = array([[100+1.0j, 0, 0],
+                   [0, 101-1.0j, 0],
+                   [0, 0, 99+9.9j]]))
+        A2 = pyamg.sparse.csr(A)
+        u = np.random.rand(A.shape[0])
+        assert_array_almost_equal(A * u, A2 * u)
+
+        # random
+        A = pyamg.gallery.sprand(20, 20, 6 / 20.0)
+        A2 = pyamg.sparse.csr(A)
+        u = np.random.rand(A.shape[0])
+        assert_array_almost_equal(A * u, A2 * u)

--- a/scripts/test_omp.py
+++ b/scripts/test_omp.py
@@ -1,0 +1,26 @@
+import pyamg
+import numpy as np
+from timeit import default_timer as timer
+
+n = 1000
+nx = n
+ny = n
+
+stencil = pyamg.gallery.diffusion_stencil_2d(
+    type='FE', epsilon=0.001, theta=np.pi / 3)
+
+A = pyamg.gallery.stencil_grid(stencil, (nx, ny), format='csr')
+
+u = np.random.rand(A.shape[0])
+
+t0 = timer()
+v = A * u
+t1 = timer()
+print('time {}'.format(t1-t0))
+
+A2 = pyamg.util.sparse.csr(A)
+
+t0 = timer()
+v = A * u
+t1 = timer()
+print('time {}'.format(t1-t0))

--- a/scripts/test_omp.py
+++ b/scripts/test_omp.py
@@ -14,13 +14,13 @@ A = pyamg.gallery.stencil_grid(stencil, (nx, ny), format='csr')
 u = np.random.rand(A.shape[0])
 
 t0 = timer()
-v = A * u
+v = A @ u
 t1 = timer()
 print('time {}'.format(t1-t0))
 
 A2 = pyamg.util.sparse.csr(A)
 
 t0 = timer()
-v = A * u
+v = A2 @ u
 t1 = timer()
 print('time {}'.format(t1-t0))

--- a/scripts/try_omp.py
+++ b/scripts/try_omp.py
@@ -2,14 +2,9 @@ import pyamg
 import numpy as np
 from timeit import default_timer as timer
 
-n = 100
-nx = n
-ny = n
+n = 300
 
 t0 = timer()
-#stencil = pyamg.gallery.diffusion_stencil_2d(
-#    type='FE', epsilon=0.001, theta=np.pi / 3)
-#A = pyamg.gallery.stencil_grid(stencil, (nx, ny), format='csr')
 A = pyamg.gallery.poisson((n,n,n), format='csr')
 ml = pyamg.smoothed_aggregation_solver(A, max_coarse=10)
 b = np.random.rand(A.shape[0])

--- a/scripts/try_omp.py
+++ b/scripts/try_omp.py
@@ -1,0 +1,28 @@
+import pyamg
+import numpy as np
+from timeit import default_timer as timer
+
+n = 100
+nx = n
+ny = n
+
+t0 = timer()
+#stencil = pyamg.gallery.diffusion_stencil_2d(
+#    type='FE', epsilon=0.001, theta=np.pi / 3)
+#A = pyamg.gallery.stencil_grid(stencil, (nx, ny), format='csr')
+A = pyamg.gallery.poisson((n,n,n), format='csr')
+ml = pyamg.smoothed_aggregation_solver(A, max_coarse=10)
+b = np.random.rand(A.shape[0])
+u = np.random.rand(A.shape[0])
+t1 = timer()
+print('setup time {}'.format(t1-t0))
+
+t0 = timer()
+x = ml.solve(b, x0=u)
+t1 = timer()
+print('reg time {}'.format(t1-t0))
+
+t0 = timer()
+x = ml.solve(b, x0=u, openmp=True)
+t1 = timer()
+print('omp time {}'.format(t1-t0))

--- a/scripts/try_omp.py
+++ b/scripts/try_omp.py
@@ -2,7 +2,7 @@ import pyamg
 import numpy as np
 from timeit import default_timer as timer
 
-n = 300
+n = 200
 
 t0 = timer()
 A = pyamg.gallery.poisson((n,n,n), format='csr')
@@ -10,14 +10,19 @@ ml = pyamg.smoothed_aggregation_solver(A, max_coarse=10)
 b = np.random.rand(A.shape[0])
 u = np.random.rand(A.shape[0])
 t1 = timer()
-print('setup time {}'.format(t1-t0))
+print(f'problem size={A.shape}')
+print(f'setup time {t1-t0}')
 
 t0 = timer()
-x = ml.solve(b, x0=u)
+res = []
+x = ml.solve(b, x0=u, residuals=res)
 t1 = timer()
-print('reg time {}'.format(t1-t0))
+print(f'reg time {t1-t0}')
+print(res, '\n')
 
 t0 = timer()
-x = ml.solve(b, x0=u, openmp=True)
+res = []
+x = ml.solve(b, x0=u, openmp=True, residuals=res)
 t1 = timer()
-print('omp time {}'.format(t1-t0))
+print(f'omp time {t1-t0}')
+print(res, '\n')

--- a/scripts/try_omp.py
+++ b/scripts/try_omp.py
@@ -2,10 +2,10 @@ import pyamg
 import numpy as np
 from timeit import default_timer as timer
 
-n = 200
+n = 10000
 
 t0 = timer()
-A = pyamg.gallery.poisson((n,n,n), format='csr')
+A = pyamg.gallery.poisson((n,n), format='csr')
 ml = pyamg.smoothed_aggregation_solver(A, max_coarse=10)
 b = np.random.rand(A.shape[0])
 u = np.random.rand(A.shape[0])

--- a/scripts/try_sparse.py
+++ b/scripts/try_sparse.py
@@ -3,7 +3,7 @@ import numpy as np
 import sparse
 import os
 
-n = 16
+n = 32
 
 A = pyamg.gallery.poisson((n,), format='csr')
 

--- a/scripts/try_sparse.py
+++ b/scripts/try_sparse.py
@@ -1,6 +1,6 @@
 import pyamg
 import numpy as np
-import sparse
+from pyamg.amg_core import sparse
 import os
 
 n = 32

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,7 @@ extra_compile_args = []
 extra_link_args = []
 
 for cflag, lflag in [('-fopenmp', '-fopenmp'),
-                     ('-Xclang -fopenmp', '-lomp'),
-                     ('-Xpreprocessor -fopenmp -lomp', '-lomp')] :
+                     ('-Xpreprocessor -fopenmp', '-lomp')] :
     try:
         openmp = has_flag(build_ext.compiler, cflag)
         extra_compile_args.append(cflag)

--- a/setup.py
+++ b/setup.py
@@ -26,12 +26,11 @@ for cflag, lflag in [('-fopenmp', '-fopenmp'),
                      ('-Xpreprocessor -fopenmp', '-lomp')] :
     try:
         openmp = has_flag(build_ext.compiler, cflag)
-        extra_compile_args.append(cflag)
-        extra_link_args.append(lflag)
+        if openmp:
+            extra_compile_args.append(cflag)
+            extra_link_args.append(lflag)
     except:
         openmp = False
-
-print(f'\n\nUsing openmp flag {extra_compile_args}\n\n')
 
 amg_core_headers = ['evolution_strength',
                     'graph',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,8 @@ amg_core_headers = ['evolution_strength',
                     'linalg',
                     'relaxation',
                     'ruge_stuben',
-                    'smoothed_aggregation']
+                    'smoothed_aggregation',
+                    'sparse']
 
 ext_modules = [
     Pybind11Extension(f'pyamg.amg_core.{f}',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,22 @@ supporting C++ code for performance critical operations.
 """
 
 from setuptools import setup
-from pybind11.setup_helpers import Pybind11Extension, build_ext
+from pybind11.setup_helpers import Pybind11Extension, build_ext, has_flag
+
+extra_compile_args = []
+extra_link_args = []
+
+for cflag, lflag in [('-fopenmp', '-fopenmp'),
+                     ('-Xclang -fopenmp', '-lomp'),
+                     ('-Xpreprocessor -fopenmp -lomp', '-lomp')] :
+    try:
+        openmp = has_flag(build_ext.compiler, cflag)
+        extra_compile_args.append(cflag)
+        extra_link_args.append(lflag)
+    except:
+        openmp = False
+
+print(f'\n\nUsing openmp flag {extra_compile_args}\n\n')
 
 amg_core_headers = ['evolution_strength',
                     'graph',
@@ -30,6 +45,8 @@ amg_core_headers = ['evolution_strength',
 
 ext_modules = [
     Pybind11Extension(f'pyamg.amg_core.{f}',
+                      extra_compile_args=extra_compile_args,
+                      extra_link_args=extra_link_args,
                       sources=[f'pyamg/amg_core/{f}_bind.cpp'],
                      )
     for f in amg_core_headers]


### PR DESCRIPTION
This start adding OpenMP support

- `sparse.csr()` is added to call an OpenMP SpMV in `sparse.h` when `openmp=True` is added to the `.solve()` phase
- The approach should work with and without OpenMP support
- `setup.py` takes the simple approach of attempting two different compiler flags.
- On testing:
  - [ ] a test on the SpMV in `util/tests/test_sparse.py`
  - [ ] builds with/without OpenMP should be added to CI