### PR TITLE
Fix issue with BSR symmetric strength

### DIFF
--- a/pyamg/strength.py
+++ b/pyamg/strength.py
@@ -307,7 +307,7 @@ def symmetric_strength_of_connection(A, theta=0):
             # the strength of connection matrix is based on the
             # Frobenius norms of the blocks
             data = (np.conjugate(A.data) * A.data).reshape(-1, R * C)
-            data = data.sum(axis=1)
+            data = np.sqrt(data.sum(axis=1))
             A = sparse.csr_matrix((data, A.indices, A.indptr),
                                   shape=(int(M / R), int(N / C)))
             return symmetric_strength_of_connection(A, theta)


### PR DESCRIPTION
fixing issue where 1x1-block BSR matrices behaved differently than the CSR equivalent.  It was due to a missing square-root