### PR TITLE
Master air

### DIFF
--- a/pyamg/multilevel.py
+++ b/pyamg/multilevel.py
@@ -84,9 +84,10 @@ class multilevel_solver:
             self.smoothers = {}
             self.smoothers['presmoother'] = [None, {}]
             self.smoothers['postsmoother'] = [None, {}]
+            self.auxiliary = None
             self.SC = None
 
-    def __init__(self, levels, coarse_solver='pinv2'):
+    def __init__(self, levels, coarse_solver='pinv'):
         """Class constructor responsible for initializing the cycle and ensuring the list of levels is complete.
 
         Parameters
@@ -170,6 +171,9 @@ class multilevel_solver:
         for level in levels[:-1]:
             if not hasattr(level, 'R'):
                 level.R = level.P.H
+            if not hasattr(level, 'auxiliary'):
+                level.auxiliary = None
+
 
     def __repr__(self):
         """Print basic statistics about the multigrid hierarchy."""
@@ -624,6 +628,12 @@ class multilevel_solver:
         else:
             return x
 
+    def __auxiliary_solve(self, lvl, bc):
+        """ Auxiliary solve using CG for Gen-AIR
+        """
+        xc = sp.sparse.linalg.cg(self.levels[lvl].auxiliary['M_aux'], bc, tol=1e-05, maxiter=10)[0]
+        return xc
+
     def __solve(self, lvl, x, b, cycle, cyclesPerLevel=1):
         """Multigrid cycling.
 
@@ -650,7 +660,12 @@ class multilevel_solver:
 
         residual = b - A * x
 
-        coarse_b = self.levels[lvl].R * residual
+        # Auxiliary coarse-grid solve for gen-AIR
+        if self.levels[lvl].auxiliary is not None:
+            coarse_b0 = self.levels[lvl].R * residual
+            coarse_b = self.__auxiliary_solve(lvl, coarse_b0)
+        else:
+            coarse_b = self.levels[lvl].R * residual
         coarse_x = np.zeros_like(coarse_b)
 
         if lvl == len(self.levels) - 2:
@@ -698,6 +713,10 @@ class multilevel_solver:
                 raise TypeError('Unrecognized cycle type (%s)' % cycle)
 
         x += self.levels[lvl].P * coarse_x   # coarse grid correction
+
+        # Auxiliary coarse-grid correction for gen-AIR
+        if self.levels[lvl].auxiliary is not None:
+            x += self.levels[lvl].auxiliary['P_aux'] * coarse_b
 
         self.levels[lvl].postsmoother(A, x, b)
 


### PR DESCRIPTION
rootnode interpolation added in air.py. Also note that pinv2 is depreciated since SciPy 1.7.0, now we are using pinv instead in multilevel.py for better tolerance control. 