### PR TITLE
add _set_dirichlet to PMIS

### DIFF
--- a/pyamg/classical/split.py
+++ b/pyamg/classical/split.py
@@ -187,7 +187,13 @@ def PMIS(S):
     S = remove_diagonal(S)
     weights, G, S, T = _preprocess(S)
     del S, T
-    return MIS(G, weights)
+
+    splitting = MIS(G, weights)
+    print(splitting)
+    _set_dirichlet(G, splitting)
+    print(splitting)
+
+    return splitting
 
 
 def PMISc(S, method='JP'):
@@ -442,3 +448,8 @@ def _preprocess(S, coloring_method=None):
                    / num_colors)
 
     return (weights, G, S, T)
+
+def _set_dirichlet(G, splitting):
+    # For rows of zero-length (Dirichlet), set as Fine.
+    I = np.where(np.diff(G.indptr)==0)[0]
+    splitting[I] = 0

--- a/pyamg/classical/split.py
+++ b/pyamg/classical/split.py
@@ -189,9 +189,7 @@ def PMIS(S):
     del S, T
 
     splitting = MIS(G, weights)
-    print(splitting)
     _set_dirichlet(G, splitting)
-    print(splitting)
 
     return splitting
 
@@ -449,7 +447,8 @@ def _preprocess(S, coloring_method=None):
 
     return (weights, G, S, T)
 
+
 def _set_dirichlet(G, splitting):
     # For rows of zero-length (Dirichlet), set as Fine.
-    I = np.where(np.diff(G.indptr)==0)[0]
+    I = np.where(np.diff(G.indptr) == 0)[0]
     splitting[I] = 0

--- a/pyamg/classical/tests/test_split.py
+++ b/pyamg/classical/tests/test_split.py
@@ -1,0 +1,33 @@
+"""Test splitting methods."""
+
+import numpy as np
+from numpy.testing import assert_array_equal
+import pyamg
+
+
+class TestMIS:
+    def test_paper_result(self):
+        # example from Figure 4.1 in
+        # Reducing Complexity in Parallel Algebraic Multigrid Preconditioners
+        # SIAM 2006
+
+        S = pyamg.gallery.poisson((7, 7), type='FE', format='csr')
+        w = [3.2, 5.6, 5.8, 5.6, 5.9, 5.9, 3.0,
+             5.0, 8.8, 8.5, 8.6, 8.7, 8.9, 5.3,
+             5.3, 8.7, 8.3, 8.4, 8.3, 8.8, 5.9,
+             5.7, 8.6, 8.3, 8.8, 8.3, 8.1, 5.0,
+             5.9, 8.1, 8.8, 8.9, 8.4, 8.2, 5.9,
+             5.2, 8.0, 8.5, 8.2, 8.6, 8.9, 5.1,
+             3.7, 5.3, 5.0, 5.9, 5.4, 5.3, 3.4]
+
+        w = np.array(w)
+        splitting = pyamg.classical.split.MIS(S, w)
+        splitting_paper =\
+            np.array([[0, 0, 0, 0, 0, 0, 0],
+                      [0, 1, 0, 1, 0, 1, 0],
+                      [0, 0, 0, 0, 0, 0, 0],
+                      [0, 1, 0, 0, 0, 1, 0],
+                      [0, 0, 0, 1, 0, 0, 0],
+                      [0, 1, 0, 0, 0, 1, 0],
+                      [0, 0, 0, 1, 0, 0, 0]], dtype=np.int32)
+        assert_array_equal(splitting.reshape((7, 7)), splitting_paper)


### PR DESCRIPTION
- [x] add function `_set_dirichlet()` to set empty rows (after `remove_diagonal`) to F-points.
- [x] add test

This is called in PMIS before the call to MIS, setting `mis[i] = 0` (F-point) for empty rows, while `mis[i] = -1` remains uninitialized for other nodes.  It could be used in CLJP as well.