### PR TITLE
Pairwise base

### DIFF
--- a/pyamg/__init__.py
+++ b/pyamg/__init__.py
@@ -23,7 +23,7 @@ __all__ = ['__version_tuple__', '__version__',
            'blackbox', 'graph', 'graph_ref', 'multilevel', 'strength',
            'coarse_grid_solver', 'multilevel_solver', 'MultilevelSolver',
            'ruge_stuben_solver', 'smoothed_aggregation_solver', 'rootnode_solver',
-           'demo', 'solve', 'solver', 'solver_configuration']
+           'pairwise_solver', 'demo', 'solve', 'solver', 'solver_configuration']
 
 __all__ += ['test']
 

--- a/pyamg/__init__.py
+++ b/pyamg/__init__.py
@@ -13,7 +13,7 @@ from . import (blackbox, graph, graph_ref, multilevel, strength)
 
 from .multilevel import coarse_grid_solver, multilevel_solver, MultilevelSolver
 from .classical import ruge_stuben_solver
-from .aggregation import smoothed_aggregation_solver, rootnode_solver
+from .aggregation import smoothed_aggregation_solver, rootnode_solver, pairwise_solver
 from .gallery import demo
 from .blackbox import solve, solver, solver_configuration
 

--- a/pyamg/aggregation/__init__.py
+++ b/pyamg/aggregation/__init__.py
@@ -17,4 +17,4 @@ __all__ = ['adaptive_sa_solver',
            'fit_candidates',
            'jacobi_prolongation_smoother', 'richardson_prolongation_smoother',
            'energy_prolongation_smoother',
-           'rootnode_solver', pairwise_solver]
+           'rootnode_solver', 'pairwise_solver']

--- a/pyamg/aggregation/__init__.py
+++ b/pyamg/aggregation/__init__.py
@@ -8,6 +8,7 @@ from .tentative import fit_candidates
 from .smooth import (jacobi_prolongation_smoother, richardson_prolongation_smoother,
                      energy_prolongation_smoother)
 from .rootnode import rootnode_solver
+from .pairwise import pairwise_solver
 
 __all__ = ['adaptive_sa_solver',
            'standard_aggregation', 'naive_aggregation',
@@ -16,4 +17,4 @@ __all__ = ['adaptive_sa_solver',
            'fit_candidates',
            'jacobi_prolongation_smoother', 'richardson_prolongation_smoother',
            'energy_prolongation_smoother',
-           'rootnode_solver']
+           'rootnode_solver', pairwise_solver]

--- a/pyamg/aggregation/aggregate.py
+++ b/pyamg/aggregation/aggregate.py
@@ -300,8 +300,10 @@ def pairwise_aggregation(A, matchings=2, theta=0.25,
 
         # Form coarse grid operator for next matching
         if i < (matchings-1):
-            TA = T_temp.T * Ac
-            Ac = TA * T_temp
+            if sparse.isspmatrix_csr(T_temp):
+                Ac = T_temp.T.tocsr() * Ac * T_temp
+            else:
+                Ac = T_temp.T * Ac * T_temp
 
     # Convert T to dtype int if only used for aggregation
     if compute_P:

--- a/pyamg/aggregation/aggregate.py
+++ b/pyamg/aggregation/aggregate.py
@@ -196,14 +196,14 @@ def pairwise_aggregation(C):
     --------
     >>> from scipy.sparse import csr_matrix
     >>> from pyamg.gallery import poisson
-    >>> from pyamg.aggregation.aggregate import naive_aggregation
+    >>> from pyamg.aggregation.aggregate import pairwise_aggregation
     >>> A = poisson((4,), format='csr')   # 1D mesh with 4 vertices
     >>> A.todense()
     matrix([[ 2., -1.,  0.,  0.],
             [-1.,  2., -1.,  0.],
             [ 0., -1.,  2., -1.],
             [ 0.,  0., -1.,  2.]])
-    >>> naive_aggregation(A)[0].todense() # two aggregates
+    >>> pairwise_aggregation(A)[0].todense() # two aggregates
     matrix([[1, 0],
             [1, 0],
             [0, 1],
@@ -213,14 +213,14 @@ def pairwise_aggregation(C):
     matrix([[1, 0, 0],
             [0, 1, 1],
             [0, 1, 1]])
-    >>> naive_aggregation(A)[0].todense() # two aggregates
+    >>> pairwise_aggregation(A)[0].todense() # two aggregates
     matrix([[1, 0],
             [0, 1],
             [0, 1]], dtype=int8)
 
     See Also
     --------
-    amg_core.naive_aggregation
+    amg_core.pairwise_aggregation
 
     Notes
     -----
@@ -242,9 +242,9 @@ def pairwise_aggregation(C):
     Tj = np.empty(num_rows, dtype=index_type)  # stores the aggregate #s
     Cpts = np.empty(num_rows, dtype=index_type)  # stores the Cpts
 
-    fn = amg_core.naive_aggregation
+    fn = amg_core.pairwise_aggregation
 
-    num_aggregates = fn(num_rows, C.indptr, C.indices, Tj, Cpts)
+    num_aggregates = fn(num_rows, C.indptr, C.indices, C.data, Tj, Cpts)
     Cpts = Cpts[:num_aggregates]
     Tj = Tj - 1
 

--- a/pyamg/aggregation/aggregate.py
+++ b/pyamg/aggregation/aggregate.py
@@ -280,7 +280,9 @@ def pairwise_aggregation(A, matchings=2, theta=0.25,
                 Tx = np.ones(len(Tj), dtype='int8')
                 T_temp = sparse.csr_matrix((Tx, Tj, Tp), shape=shape)
             else:
-                Tx = np.dstack([np.eye(A.blocksize[0])]*len(Tj), dtype='int8')
+                shape = (shape[0]*A.blocksize[0], shape[1])
+                Tx = np.array(len(Tj)*[np.identity(A.blocksize[0])], dtype='int8')
+                # TODO this is old code, Tx = np.dstack([np.eye(A.blocksize[0])]*len(Tj), dtype='int8')
                 T_temp = sparse.bsr_matrix((Tx, Tj, Tp), blocksize=A.blocksize, shape=shape)
 
         # Form aggregation matrix, need to make sure is CSR/BSR

--- a/pyamg/aggregation/aggregate.py
+++ b/pyamg/aggregation/aggregate.py
@@ -1,11 +1,11 @@
 """Aggregation methods."""
 
 
+from warnings import warn
 import numpy as np
 from scipy import sparse
 from .. import amg_core
 from ..graph import lloyd_cluster
-from warnings import warn
 from ..strength import classical_strength_of_connection
 
 
@@ -232,14 +232,13 @@ def pairwise_aggregation(A, matchings=2, theta=0.25,
     method. Electronic transactions on numerical analysis, 37(6),
     123-146.
     """
-
     # Get SOC matrix
     if not (sparse.isspmatrix_bsr(A) or sparse.isspmatrix_csr(A)):
         try:
             A = A.tocsr()
-            warn("Implicit conversion of A to csr", sparse.SparseEfficiencyWarning)
+            warn('Implicit conversion of A to csr', sparse.SparseEfficiencyWarning)
         except BaseException as e:
-            raise TypeError("Invalid matrix type, must be CSR or BSR.") from e
+            raise TypeError('Invalid matrix type, must be CSR or BSR.') from e
 
     index_type = A.indptr.dtype
     Ac = A      # Let Ac reference A for loop purposes
@@ -247,7 +246,7 @@ def pairwise_aggregation(A, matchings=2, theta=0.25,
     Cpts = None
 
     # Loop over the number of pairwise matchings to be done
-    for i in range(0,matchings):
+    for i in range(0, matchings):
 
         # Compute SOC matrix for this matching
         if sparse.isspmatrix_bsr(A):
@@ -275,7 +274,7 @@ def pairwise_aggregation(A, matchings=2, theta=0.25,
         else:
             shape = (num_rows, num_aggregates)
             Tp = np.arange(num_rows+1, dtype=index_type)
-            # If A is not BSR, 
+            # If A is not BSR
             if not sparse.isspmatrix_bsr(A):
                 Tx = np.ones(len(Tj), dtype='int8')
                 T_temp = sparse.csr_matrix((Tx, Tj, Tp), shape=shape)
@@ -292,7 +291,7 @@ def pairwise_aggregation(A, matchings=2, theta=0.25,
                 T = sparse.bsr_matrix(T * T_temp)
             else:
                 T = sparse.csr_matrix(T * T_temp)
-        
+
         # Break loop if zero aggregates were found
         if num_aggregates == 0:
             break

--- a/pyamg/aggregation/aggregate.py
+++ b/pyamg/aggregation/aggregate.py
@@ -222,12 +222,11 @@ def pairwise_aggregation(C):
     --------
     amg_core.pairwise_aggregation
 
-    Notes
-    -----
-    Differs from standard aggregation.  Each dof is considered.  If it has been
-    aggregated, skip over.  Otherwise, put dof and any unaggregated neighbors
-    in an aggregate.  Results in possibly much higher complexities than
-    standard aggregation.
+
+    References
+    ----------
+    .. [1] Notay, Yvan. "An aggregation-based algebraic multigrid method."
+    Electronic transactions on numerical analysis 37.6 (2010): 123-146.
 
     """
     if not isspmatrix_csr(C):

--- a/pyamg/aggregation/aggregate.py
+++ b/pyamg/aggregation/aggregate.py
@@ -5,6 +5,8 @@ import numpy as np
 from scipy import sparse
 from .. import amg_core
 from ..graph import lloyd_cluster
+from warnings import warn
+from ..strength import classical_strength_of_connection
 
 
 def standard_aggregation(C):
@@ -176,19 +178,29 @@ def naive_aggregation(C):
     return sparse.csr_matrix((Tx, Tj, Tp), shape=shape), Cpts
 
 
-def pairwise_aggregation(C):
+def pairwise_aggregation(C, A, compute_P=False):
     """Compute the sparsity pattern of the tentative prolongator.
 
     Parameters
     ----------
     C : csr_matrix
         strength of connection matrix
+    A : csr_matrix or bsr_matrix
+        level matrix
+    compute_P : bool; default False
+        Compute pairwise interpolation directly; if False, return
+        integer aggregation matrix for smoothed_aggregation_solver.
+        If True, return float interpolation P, converting to BSR
+        form with identity of size bsize x bsize on each aggregate
+        if A is BSR.
 
     Returns
     -------
-    AggOp : csr_matrix
-        aggregation operator which determines the sparsity pattern
-        of the tentative prolongator
+    AggOp : csr_matrix or bsr_matrix.
+        compute_P = False: aggregation operator which determines
+        the sparsity pattern of the tentative prolongator.
+        compute_P = True: pairwise interpolation operator in 
+        same format as A (csr_matrix or bsr_matrix).
     Cpts : array
         array of Cpts, i.e., Cpts[i] = root node of aggregate i
 
@@ -229,7 +241,7 @@ def pairwise_aggregation(C):
     Electronic transactions on numerical analysis 37.6 (2010): 123-146.
 
     """
-    if not isspmatrix_csr(C):
+    if not sparse.isspmatrix_csr(C):
         raise TypeError('expected csr_matrix')
 
     if C.shape[0] != C.shape[1]:
@@ -247,15 +259,123 @@ def pairwise_aggregation(C):
     Cpts = Cpts[:num_aggregates]
     Tj = Tj - 1
 
-    if num_aggregates == 0:
-        # all zero matrix
-        return csr_matrix((num_rows, 1), dtype='int8'), Cpts
+    if compute_P:
+        if num_aggregates == 0:
+            # all zero matrix
+            return sparse.csr_matrix((num_rows, 1), dtype=A.dtype), Cpts
+        else:
+            shape = (num_rows, num_aggregates)
+            # all nodes aggregated
+            Tp = np.arange(num_rows+1, dtype=index_type)
+            # If A is not BSR, 
+            if not sparse.isspmatrix_bsr(A):
+                Tx = np.ones(len(Tj), dtype=A.dtype)
+                return sparse.csr_matrix((Tx, Tj, Tp), shape=shape), Cpts
+            else:
+                Tx = np.dstack([np.eye(A.blocksize[0])]*len(Tj), dtype=A.dtype)
+                return sparse.bsr_matrix((Tx, Tj, Tp), blocksize=A.blocksize, shape=shape), Cpts
     else:
-        shape = (num_rows, num_aggregates)
-        # all nodes aggregated
-        Tp = np.arange(num_rows+1, dtype=index_type)
-        Tx = np.ones(len(Tj), dtype='int8')
-        return csr_matrix((Tx, Tj, Tp), shape=shape), Cpts
+        if num_aggregates == 0:
+            # all zero matrix
+            return sparse.csr_matrix((num_rows, 1), dtype='int8'), Cpts
+        else:
+            shape = (num_rows, num_aggregates)
+            # all nodes aggregated
+            Tp = np.arange(num_rows+1, dtype=index_type)
+            Tx = np.ones(len(Tj), dtype='int8')
+            return sparse.csr_matrix((Tx, Tj, Tp), shape=shape), Cpts
+
+
+def pairwise_aggregation2(A, matchings=2, theta=0.25,
+    norm='min', compute_P=False):
+    """Compute the sparsity pattern of the tentative prolongator.
+
+    Parameters
+    ----------
+    A : csr_matrix or bsr_matrix
+        level matrix
+    compute_P : bool; default False
+        Compute pairwise interpolation directly; if False, return
+        integer aggregation matrix for smoothed_aggregation_solver.
+        If True, return float interpolation P, converting to BSR
+        form with identity of size bsize x bsize on each aggregate
+        if A is BSR.
+
+    """
+
+    # Get SOC matrix
+    if not (sparse.isspmatrix_bsr(A) or sparse.isspmatrix_csr(A)):
+        try:
+            A = A.tocsr()
+            warn("Implicit conversion of A to csr", sparse.SparseEfficiencyWarning)
+        except BaseException as e:
+            raise TypeError("Invalid matrix type, must be CSR or BSR.") from e
+
+    index_type = A.indptr.dtype
+    Ac = A      # Let Ac reference A for loop purposes
+    T = None
+    Cpts = None
+
+    # Loop over the number of pairwise matchings to be done
+    for i in range(0,matchings):
+
+        # Compute SOC matrix for this matching
+        if sparse.isspmatrix_bsr(A):
+            C = classical_strength_of_connection(A=Ac, theta=theta, block=True, norm=norm)
+        else:
+            C = classical_strength_of_connection(A=Ac, theta=theta, block=False, norm=norm)
+
+        # Form pairwise aggregation matrix
+        num_rows = C.shape[0]
+        Tj = np.empty(num_rows, dtype=index_type)  # stores the aggregate #s
+        new_cpts = np.empty(num_rows, dtype=index_type)  # stores the new_cpts
+        fn = amg_core.pairwise_aggregation
+        num_aggregates = fn(num_rows, C.indptr, C.indices, C.data, Tj, new_cpts)
+        if Cpts is None:
+            Cpts = new_cpts[:num_aggregates]
+        else:
+            Cpts = Cpts[new_cpts[:num_aggregates]]
+        Tj = Tj - 1
+
+        # Construct sparse T
+        if num_aggregates == 0:
+            # all zero matrix
+            T_temp = sparse.csr_matrix((num_rows, 1), dtype='int8')
+            warn('No pairwise aggregates found, T = 0.')
+        else:
+            shape = (num_rows, num_aggregates)
+            Tp = np.arange(num_rows+1, dtype=index_type)
+            # If A is not BSR, 
+            if not sparse.isspmatrix_bsr(A):
+                Tx = np.ones(len(Tj), dtype='int8')
+                T_temp = sparse.csr_matrix((Tx, Tj, Tp), shape=shape)
+            else:
+                Tx = np.dstack([np.eye(A.blocksize[0])]*len(Tj), dtype='int8')
+                T_temp = sparse.bsr_matrix((Tx, Tj, Tp), blocksize=A.blocksize, shape=shape)
+
+        # Form aggregation matrix, need to make sure is CSR/BSR
+        if i == 0:
+            T = T_temp
+        else:
+            if sparse.isspmatrix_bsr(A):
+                T = sparse.bsr_matrix(T * T_temp)
+            else:
+                T = sparse.csr_matrix(T * T_temp)
+        
+        # Break loop if zero aggregates were found
+        if num_aggregates == 0:
+            break
+
+        # Form coarse grid operator for next matching
+        if i < (matchings-1):
+            TA = T_temp.T * Ac
+            Ac = TA * T_temp
+
+    # Convert T to dtype int if only used for aggregation
+    if compute_P:
+        T = T.astype(A.dtype, copy=False)
+
+    return T, Cpts
 
 
 def lloyd_aggregation(C, ratio=0.03, distance='unit', maxiter=10):

--- a/pyamg/aggregation/aggregate.py
+++ b/pyamg/aggregation/aggregate.py
@@ -176,6 +176,89 @@ def naive_aggregation(C):
     return sparse.csr_matrix((Tx, Tj, Tp), shape=shape), Cpts
 
 
+def pairwise_aggregation(C):
+    """Compute the sparsity pattern of the tentative prolongator.
+
+    Parameters
+    ----------
+    C : csr_matrix
+        strength of connection matrix
+
+    Returns
+    -------
+    AggOp : csr_matrix
+        aggregation operator which determines the sparsity pattern
+        of the tentative prolongator
+    Cpts : array
+        array of Cpts, i.e., Cpts[i] = root node of aggregate i
+
+    Examples
+    --------
+    >>> from scipy.sparse import csr_matrix
+    >>> from pyamg.gallery import poisson
+    >>> from pyamg.aggregation.aggregate import naive_aggregation
+    >>> A = poisson((4,), format='csr')   # 1D mesh with 4 vertices
+    >>> A.todense()
+    matrix([[ 2., -1.,  0.,  0.],
+            [-1.,  2., -1.,  0.],
+            [ 0., -1.,  2., -1.],
+            [ 0.,  0., -1.,  2.]])
+    >>> naive_aggregation(A)[0].todense() # two aggregates
+    matrix([[1, 0],
+            [1, 0],
+            [0, 1],
+            [0, 1]], dtype=int8)
+    >>> A = csr_matrix([[1,0,0],[0,1,1],[0,1,1]])
+    >>> A.todense()                      # first vertex is isolated
+    matrix([[1, 0, 0],
+            [0, 1, 1],
+            [0, 1, 1]])
+    >>> naive_aggregation(A)[0].todense() # two aggregates
+    matrix([[1, 0],
+            [0, 1],
+            [0, 1]], dtype=int8)
+
+    See Also
+    --------
+    amg_core.naive_aggregation
+
+    Notes
+    -----
+    Differs from standard aggregation.  Each dof is considered.  If it has been
+    aggregated, skip over.  Otherwise, put dof and any unaggregated neighbors
+    in an aggregate.  Results in possibly much higher complexities than
+    standard aggregation.
+
+    """
+    if not isspmatrix_csr(C):
+        raise TypeError('expected csr_matrix')
+
+    if C.shape[0] != C.shape[1]:
+        raise ValueError('expected square matrix')
+
+    index_type = C.indptr.dtype
+    num_rows = C.shape[0]
+
+    Tj = np.empty(num_rows, dtype=index_type)  # stores the aggregate #s
+    Cpts = np.empty(num_rows, dtype=index_type)  # stores the Cpts
+
+    fn = amg_core.naive_aggregation
+
+    num_aggregates = fn(num_rows, C.indptr, C.indices, Tj, Cpts)
+    Cpts = Cpts[:num_aggregates]
+    Tj = Tj - 1
+
+    if num_aggregates == 0:
+        # all zero matrix
+        return csr_matrix((num_rows, 1), dtype='int8'), Cpts
+    else:
+        shape = (num_rows, num_aggregates)
+        # all nodes aggregated
+        Tp = np.arange(num_rows+1, dtype=index_type)
+        Tx = np.ones(len(Tj), dtype='int8')
+        return csr_matrix((Tx, Tj, Tp), shape=shape), Cpts
+
+
 def lloyd_aggregation(C, ratio=0.03, distance='unit', maxiter=10):
     """Aggregate nodes using Lloyd Clustering.
 

--- a/pyamg/aggregation/aggregate.py
+++ b/pyamg/aggregation/aggregate.py
@@ -200,6 +200,32 @@ def pairwise_aggregation(A, matchings=2, theta=0.25,
         form with identity of size bsize x bsize on each aggregate
         if A is BSR.
 
+    Examples
+    --------
+    >>> from scipy.sparse import csr_matrix
+    >>> from pyamg.gallery import poisson
+    >>> from pyamg.aggregation.aggregate import pairwise_aggregation
+    >>> A = poisson((4,), format='csr')   # 1D mesh with 4 vertices
+    >>> A.toarray()
+    array([[ 2., -1.,  0.,  0.],
+           [-1.,  2., -1.,  0.],
+           [ 0., -1.,  2., -1.],
+           [ 0.,  0., -1.,  2.]])
+    >>> pairwise_aggregation(A, matchings=1)[0].toarray() # two aggregates
+    array([[1, 0],
+           [1, 0],
+           [0, 1],
+           [0, 1]], dtype=int8)
+    >>> pairwise_aggregation(A, matchings=2)[0].toarray() # one aggregate
+    array([[1],
+           [1],
+           [1],
+           [1]], dtype=int8)
+
+    See Also
+    --------
+    amg_core.pairwise_aggregation
+
     References
     ----------
     [0] Notay, Y. (2010). An aggregation-based algebraic multigrid

--- a/pyamg/aggregation/aggregate.py
+++ b/pyamg/aggregation/aggregate.py
@@ -280,9 +280,8 @@ def pairwise_aggregation(A, matchings=2, theta=0.25,
                 Tx = np.ones(len(Tj), dtype='int8')
                 T_temp = sparse.csr_matrix((Tx, Tj, Tp), shape=shape)
             else:
-                shape = (shape[0]*A.blocksize[0], shape[1])
+                shape = (shape[0]*A.blocksize[0], shape[1]*A.blocksize[1])
                 Tx = np.array(len(Tj)*[np.identity(A.blocksize[0])], dtype='int8')
-                # TODO this is old code, Tx = np.dstack([np.eye(A.blocksize[0])]*len(Tj), dtype='int8')
                 T_temp = sparse.bsr_matrix((Tx, Tj, Tp), blocksize=A.blocksize, shape=shape)
 
         # Form aggregation matrix, need to make sure is CSR/BSR

--- a/pyamg/aggregation/aggregation.py
+++ b/pyamg/aggregation/aggregation.py
@@ -348,7 +348,7 @@ def _extend_hierarchy(levels, strength, aggregate, smooth, improve_candidates,
     elif fn == 'lloyd':
         AggOp = lloyd_aggregation(C, **kwargs)[0]
     elif fn == 'pairwise':
-        AggOp = pairwise_aggregation(C, **kwargs)[0]
+        AggOp = pairwise_aggregation(C, A, **kwargs)[0]
     elif fn == 'predefined':
         AggOp = kwargs['AggOp'].tocsr()
     else:

--- a/pyamg/aggregation/aggregation.py
+++ b/pyamg/aggregation/aggregation.py
@@ -348,7 +348,7 @@ def _extend_hierarchy(levels, strength, aggregate, smooth, improve_candidates,
     elif fn == 'lloyd':
         AggOp = lloyd_aggregation(C, **kwargs)[0]
     elif fn == 'pairwise':
-        AggOp = pairwise_aggregation(C, A, **kwargs)[0]
+        AggOp = pairwise_aggregation(A, **kwargs)[0]
     elif fn == 'predefined':
         AggOp = kwargs['AggOp'].tocsr()
     else:

--- a/pyamg/aggregation/aggregation.py
+++ b/pyamg/aggregation/aggregation.py
@@ -15,7 +15,7 @@ from pyamg.strength import classical_strength_of_connection,\
     energy_based_strength_of_connection, distance_strength_of_connection,\
     algebraic_distance, affinity_distance
 from .aggregate import standard_aggregation, naive_aggregation,\
-    lloyd_aggregation
+    lloyd_aggregation, pairwise_aggregation
 from .tentative import fit_candidates
 from .smooth import jacobi_prolongation_smoother,\
     richardson_prolongation_smoother, energy_prolongation_smoother
@@ -71,7 +71,7 @@ def smoothed_aggregation_solver(A, B=None, BH=None,
 
     aggregate : string or list
         Method used to aggregate nodes.
-        Choose from 'standard', 'lloyd', 'naive',
+        Choose from 'standard', 'lloyd', 'naive', 'pairwise',
         ('predefined', {'AggOp' : csr_matrix})
 
     smooth : list
@@ -347,6 +347,8 @@ def _extend_hierarchy(levels, strength, aggregate, smooth, improve_candidates,
         AggOp = naive_aggregation(C, **kwargs)[0]
     elif fn == 'lloyd':
         AggOp = lloyd_aggregation(C, **kwargs)[0]
+    elif fn == 'pairwise':
+        AggOp = pairwise_aggregation(C, **kwargs)[0]
     elif fn == 'predefined':
         AggOp = kwargs['AggOp'].tocsr()
     else:

--- a/pyamg/aggregation/pairwise.py
+++ b/pyamg/aggregation/pairwise.py
@@ -129,7 +129,7 @@ def _extend_hierarchy(levels, aggregate):
     A = levels[-1].A
 
     # Compute pairwise interpolation and restriction matrices, R=P^*
-    fn, kwargs = unpack_arg(aggregate[len(levels)-1])
+    _, kwargs = unpack_arg(aggregate[len(levels)-1])
     P = pairwise_aggregation(A, **kwargs, compute_P=True)[0]
     R = P.H
     if isspmatrix_csr(P):

--- a/pyamg/aggregation/pairwise.py
+++ b/pyamg/aggregation/pairwise.py
@@ -32,7 +32,8 @@ def pairwise_solver(A,
             {'theta': 0.25, 'norm':'min', 'matchings': 2})
         Method choice must be 'pairwise'; inner pairwise options including
         matchings, theta, and norm can be modified,
-    presmoother : {tuple, string, list} : default ('block_gauss_seidel', {'sweep':'symmetric'})
+    presmoother : {tuple, string, list} : default ('block_gauss_seidel',
+        {'sweep':'symmetric'})
         Defines the presmoother for the multilevel cycling.  The default block
         Gauss-Seidel option defaults to point-wise Gauss-Seidel, if the matrix
         is CSR or is a BSR matrix with blocksize of 1.  See notes below for

--- a/pyamg/aggregation/pairwise.py
+++ b/pyamg/aggregation/pairwise.py
@@ -56,6 +56,15 @@ def pairwise_solver(A,
     max_coarse : {integer} : default 500
         Maximum number of variables permitted on the coarse grid.
 
+    Other Parameters
+    ----------------
+    coarse_solver : ['splu', 'lu', 'cholesky, 'pinv', 'gauss_seidel', ... ]
+        Solver used at the coarsest level of the MG hierarchy.
+        Optionally, may be a tuple (fn, args), where fn is a string such as
+        ['splu', 'lu', ...] or a callable function, and args is a dictionary of
+        arguments to be passed to fn.
+
+
     Returns
     -------
     ml : multilevel_solver
@@ -97,6 +106,8 @@ def pairwise_solver(A,
 
     if A.shape[0] != A.shape[1]:
         raise ValueError('expected square matrix')
+    if np.iscomplexobj(A.data):
+        raise ValueError('Pairwise solver not verified for complex matrices')
 
     # Levelize the user parameters, so that they become lists describing the
     # desired user option on each level.

--- a/pyamg/aggregation/pairwise.py
+++ b/pyamg/aggregation/pairwise.py
@@ -8,29 +8,20 @@ from scipy.sparse import csr_matrix, isspmatrix_csr, isspmatrix_bsr,\
 
 from pyamg.multilevel import MultilevelSolver
 from pyamg.relaxation.smoothing import change_smoothers
-from pyamg.util.utils import eliminate_diag_dom_nodes, get_blocksize,\
-    levelize_strength_or_aggregation, levelize_smooth_or_improve_candidates
-from pyamg.strength import classical_strength_of_connection,\
-    symmetric_strength_of_connection, evolution_strength_of_connection,\
-    energy_based_strength_of_connection, distance_strength_of_connection,\
-    algebraic_distance, affinity_distance
+from pyamg.util.utils import get_blocksize, levelize_strength_or_aggregation
 from .aggregate import pairwise_aggregation
-from .tentative import fit_candidates
-
-from ..relaxation.utils import relaxation_as_linear_operator
-
 
 __all__ = ['pairwise_solver']
 
 
 def pairwise_solver(A,
                     aggregate=('pairwise', {'theta': 0.25,
-                        'norm':'min', 'matchings': 2}),
+                               'norm': 'min', 'matchings': 2}),
                     presmoother=('block_gauss_seidel',
                                  {'sweep': 'symmetric'}),
                     postsmoother=('block_gauss_seidel',
                                   {'sweep': 'symmetric'}),
-                    max_levels = 20, max_coarse = 10,
+                    max_levels=20, max_coarse=10,
                     **kwargs):
     """
     Create a multilevel solver using Pairwise Aggregation.
@@ -129,9 +120,7 @@ def pairwise_solver(A,
 
 
 def _extend_hierarchy(levels, aggregate):
-    """Extend the multigrid hierarchy.
-
-    """
+    """Extend the multigrid hierarchy."""
     def unpack_arg(v):
         if isinstance(v, tuple):
             return v[0], v[1]

--- a/pyamg/aggregation/pairwise.py
+++ b/pyamg/aggregation/pairwise.py
@@ -134,7 +134,7 @@ def _extend_hierarchy(levels, aggregate):
         # In this case, R will be CSC, which must be changed
         R = R.tocsr()
 
-    levels[-1].P = P  # smoothed prolongator
+    levels[-1].P = P  # unsmoothed prolongator
     levels[-1].R = R  # restriction operator
 
     levels.append(MultilevelSolver.Level())

--- a/pyamg/aggregation/pairwise.py
+++ b/pyamg/aggregation/pairwise.py
@@ -1,4 +1,4 @@
-"""Support for aggregation-based AMG."""
+"""Support for pairwise-aggregation-based AMG."""
 
 
 from warnings import warn
@@ -14,11 +14,8 @@ from pyamg.strength import classical_strength_of_connection,\
     symmetric_strength_of_connection, evolution_strength_of_connection,\
     energy_based_strength_of_connection, distance_strength_of_connection,\
     algebraic_distance, affinity_distance
-from .aggregate import standard_aggregation, naive_aggregation,\
-    lloyd_aggregation, notay_pairwise, weighted_matching
+from .aggregate import pairwise_aggregation, pairwise_aggregation2
 from .tentative import fit_candidates
-from .smooth import jacobi_prolongation_smoother,\
-    richardson_prolongation_smoother, energy_prolongation_smoother
 
 from ..relaxation.utils import relaxation_as_linear_operator
 
@@ -26,19 +23,15 @@ from ..relaxation.utils import relaxation_as_linear_operator
 __all__ = ['pairwise_solver']
 
 
-def pairwise_solver(A, B=None, BH=None,
-                    symmetry='hermitian',
-                    strength=None,
-                    aggregate='standard',
+def pairwise_solver(A,
+                    aggregate=('pairwise', {'theta': 0.25,
+                        'norm':'min', 'matchings': 2}),
                     presmoother=('block_gauss_seidel',
                                  {'sweep': 'symmetric'}),
                     postsmoother=('block_gauss_seidel',
                                   {'sweep': 'symmetric'}),
-                    improve_candidates=[('block_gauss_seidel',
-                                        {'sweep': 'symmetric',
-                                         'iterations': 4}), None],
                     max_levels = 20, max_coarse = 10,
-                    keep=False, **kwargs):
+                    **kwargs):
     """
     Create a multilevel solver using Pairwise Aggregation
 
@@ -46,25 +39,6 @@ def pairwise_solver(A, B=None, BH=None,
     ----------
     A : {csr_matrix, bsr_matrix}
         Sparse NxN matrix in CSR or BSR format
-    B : {None, array_like}
-        Right near-nullspace candidates stored in the columns of an NxK array.
-        The default value B=None is equivalent to B=ones((N,1))
-    BH : {None, array_like}
-        Left near-nullspace candidates stored in the columns of an NxK array.
-        BH is only used if symmetry is 'nonsymmetric'.
-        The default value B=None is equivalent to BH=B.copy()
-    symmetry : {string}
-        'symmetric' refers to both real and complex symmetric
-        'hermitian' refers to both complex Hermitian and real Hermitian
-        'nonsymmetric' i.e. nonsymmetric in a hermitian sense
-        Note, in the strictly real case, symmetric and hermitian are the same
-        Note, this flag does not denote definiteness of the operator.
-    aggregate : {list} : default ['standard', 'lloyd', 'naive', 'pairwise',
-                ('predefined', {'AggOp' : csr_matrix})]
-        Method used to aggregate nodes.  See notes below for varying this
-        parameter on a per level basis.  Also, see notes below for using a
-        predefined aggregation on each level. Method-specific parameters may be
-        passed in using a tuple, e.g. aggregate=('pairwise',{'num_matchings': 2 })
     presmoother : {tuple, string, list} : default ('block_gauss_seidel',
                   {'sweep':'symmetric'})
         Defines the presmoother for the multilevel cycling.  The default block
@@ -73,38 +47,10 @@ def pairwise_solver(A, B=None, BH=None,
         varying this parameter on a per level basis.
     postsmoother : {tuple, string, list}
         Same as presmoother, except defines the postsmoother.
-    improve_candidates : {tuple, string, list} : default
-                        [('block_gauss_seidel',
-                         {'sweep': 'symmetric', 'iterations': 4}), None]
-        The ith entry defines the method used to improve the candidates B on
-        level i.  If the list is shorter than max_levels, then the last entry
-        will define the method for all levels lower.  If tuple or string, then
-        this single relaxation descriptor defines improve_candidates on all
-        levels.
-        The list elements are relaxation descriptors of the form used for
-        presmoother and postsmoother.  A value of None implies no action on B.
     max_levels : {integer} : default 10
         Maximum number of levels to be used in the multilevel solver.
     max_coarse : {integer} : default 500
         Maximum number of variables permitted on the coarse grid.
-    keep : {bool} : default False
-        Flag to indicate keeping extra operators in the hierarchy for
-        diagnostics.  For example, if True, then strength of connection (C),
-        tentative prolongation (T), and aggregation (AggOp) are kept.
-
-    Other Parameters
-    ----------------
-    cycle_type : ['V','W','F']
-        Structrure of multigrid cycle
-    coarse_solver : ['splu', 'lu', 'cholesky, 'pinv', 'gauss_seidel', ... ]
-        Solver used at the coarsest level of the MG hierarchy.
-            Optionally, may be a tuple (fn, args), where fn is a string such as
-        ['splu', 'lu', ...] or a callable function, and args is a dictionary of
-        arguments to be passed to fn.
-    setup_complexity : bool
-        For a detailed, more accurate setup complexity, pass in 
-        'setup_complexity' = True. This will slow down performance, but
-        increase accuracy of complexity count. 
 
     Returns
     -------
@@ -120,10 +66,8 @@ def pairwise_solver(A, B=None, BH=None,
     -----
 
 
-
     References
     ----------
-
 
 
     """
@@ -137,78 +81,30 @@ def pairwise_solver(A, B=None, BH=None,
 
     A = A.asfptype()
 
-    if symmetry not in ('symmetric', 'hermitian', 'nonsymmetric'):
-        raise ValueError('Expected "symmetric", "nonsymmetric" or "hermitian" '
-                         'for the symmetry parameter ')
-    A.symmetry = symmetry
-
     if A.shape[0] != A.shape[1]:
         raise ValueError('expected square matrix')
 
-    # Right near nullspace candidates use constant for each variable as default
-    if B is None:
-        B = np.kron(np.ones((int(A.shape[0]/get_blocksize(A)), 1), dtype=A.dtype),
-                    np.eye(get_blocksize(A), dtype=A.dtype))
-    else:
-        B = np.asarray(B, dtype=A.dtype)
-        if len(B.shape) == 1:
-            B = B.reshape(-1, 1)
-        if B.shape[0] != A.shape[0]:
-            raise ValueError('The shape of near null-space modes B is incorrect')
-        if B.shape[1] < get_blocksize(A):
-            warn('Having less target vectors, B.shape[1], than blocksize of A '
-                 'can degrade convergence factors.')
-
-    # Left near nullspace candidates
-    if A.symmetry == 'nonsymmetric':
-        if BH is None:
-            BH = B.copy()
-        else:
-            BH = np.asarray(BH, dtype=A.dtype)
-            if len(BH.shape) == 1:
-                BH = BH.reshape(-1, 1)
-            if BH.shape[1] != B.shape[1]:
-                raise ValueError('The number of left and right near null-space '
-                                 'modes B and BH must be equal')
-            if BH.shape[0] != A.shape[0]:
-                raise ValueError('The shape of near null-space modes B is incorrect')
-
     # Levelize the user parameters, so that they become lists describing the
     # desired user option on each level.
-    max_levels, max_coarse, strength =\
-        levelize_strength_or_aggregation(strength, max_levels, max_coarse)
     max_levels, max_coarse, aggregate =\
         levelize_strength_or_aggregation(aggregate, max_levels, max_coarse)
-    improve_candidates =\
-        levelize_smooth_or_improve_candidates(improve_candidates, max_levels)
-    smooth = levelize_smooth_or_improve_candidates(smooth, max_levels)
 
     # Construct multilevel structure
     levels = []
     levels.append(MultilevelSolver.Level())
     levels[-1].A = A          # matrix
 
-    # Append near nullspace candidates
-    levels[-1].B = B          # right candidates
-    if A.symmetry == 'nonsymmetric':
-        levels[-1].BH = BH    # left candidates
-
     while len(levels) < max_levels and\
             int(levels[-1].A.shape[0]/get_blocksize(levels[-1].A)) > max_coarse:
-        _extend_hierarchy(levels, strength, aggregate,
-                          improve_candidates, keep)
+        _extend_hierarchy(levels, aggregate)
 
     ml = MultilevelSolver(levels, **kwargs)
     change_smoothers(ml, presmoother, postsmoother)
     return ml
 
 
-def _extend_hierarchy(levels, strength, aggregate, improve_candidates, keep):
+def _extend_hierarchy(levels, aggregate):
     """Extend the multigrid hierarchy.
-
-    Service routine to implement the strength of connection, aggregation,
-    tentative prolongation construction, and prolongation smoothing.  Called by
-    smoothed_aggregation_solver.
 
     """
     def unpack_arg(v):
@@ -217,107 +113,15 @@ def _extend_hierarchy(levels, strength, aggregate, improve_candidates, keep):
         return v, {}
 
     A = levels[-1].A
-    B = levels[-1].B
-    if A.symmetry == "nonsymmetric":
-        AH = A.H.asformat(A.format)
-        BH = levels[-1].BH
 
-    # Compute the strength-of-connection matrix C, where larger
-    # C[i,j] denote stronger couplings between i and j. Note, this
-    # is not used for aggregation, only as sparsity pattern for
-    # energy-min smoothing, or filtering Jacobi smoothing of T.
-    fn, kwargs = unpack_arg(strength[len(levels)-1])
-    if fn == 'symmetric':
-        C = symmetric_strength_of_connection(A, **kwargs)
-    elif fn == 'classical':
-        C = classical_strength_of_connection(A, **kwargs)
-    elif fn == 'distance':
-        C = distance_strength_of_connection(A, **kwargs)
-    elif (fn == 'ode') or (fn == 'evolution'):
-        if 'B' in kwargs:
-            C = evolution_strength_of_connection(A, **kwargs)
-        else:
-            C = evolution_strength_of_connection(A, B, **kwargs)
-    elif fn == 'energy_based':
-        C = energy_based_strength_of_connection(A, **kwargs)
-    elif fn == 'predefined':
-        C = kwargs['C'].tocsr()
-    elif fn == 'algebraic_distance':
-        C = algebraic_distance(A, **kwargs)
-    elif fn == 'affinity':
-        C = affinity_distance(A, **kwargs)
-    elif fn is None:
-        C = A.tocsr()
-    else:
-        raise ValueError('unrecognized strength of connection method: %s' %
-                         str(fn))
-
-    # Get choice of aggregation routine and arguments
+    # Compute pairwise interpolation and restriction matrices, R=P^*
     fn, kwargs = unpack_arg(aggregate[len(levels)-1])
-
-    # Check for boolean "improve_candidates." If true, target vectors are
-    # improved each level of pairwise aggregation with chosen relaxation scheme. 
-    if ('improve_candidates' in kwargs) and \
-       (kwargs['improve_candidates'] == True):
-       kwargs['improve_candidates'] = improve_candidates[len(levels)-1]
-    else:
-       kwargs['improve_candidates'] = None
-
-    # Improve near nullspace candidates by relaxing on A B = 0
-    fn, kwargs = unpack_arg(improve_candidates[len(levels)-1])
-    if fn is not None:
-        b = np.zeros((A.shape[0], 1), dtype=A.dtype)
-        B = relaxation_as_linear_operator((fn, kwargs), A, b) * B
-        levels[-1].B = B
-        if A.symmetry == 'nonsymmetric':
-            BH = relaxation_as_linear_operator((fn, kwargs), AH, b) * BH
-            levels[-1].BH = BH
-
-
-    # Compute tentative interpolation operator T. Only fits one target
-    # per aggregate - if more are provided, they are fit in fit_candidates().
-    if fn == 'notay':
-        P = notay_pairwise(A, B=B, **kwargs)
-    elif fn == 'matching':
-        P = weighted_matching(A, B=B, **kwargs)
-    else:
-        raise ValueError('unrecognized aggregation method %s' % str(fn))
-
-    # TODO : Need option for B=None because this saves cost in computing
-    #        pairwise... 
-
-
-    ### GENERAL TODO :
-    ### - Generalize current Notay PR to support block matrix, candidate 
-    ### vectors, and multiple rounds of aggregation/matching.
-    
-
-
-
-    # Compute the restriction matrix, R, which interpolates from the fine-grid
-    # to the coarse-grid.  If A is nonsymmetric, then R must be constructed
-    # based on A.H.  Otherwise R = P.H or P.T.
-    symmetry = A.symmetry
-    if symmetry == 'hermitian':
-        R = P.H
-    elif symmetry == 'symmetric':
-        R = P.T
-    elif symmetry == 'nonsymmetric':
-        R = T.H
-
-    if keep:
-        levels[-1].C = C  # strength of connection matrix
-        levels[-1].AggOp = AggOp  # aggregation operator
-        levels[-1].T = T  # tentative prolongator
+    P = pairwise_aggregation2(A, **kwargs, compute_P=True)[0]
+    R = P.H
 
     levels[-1].P = P  # smoothed prolongator
     levels[-1].R = R  # restriction operator
 
     levels.append(MultilevelSolver.Level())
     A = R * A * P              # Galerkin operator
-    A.symmetry = symmetry
     levels[-1].A = A
-    levels[-1].B = B           # right near nullspace candidates
-
-    if A.symmetry == 'nonsymmetric':
-        levels[-1].BH = BH     # left near nullspace candidates

--- a/pyamg/aggregation/pairwise.py
+++ b/pyamg/aggregation/pairwise.py
@@ -1,0 +1,323 @@
+"""Support for aggregation-based AMG."""
+
+
+from warnings import warn
+import numpy as np
+from scipy.sparse import csr_matrix, isspmatrix_csr, isspmatrix_bsr,\
+    SparseEfficiencyWarning
+
+from pyamg.multilevel import MultilevelSolver
+from pyamg.relaxation.smoothing import change_smoothers
+from pyamg.util.utils import eliminate_diag_dom_nodes, get_blocksize,\
+    levelize_strength_or_aggregation, levelize_smooth_or_improve_candidates
+from pyamg.strength import classical_strength_of_connection,\
+    symmetric_strength_of_connection, evolution_strength_of_connection,\
+    energy_based_strength_of_connection, distance_strength_of_connection,\
+    algebraic_distance, affinity_distance
+from .aggregate import standard_aggregation, naive_aggregation,\
+    lloyd_aggregation, notay_pairwise, weighted_matching
+from .tentative import fit_candidates
+from .smooth import jacobi_prolongation_smoother,\
+    richardson_prolongation_smoother, energy_prolongation_smoother
+
+from ..relaxation.utils import relaxation_as_linear_operator
+
+
+__all__ = ['pairwise_solver']
+
+
+def pairwise_solver(A, B=None, BH=None,
+                    symmetry='hermitian',
+                    strength=None,
+                    aggregate='standard',
+                    presmoother=('block_gauss_seidel',
+                                 {'sweep': 'symmetric'}),
+                    postsmoother=('block_gauss_seidel',
+                                  {'sweep': 'symmetric'}),
+                    improve_candidates=[('block_gauss_seidel',
+                                        {'sweep': 'symmetric',
+                                         'iterations': 4}), None],
+                    max_levels = 20, max_coarse = 10,
+                    keep=False, **kwargs):
+    """
+    Create a multilevel solver using Pairwise Aggregation
+
+    Parameters
+    ----------
+    A : {csr_matrix, bsr_matrix}
+        Sparse NxN matrix in CSR or BSR format
+    B : {None, array_like}
+        Right near-nullspace candidates stored in the columns of an NxK array.
+        The default value B=None is equivalent to B=ones((N,1))
+    BH : {None, array_like}
+        Left near-nullspace candidates stored in the columns of an NxK array.
+        BH is only used if symmetry is 'nonsymmetric'.
+        The default value B=None is equivalent to BH=B.copy()
+    symmetry : {string}
+        'symmetric' refers to both real and complex symmetric
+        'hermitian' refers to both complex Hermitian and real Hermitian
+        'nonsymmetric' i.e. nonsymmetric in a hermitian sense
+        Note, in the strictly real case, symmetric and hermitian are the same
+        Note, this flag does not denote definiteness of the operator.
+    aggregate : {list} : default ['standard', 'lloyd', 'naive', 'pairwise',
+                ('predefined', {'AggOp' : csr_matrix})]
+        Method used to aggregate nodes.  See notes below for varying this
+        parameter on a per level basis.  Also, see notes below for using a
+        predefined aggregation on each level. Method-specific parameters may be
+        passed in using a tuple, e.g. aggregate=('pairwise',{'num_matchings': 2 })
+    presmoother : {tuple, string, list} : default ('block_gauss_seidel',
+                  {'sweep':'symmetric'})
+        Defines the presmoother for the multilevel cycling.  The default block
+        Gauss-Seidel option defaults to point-wise Gauss-Seidel, if the matrix
+        is CSR or is a BSR matrix with blocksize of 1.  See notes below for
+        varying this parameter on a per level basis.
+    postsmoother : {tuple, string, list}
+        Same as presmoother, except defines the postsmoother.
+    improve_candidates : {tuple, string, list} : default
+                        [('block_gauss_seidel',
+                         {'sweep': 'symmetric', 'iterations': 4}), None]
+        The ith entry defines the method used to improve the candidates B on
+        level i.  If the list is shorter than max_levels, then the last entry
+        will define the method for all levels lower.  If tuple or string, then
+        this single relaxation descriptor defines improve_candidates on all
+        levels.
+        The list elements are relaxation descriptors of the form used for
+        presmoother and postsmoother.  A value of None implies no action on B.
+    max_levels : {integer} : default 10
+        Maximum number of levels to be used in the multilevel solver.
+    max_coarse : {integer} : default 500
+        Maximum number of variables permitted on the coarse grid.
+    keep : {bool} : default False
+        Flag to indicate keeping extra operators in the hierarchy for
+        diagnostics.  For example, if True, then strength of connection (C),
+        tentative prolongation (T), and aggregation (AggOp) are kept.
+
+    Other Parameters
+    ----------------
+    cycle_type : ['V','W','F']
+        Structrure of multigrid cycle
+    coarse_solver : ['splu', 'lu', 'cholesky, 'pinv', 'gauss_seidel', ... ]
+        Solver used at the coarsest level of the MG hierarchy.
+            Optionally, may be a tuple (fn, args), where fn is a string such as
+        ['splu', 'lu', ...] or a callable function, and args is a dictionary of
+        arguments to be passed to fn.
+    setup_complexity : bool
+        For a detailed, more accurate setup complexity, pass in 
+        'setup_complexity' = True. This will slow down performance, but
+        increase accuracy of complexity count. 
+
+    Returns
+    -------
+    ml : multilevel_solver
+        Multigrid hierarchy of matrices and prolongation operators
+
+    See Also
+    --------
+    multilevel_solver, classical.ruge_stuben_solver,
+    aggregation.smoothed_aggregation_solver
+
+    Notes
+    -----
+
+
+
+    References
+    ----------
+
+
+
+    """
+    if not (isspmatrix_csr(A) or isspmatrix_bsr(A)):
+        try:
+            A = csr_matrix(A)
+            warn('Implicit conversion of A to CSR', SparseEfficiencyWarning)
+        except BaseException as e:
+            raise TypeError('Argument A must have type csr_matrix or bsr_matrix, '
+                            'or be convertible to csr_matrix') from e
+
+    A = A.asfptype()
+
+    if symmetry not in ('symmetric', 'hermitian', 'nonsymmetric'):
+        raise ValueError('Expected "symmetric", "nonsymmetric" or "hermitian" '
+                         'for the symmetry parameter ')
+    A.symmetry = symmetry
+
+    if A.shape[0] != A.shape[1]:
+        raise ValueError('expected square matrix')
+
+    # Right near nullspace candidates use constant for each variable as default
+    if B is None:
+        B = np.kron(np.ones((int(A.shape[0]/get_blocksize(A)), 1), dtype=A.dtype),
+                    np.eye(get_blocksize(A), dtype=A.dtype))
+    else:
+        B = np.asarray(B, dtype=A.dtype)
+        if len(B.shape) == 1:
+            B = B.reshape(-1, 1)
+        if B.shape[0] != A.shape[0]:
+            raise ValueError('The shape of near null-space modes B is incorrect')
+        if B.shape[1] < get_blocksize(A):
+            warn('Having less target vectors, B.shape[1], than blocksize of A '
+                 'can degrade convergence factors.')
+
+    # Left near nullspace candidates
+    if A.symmetry == 'nonsymmetric':
+        if BH is None:
+            BH = B.copy()
+        else:
+            BH = np.asarray(BH, dtype=A.dtype)
+            if len(BH.shape) == 1:
+                BH = BH.reshape(-1, 1)
+            if BH.shape[1] != B.shape[1]:
+                raise ValueError('The number of left and right near null-space '
+                                 'modes B and BH must be equal')
+            if BH.shape[0] != A.shape[0]:
+                raise ValueError('The shape of near null-space modes B is incorrect')
+
+    # Levelize the user parameters, so that they become lists describing the
+    # desired user option on each level.
+    max_levels, max_coarse, strength =\
+        levelize_strength_or_aggregation(strength, max_levels, max_coarse)
+    max_levels, max_coarse, aggregate =\
+        levelize_strength_or_aggregation(aggregate, max_levels, max_coarse)
+    improve_candidates =\
+        levelize_smooth_or_improve_candidates(improve_candidates, max_levels)
+    smooth = levelize_smooth_or_improve_candidates(smooth, max_levels)
+
+    # Construct multilevel structure
+    levels = []
+    levels.append(MultilevelSolver.Level())
+    levels[-1].A = A          # matrix
+
+    # Append near nullspace candidates
+    levels[-1].B = B          # right candidates
+    if A.symmetry == 'nonsymmetric':
+        levels[-1].BH = BH    # left candidates
+
+    while len(levels) < max_levels and\
+            int(levels[-1].A.shape[0]/get_blocksize(levels[-1].A)) > max_coarse:
+        _extend_hierarchy(levels, strength, aggregate,
+                          improve_candidates, keep)
+
+    ml = MultilevelSolver(levels, **kwargs)
+    change_smoothers(ml, presmoother, postsmoother)
+    return ml
+
+
+def _extend_hierarchy(levels, strength, aggregate, improve_candidates, keep):
+    """Extend the multigrid hierarchy.
+
+    Service routine to implement the strength of connection, aggregation,
+    tentative prolongation construction, and prolongation smoothing.  Called by
+    smoothed_aggregation_solver.
+
+    """
+    def unpack_arg(v):
+        if isinstance(v, tuple):
+            return v[0], v[1]
+        return v, {}
+
+    A = levels[-1].A
+    B = levels[-1].B
+    if A.symmetry == "nonsymmetric":
+        AH = A.H.asformat(A.format)
+        BH = levels[-1].BH
+
+    # Compute the strength-of-connection matrix C, where larger
+    # C[i,j] denote stronger couplings between i and j. Note, this
+    # is not used for aggregation, only as sparsity pattern for
+    # energy-min smoothing, or filtering Jacobi smoothing of T.
+    fn, kwargs = unpack_arg(strength[len(levels)-1])
+    if fn == 'symmetric':
+        C = symmetric_strength_of_connection(A, **kwargs)
+    elif fn == 'classical':
+        C = classical_strength_of_connection(A, **kwargs)
+    elif fn == 'distance':
+        C = distance_strength_of_connection(A, **kwargs)
+    elif (fn == 'ode') or (fn == 'evolution'):
+        if 'B' in kwargs:
+            C = evolution_strength_of_connection(A, **kwargs)
+        else:
+            C = evolution_strength_of_connection(A, B, **kwargs)
+    elif fn == 'energy_based':
+        C = energy_based_strength_of_connection(A, **kwargs)
+    elif fn == 'predefined':
+        C = kwargs['C'].tocsr()
+    elif fn == 'algebraic_distance':
+        C = algebraic_distance(A, **kwargs)
+    elif fn == 'affinity':
+        C = affinity_distance(A, **kwargs)
+    elif fn is None:
+        C = A.tocsr()
+    else:
+        raise ValueError('unrecognized strength of connection method: %s' %
+                         str(fn))
+
+    # Get choice of aggregation routine and arguments
+    fn, kwargs = unpack_arg(aggregate[len(levels)-1])
+
+    # Check for boolean "improve_candidates." If true, target vectors are
+    # improved each level of pairwise aggregation with chosen relaxation scheme. 
+    if ('improve_candidates' in kwargs) and \
+       (kwargs['improve_candidates'] == True):
+       kwargs['improve_candidates'] = improve_candidates[len(levels)-1]
+    else:
+       kwargs['improve_candidates'] = None
+
+    # Improve near nullspace candidates by relaxing on A B = 0
+    fn, kwargs = unpack_arg(improve_candidates[len(levels)-1])
+    if fn is not None:
+        b = np.zeros((A.shape[0], 1), dtype=A.dtype)
+        B = relaxation_as_linear_operator((fn, kwargs), A, b) * B
+        levels[-1].B = B
+        if A.symmetry == 'nonsymmetric':
+            BH = relaxation_as_linear_operator((fn, kwargs), AH, b) * BH
+            levels[-1].BH = BH
+
+
+    # Compute tentative interpolation operator T. Only fits one target
+    # per aggregate - if more are provided, they are fit in fit_candidates().
+    if fn == 'notay':
+        P = notay_pairwise(A, B=B, **kwargs)
+    elif fn == 'matching':
+        P = weighted_matching(A, B=B, **kwargs)
+    else:
+        raise ValueError('unrecognized aggregation method %s' % str(fn))
+
+    # TODO : Need option for B=None because this saves cost in computing
+    #        pairwise... 
+
+
+    ### GENERAL TODO :
+    ### - Generalize current Notay PR to support block matrix, candidate 
+    ### vectors, and multiple rounds of aggregation/matching.
+    
+
+
+
+    # Compute the restriction matrix, R, which interpolates from the fine-grid
+    # to the coarse-grid.  If A is nonsymmetric, then R must be constructed
+    # based on A.H.  Otherwise R = P.H or P.T.
+    symmetry = A.symmetry
+    if symmetry == 'hermitian':
+        R = P.H
+    elif symmetry == 'symmetric':
+        R = P.T
+    elif symmetry == 'nonsymmetric':
+        R = T.H
+
+    if keep:
+        levels[-1].C = C  # strength of connection matrix
+        levels[-1].AggOp = AggOp  # aggregation operator
+        levels[-1].T = T  # tentative prolongator
+
+    levels[-1].P = P  # smoothed prolongator
+    levels[-1].R = R  # restriction operator
+
+    levels.append(MultilevelSolver.Level())
+    A = R * A * P              # Galerkin operator
+    A.symmetry = symmetry
+    levels[-1].A = A
+    levels[-1].B = B           # right near nullspace candidates
+
+    if A.symmetry == 'nonsymmetric':
+        levels[-1].BH = BH     # left near nullspace candidates

--- a/pyamg/aggregation/pairwise.py
+++ b/pyamg/aggregation/pairwise.py
@@ -11,8 +11,6 @@ from pyamg.relaxation.smoothing import change_smoothers
 from pyamg.util.utils import get_blocksize, levelize_strength_or_aggregation
 from .aggregate import pairwise_aggregation
 
-__all__ = ['pairwise_solver']
-
 
 def pairwise_solver(A,
                     aggregate=('pairwise', {'theta': 0.25,
@@ -34,8 +32,7 @@ def pairwise_solver(A,
             {'theta': 0.25, 'norm':'min', 'matchings': 2})
         Method choice must be 'pairwise'; inner pairwise options including
         matchings, theta, and norm can be modified,
-    presmoother : {tuple, string, list} : default ('block_gauss_seidel',
-            {'sweep':'symmetric'})
+    presmoother : {tuple, string, list} : default ('block_gauss_seidel', {'sweep':'symmetric'})
         Defines the presmoother for the multilevel cycling.  The default block
         Gauss-Seidel option defaults to point-wise Gauss-Seidel, if the matrix
         is CSR or is a BSR matrix with blocksize of 1.  See notes below for

--- a/pyamg/aggregation/pairwise.py
+++ b/pyamg/aggregation/pairwise.py
@@ -14,7 +14,7 @@ from pyamg.strength import classical_strength_of_connection,\
     symmetric_strength_of_connection, evolution_strength_of_connection,\
     energy_based_strength_of_connection, distance_strength_of_connection,\
     algebraic_distance, affinity_distance
-from .aggregate import pairwise_aggregation, pairwise_aggregation2
+from .aggregate import pairwise_aggregation
 from .tentative import fit_candidates
 
 from ..relaxation.utils import relaxation_as_linear_operator
@@ -39,8 +39,12 @@ def pairwise_solver(A,
     ----------
     A : {csr_matrix, bsr_matrix}
         Sparse NxN matrix in CSR or BSR format
+    aggregate : {tuple, string, list} : default ('pairwise',
+            {'theta': 0.25, 'norm':'min', 'matchings': 2})
+        Type must be 'pairwise'; inner pairwise options including
+        matchings, theta, and norm can be modified,
     presmoother : {tuple, string, list} : default ('block_gauss_seidel',
-                  {'sweep':'symmetric'})
+            {'sweep':'symmetric'})
         Defines the presmoother for the multilevel cycling.  The default block
         Gauss-Seidel option defaults to point-wise Gauss-Seidel, if the matrix
         is CSR or is a BSR matrix with blocksize of 1.  See notes below for
@@ -62,13 +66,11 @@ def pairwise_solver(A,
     multilevel_solver, classical.ruge_stuben_solver,
     aggregation.smoothed_aggregation_solver
 
-    Notes
-    -----
-
-
     References
     ----------
-
+    [0] Notay, Y. (2010). An aggregation-based algebraic multigrid
+    method. Electronic transactions on numerical analysis, 37(6),
+    123-146.
 
     """
     if not (isspmatrix_csr(A) or isspmatrix_bsr(A)):
@@ -116,7 +118,7 @@ def _extend_hierarchy(levels, aggregate):
 
     # Compute pairwise interpolation and restriction matrices, R=P^*
     fn, kwargs = unpack_arg(aggregate[len(levels)-1])
-    P = pairwise_aggregation2(A, **kwargs, compute_P=True)[0]
+    P = pairwise_aggregation(A, **kwargs, compute_P=True)[0]
     R = P.H
 
     levels[-1].P = P  # smoothed prolongator

--- a/pyamg/aggregation/rootnode.py
+++ b/pyamg/aggregation/rootnode.py
@@ -18,7 +18,7 @@ from ..strength import classical_strength_of_connection,\
     energy_based_strength_of_connection, distance_strength_of_connection,\
     algebraic_distance, affinity_distance
 from .aggregate import standard_aggregation, naive_aggregation, \
-    lloyd_aggregation
+    lloyd_aggregation, pairwise_aggregation
 from .tentative import fit_candidates
 from .smooth import energy_prolongation_smoother
 
@@ -179,7 +179,7 @@ def rootnode_solver(A, B=None, BH=None,
            Examples are:
            smooth=[('jacobi', {'omega':1.0}), None, 'jacobi']
            presmoother=[('block_gauss_seidel', {'sweep':symmetric}), 'sor']
-           aggregate=['standard', 'naive']
+           aggregate=['standard', 'naive', 'lloyd', 'pairwise']
            strength=[('symmetric', {'theta':0.25}), ('symmetric', {'theta':0.08})]
 
          - Predefined strength of connection and aggregation schemes can be
@@ -368,6 +368,8 @@ def _extend_hierarchy(levels, strength, aggregate, smooth, improve_candidates,
         AggOp, Cnodes = naive_aggregation(C, **kwargs)
     elif fn == 'lloyd':
         AggOp, Cnodes = lloyd_aggregation(C, **kwargs)
+    elif fn == 'pairwise':
+        AggOp, Cnodes = pairwise_aggregation(C, **kwargs)
     elif fn == 'predefined':
         AggOp = kwargs['AggOp'].tocsr()
         Cnodes = kwargs['Cnodes']

--- a/pyamg/aggregation/rootnode.py
+++ b/pyamg/aggregation/rootnode.py
@@ -369,7 +369,7 @@ def _extend_hierarchy(levels, strength, aggregate, smooth, improve_candidates,
     elif fn == 'lloyd':
         AggOp, Cnodes = lloyd_aggregation(C, **kwargs)
     elif fn == 'pairwise':
-        AggOp, Cnodes = pairwise_aggregation(C, **kwargs)
+        AggOp, Cnodes = pairwise_aggregation(A, **kwargs)
     elif fn == 'predefined':
         AggOp = kwargs['AggOp'].tocsr()
         Cnodes = kwargs['Cnodes']

--- a/pyamg/aggregation/tests/test_aggregate.py
+++ b/pyamg/aggregation/tests/test_aggregate.py
@@ -4,7 +4,8 @@ from numpy.testing import TestCase, assert_equal
 from scipy import sparse
 
 from pyamg.gallery import poisson, load_example
-from pyamg.strength import symmetric_strength_of_connection
+from pyamg.strength import (symmetric_strength_of_connection,
+    classical_strength_of_connection)
 from pyamg.aggregation.aggregate import (standard_aggregation, naive_aggregation,
     pairwise_aggregation)
 
@@ -244,7 +245,7 @@ def reference_pairwise_aggregation(C):
         R = np.union1d(R, np.array([i]))
         aggregate_set = [i]
         aggregates[i] = aggregate_count
-        max_aij = 0
+        max_aij = -np.inf
         max_aij_index = -1
 
         for k, j in enumerate(row):

--- a/pyamg/aggregation/tests/test_aggregate.py
+++ b/pyamg/aggregation/tests/test_aggregate.py
@@ -79,7 +79,7 @@ class TestAggregate(TestCase):
             assert_equal(np.setdiff1d(Cpts, expected_Cpts).shape[0], 0)
 
         # S is diagonal - no dofs aggregated
-        S = sparse.spdiags([[1, 1, 1, 1]], [0], 4, 4, format='csr')
+        S = sparse.spdiags([[1.0, 1.0, 1.0, 1.0]], [0], 4, 4, format='csr', dtype='float')
         (result, Cpts) = pairwise_aggregation(S, matchings=1, theta=0.25, norm='min')
         expected = np.eye(4)
         assert_equal(result.todense(), expected)

--- a/pyamg/aggregation/tests/test_aggregate.py
+++ b/pyamg/aggregation/tests/test_aggregate.py
@@ -80,7 +80,7 @@ class TestAggregate(TestCase):
             assert_equal(np.setdiff1d(Cpts, expected_Cpts).shape[0], 0)
 
         # S is diagonal - no dofs aggregated
-        S = spdiags([[1, 1, 1, 1]], [0], 4, 4, format='csr')
+        S = sparse.spdiags([[1, 1, 1, 1]], [0], 4, 4, format='csr')
         (result, Cpts) = pairwise_aggregation(S, A)
         expected = np.eye(4)
         assert_equal(result.todense(), expected)

--- a/pyamg/aggregation/tests/test_aggregate.py
+++ b/pyamg/aggregation/tests/test_aggregate.py
@@ -81,7 +81,7 @@ class TestAggregate(TestCase):
 
         # S is diagonal - no dofs aggregated
         S = spdiags([[1, 1, 1, 1]], [0], 4, 4, format='csr')
-        (result, Cpts) = pairwise_aggregation(S)
+        (result, Cpts) = pairwise_aggregation(S, A)
         expected = np.eye(4)
         assert_equal(result.todense(), expected)
         assert_equal(Cpts.shape[0], 4)

--- a/pyamg/aggregation/tests/test_aggregate.py
+++ b/pyamg/aggregation/tests/test_aggregate.py
@@ -80,7 +80,7 @@ class TestAggregate(TestCase):
 
         # S is diagonal - no dofs aggregated
         S = sparse.spdiags([[1, 1, 1, 1]], [0], 4, 4, format='csr')
-        (result, Cpts) = pairwise_aggregation(A, matchings=1, theta=0.25, norm='min')
+        (result, Cpts) = pairwise_aggregation(S, matchings=1, theta=0.25, norm='min')
         expected = np.eye(4)
         assert_equal(result.todense(), expected)
         assert_equal(Cpts.shape[0], 4)

--- a/pyamg/aggregation/tests/test_aggregate.py
+++ b/pyamg/aggregation/tests/test_aggregate.py
@@ -283,4 +283,4 @@ def reference_pairwise_aggregation(C):
     Pp = np.arange(n+1)
     Px = np.ones(n)
 
-    return csr_matrix((Px, Pj, Pp)), np.array(Cpts)
+    return sparse.csr_matrix((Px, Pj, Pp)), np.array(Cpts)

--- a/pyamg/aggregation/tests/test_aggregate.py
+++ b/pyamg/aggregation/tests/test_aggregate.py
@@ -79,7 +79,7 @@ class TestAggregate(TestCase):
             assert_equal(np.setdiff1d(Cpts, expected_Cpts).shape[0], 0)
 
         # S is diagonal - no dofs aggregated
-        S = sparse.spdiags([[1.0, 1.0, 1.0, 1.0]], [0], 4, 4, format='csr', dtype='float')
+        S = sparse.spdiags([[1.0, 1.0, 1.0, 1.0]], [0], 4, 4, format='csr')
         (result, Cpts) = pairwise_aggregation(S, matchings=1, theta=0.25, norm='min')
         expected = np.eye(4)
         assert_equal(result.todense(), expected)

--- a/pyamg/aggregation/tests/test_aggregate.py
+++ b/pyamg/aggregation/tests/test_aggregate.py
@@ -69,7 +69,7 @@ class TestAggregate(TestCase):
 
     def test_pairwise_aggregation(self):
         for i, A in enumerate(self.cases):
-            S = symmetric_strength_of_connection(A)
+            S = classical_strength_of_connection(A, norm='min')
 
             (expected, expected_Cpts) = reference_pairwise_aggregation(S)
             (result, Cpts) = pairwise_aggregation(S)
@@ -244,16 +244,16 @@ def reference_pairwise_aggregation(C):
         R = np.union1d(R, np.array([i]))
         aggregate_set = [i]
         aggregates[i] = aggregate_count
-        min_aij = np.inf
-        min_aij_index = -1
+        max_aij = 0
+        max_aij_index = -1
 
         for k, j in enumerate(row):
-            if j not in R and data[i][k] < min_aij:
-                min_aij = data[i][k]
-                min_aij_index = j
+            if j not in R and data[i][k] >= max_aij:
+                max_aij = data[i][k]
+                max_aij_index = j
 
-        if min_aij_index != -1:
-            j = min_aij_index
+        if max_aij_index != -1:
+            j = max_aij_index
             aggregate_set.append(j)
             R = np.union1d(R, np.array([j]))
             aggregates[j] = aggregate_count

--- a/pyamg/aggregation/tests/test_aggregate.py
+++ b/pyamg/aggregation/tests/test_aggregate.py
@@ -5,12 +5,11 @@ from scipy import sparse
 
 from pyamg.gallery import poisson, load_example
 from pyamg.strength import (symmetric_strength_of_connection,
-    classical_strength_of_connection)
+                            classical_strength_of_connection)
 from pyamg.aggregation.aggregate import (standard_aggregation, naive_aggregation,
-    pairwise_aggregation)
+                                         pairwise_aggregation)
 
-from numpy.testing import TestCase, assert_equal
-from collections import OrderedDict, defaultdict
+from collections import OrderedDict
 
 
 class TestAggregate(TestCase):
@@ -69,7 +68,7 @@ class TestAggregate(TestCase):
         assert_equal(Cpts.shape[0], 4)
 
     def test_pairwise_aggregation(self):
-        for i, A in enumerate(self.cases):
+        for A in self.cases:
             S = classical_strength_of_connection(A, theta=0.25, norm='min')
             (expected, expected_Cpts) = reference_pairwise_aggregation(S)
             (result, Cpts) = pairwise_aggregation(A, matchings=1, theta=0.25, norm='min')
@@ -221,7 +220,7 @@ def reference_pairwise_aggregation(C):
     aggregate_count = 0               # aggregate_count is the aggregate counter
     Cpts = []
     m = np.zeros(n, dtype=C.indices.dtype)
-    for i, row in enumerate(S):
+    for row in S:
         m[row] = m[row] + 1
 
     max_m = max(m)
@@ -276,7 +275,7 @@ def reference_pairwise_aggregation(C):
         count += len(aggregate_set)
         aggregate_count += 1
 
-    assert(np.unique(R).shape[0] == n)
+    assert (np.unique(R).shape[0] == n)
 
     Pj = aggregates
     Pp = np.arange(n+1)

--- a/pyamg/aggregation/tests/test_aggregate.py
+++ b/pyamg/aggregation/tests/test_aggregate.py
@@ -73,7 +73,7 @@ class TestAggregate(TestCase):
             S = classical_strength_of_connection(A, norm='min')
 
             (expected, expected_Cpts) = reference_pairwise_aggregation(S)
-            (result, Cpts) = pairwise_aggregation(S)
+            (result, Cpts) = pairwise_aggregation(S, A)
 
             assert_equal((result - expected).nnz, 0)
             assert_equal(Cpts.shape[0], expected_Cpts.shape[0])

--- a/pyamg/aggregation/tests/test_aggregate.py
+++ b/pyamg/aggregation/tests/test_aggregate.py
@@ -284,5 +284,3 @@ def reference_pairwise_aggregation(C):
     Px = np.ones(n)
 
     return csr_matrix((Px, Pj, Pp)), np.array(Cpts)
-
->>>>>>> 71cfe81 (Add tests and fix bugs)

--- a/pyamg/aggregation/tests/test_aggregate.py
+++ b/pyamg/aggregation/tests/test_aggregate.py
@@ -5,7 +5,11 @@ from scipy import sparse
 
 from pyamg.gallery import poisson, load_example
 from pyamg.strength import symmetric_strength_of_connection
-from pyamg.aggregation.aggregate import standard_aggregation, naive_aggregation
+from pyamg.aggregation.aggregate import (standard_aggregation, naive_aggregation,
+    pairwise_aggregation)
+
+from numpy.testing import TestCase, assert_equal
+from collections import OrderedDict, defaultdict
 
 
 class TestAggregate(TestCase):
@@ -61,6 +65,26 @@ class TestAggregate(TestCase):
         (result, Cpts) = naive_aggregation(S)
         expected = np.eye(4)
         assert_equal(result.toarray(), expected)
+        assert_equal(Cpts.shape[0], 4)
+
+    def test_pairwise_aggregation(self):
+        for i, A in enumerate(self.cases):
+            print("case", i)
+            print(A)
+            S = A #symmetric_strength_of_connection(A)
+
+            (expected, expected_Cpts) = reference_pairwise_aggregation(S)
+            (result, Cpts) = pairwise_aggregation(S)
+
+            assert_equal((result - expected).nnz, 0)
+            assert_equal(Cpts.shape[0], expected_Cpts.shape[0])
+            assert_equal(np.setdiff1d(Cpts, expected_Cpts).shape[0], 0)
+
+        # S is diagonal - no dofs aggregated
+        S = spdiags([[1, 1, 1, 1]], [0], 4, 4, format='csr')
+        (result, Cpts) = pairwise_aggregation(S)
+        expected = np.eye(4)
+        assert_equal(result.todense(), expected)
         assert_equal(Cpts.shape[0], 4)
 
 
@@ -187,3 +211,82 @@ def reference_naive_aggregation(C):
     Px = np.ones(n)
 
     return sparse.csr_matrix((Px, Pj, Pp)), np.array(Cpts)
+
+
+def reference_pairwise_aggregation(C):
+    S = np.array_split(C.indices, C.indptr[1:-1])
+    data = np.array_split(C.data, C.indptr[1:-1])
+    n = C.shape[0]
+    aggregates = np.empty(n, dtype=C.indices.dtype)
+    aggregates[:] = -1     # aggregates[j] denotes the aggregate j is in
+    R = np.zeros((0,))     # R stores already aggregated nodes
+    aggregate_count = 0               # aggregate_count is the aggregate counter
+    Cpts = []
+    m = np.zeros(n, dtype=C.indices.dtype)
+    for i, row in enumerate(S):
+        m[row] = m[row] + 1
+
+    max_m = max(m)
+
+    # using a ordereddict here as there's no orderedset in python
+    mmap = [OrderedDict() for _ in range(0, max_m+1)]
+
+    for i in range(n):
+        mmap[m[i]][i] = True
+
+    count = 0
+    aggregate_count = 0
+    while (count < n):
+        #print(mmap)
+        for k in range(0, max_m+1):
+            if mmap[k]:
+                i = list(mmap[k].keys())[0]
+                break
+
+        row = S[i]
+        R = np.union1d(R, np.array([i]))
+        aggregate_set = [i]
+        aggregates[i] = aggregate_count
+        min_aij = np.inf
+        min_aij_index = -1
+
+        for k, j in enumerate(row):
+            if j not in R and data[i][k] < min_aij:
+                min_aij = data[i][k]
+                min_aij_index = j
+
+        #print("min_aij_index", i, min_aij_index, row, data[i])
+        if min_aij_index != -1:
+            j = min_aij_index
+            aggregate_set.append(j)
+            R = np.union1d(R, np.array([j]))
+            aggregates[j] = aggregate_count
+
+        Cpts.append(i)
+
+        # Remove the aggregated nodes from mmap
+        for j in aggregate_set:
+            del mmap[m[j]][j]
+
+        # Reduce m of the neighbors of the aggregated nodes
+        for j in aggregate_set:
+            row = S[j]
+            unaggregated_neighbors = np.setdiff1d(row, R)
+            for neighbour in unaggregated_neighbors:
+                del mmap[m[neighbour]][neighbour]
+                m[neighbour] = m[neighbour] - 1
+                mmap[m[neighbour]][neighbour] = True
+
+        count += len(aggregate_set)
+        aggregate_count += 1
+
+    assert(np.unique(R).shape[0] == n)
+
+    Pj = aggregates
+    Pp = np.arange(n+1)
+    Px = np.ones(n)
+    #print(Pj, Pp, Px, Cpts)
+
+    return csr_matrix((Px, Pj, Pp)), np.array(Cpts)
+
+>>>>>>> 71cfe81 (Add tests and fix bugs)

--- a/pyamg/aggregation/tests/test_aggregate.py
+++ b/pyamg/aggregation/tests/test_aggregate.py
@@ -70,10 +70,9 @@ class TestAggregate(TestCase):
 
     def test_pairwise_aggregation(self):
         for i, A in enumerate(self.cases):
-            S = classical_strength_of_connection(A, norm='min')
-
+            S = classical_strength_of_connection(A, theta=0.25, norm='min')
             (expected, expected_Cpts) = reference_pairwise_aggregation(S)
-            (result, Cpts) = pairwise_aggregation(S, A)
+            (result, Cpts) = pairwise_aggregation(A, matchings=1, theta=0.25, norm='min')
 
             assert_equal((result - expected).nnz, 0)
             assert_equal(Cpts.shape[0], expected_Cpts.shape[0])
@@ -81,7 +80,7 @@ class TestAggregate(TestCase):
 
         # S is diagonal - no dofs aggregated
         S = sparse.spdiags([[1, 1, 1, 1]], [0], 4, 4, format='csr')
-        (result, Cpts) = pairwise_aggregation(S, A)
+        (result, Cpts) = pairwise_aggregation(A, matchings=1, theta=0.25, norm='min')
         expected = np.eye(4)
         assert_equal(result.todense(), expected)
         assert_equal(Cpts.shape[0], 4)

--- a/pyamg/aggregation/tests/test_aggregate.py
+++ b/pyamg/aggregation/tests/test_aggregate.py
@@ -69,9 +69,7 @@ class TestAggregate(TestCase):
 
     def test_pairwise_aggregation(self):
         for i, A in enumerate(self.cases):
-            print("case", i)
-            print(A)
-            S = A #symmetric_strength_of_connection(A)
+            S = symmetric_strength_of_connection(A)
 
             (expected, expected_Cpts) = reference_pairwise_aggregation(S)
             (result, Cpts) = pairwise_aggregation(S)
@@ -237,7 +235,6 @@ def reference_pairwise_aggregation(C):
     count = 0
     aggregate_count = 0
     while (count < n):
-        #print(mmap)
         for k in range(0, max_m+1):
             if mmap[k]:
                 i = list(mmap[k].keys())[0]
@@ -255,7 +252,6 @@ def reference_pairwise_aggregation(C):
                 min_aij = data[i][k]
                 min_aij_index = j
 
-        #print("min_aij_index", i, min_aij_index, row, data[i])
         if min_aij_index != -1:
             j = min_aij_index
             aggregate_set.append(j)
@@ -285,7 +281,6 @@ def reference_pairwise_aggregation(C):
     Pj = aggregates
     Pp = np.arange(n+1)
     Px = np.ones(n)
-    #print(Pj, Pp, Px, Cpts)
 
     return csr_matrix((Px, Pj, Pp)), np.array(Cpts)
 

--- a/pyamg/aggregation/tests/test_pairwise.py
+++ b/pyamg/aggregation/tests/test_pairwise.py
@@ -1,0 +1,41 @@
+"""Test Pairwise AMG."""
+import numpy as np
+
+from numpy.testing import TestCase, assert_array_almost_equal
+from scipy.sparse import bsr_matrix, diags
+from pyamg.aggregation import pairwise_solver
+from pyamg.gallery import poisson, linear_elasticity, load_example
+
+
+class TestPairwise(TestCase):
+
+    def test_spd(self):
+        cases = []
+        import pdb; pdb.set_trace()
+        cases.append(poisson((500,), format='csr'))
+        cases.append(poisson((50, 50), format='csr'))
+        #cases.append(linear_elasticity((7, 7), format='bsr')[0])
+        cases.append(load_example('airfoil')['A'])
+        
+        for A in cases:
+            for agg, expected in [(('pairwise', {'theta': 0.25, 'matchings': 2}), 0.75),
+                                  (('pairwise', {'theta': 0.10, 'matchings': 2}), 0.75),
+                                  (('pairwise', {'theta': 0.25, 'matchings': 1}), 0.75),
+                                  (('pairwise', {'theta': 0.10, 'matchings': 1}), 0.75)]:
+ 
+                np.random.seed(0)  # make tests repeatable
+                x = np.random.rand(A.shape[0])
+                b = A*np.random.rand(A.shape[0])
+
+                ml = pairwise_solver(A, aggregate=agg, max_coarse=10)
+
+                res = []
+                x_sol = ml.solve(b, x0=x, maxiter=20, tol=1e-12,
+                                 residuals=res)
+                del x_sol
+
+                avg_convergence_ratio = (res[-1]/res[0])**(1.0/len(res))
+                assert (avg_convergence_ratio < expected)
+
+
+

--- a/pyamg/aggregation/tests/test_pairwise.py
+++ b/pyamg/aggregation/tests/test_pairwise.py
@@ -1,8 +1,7 @@
 """Test Pairwise AMG."""
 import numpy as np
 
-from numpy.testing import TestCase, assert_array_almost_equal
-from scipy.sparse import bsr_matrix, diags
+from numpy.testing import TestCase
 from pyamg.aggregation import pairwise_solver
 from pyamg.gallery import poisson, linear_elasticity, load_example
 
@@ -15,13 +14,13 @@ class TestPairwise(TestCase):
         cases.append(poisson((50, 50), format='csr'))
         cases.append(linear_elasticity((7, 7), format='bsr')[0])
         cases.append(load_example('airfoil')['A'].tocsr())
-        
+
         for A in cases:
             for agg, expected in [(('pairwise', {'theta': 0.25, 'matchings': 2}), 0.75),
                                   (('pairwise', {'theta': 0.10, 'matchings': 2}), 0.75),
                                   (('pairwise', {'theta': 0.25, 'matchings': 1}), 0.75),
                                   (('pairwise', {'theta': 0.10, 'matchings': 1}), 0.75)]:
- 
+
                 np.random.seed(0)  # make tests repeatable
                 x = np.random.rand(A.shape[0])
                 b = A*np.random.rand(A.shape[0])
@@ -35,6 +34,3 @@ class TestPairwise(TestCase):
 
                 avg_convergence_ratio = (res[-1]/res[0])**(1.0/len(res))
                 assert (avg_convergence_ratio < expected)
-
-
-

--- a/pyamg/aggregation/tests/test_pairwise.py
+++ b/pyamg/aggregation/tests/test_pairwise.py
@@ -11,7 +11,6 @@ class TestPairwise(TestCase):
 
     def test_spd(self):
         cases = []
-        import pdb; pdb.set_trace()
         cases.append(poisson((500,), format='csr'))
         cases.append(poisson((50, 50), format='csr'))
         #cases.append(linear_elasticity((7, 7), format='bsr')[0])

--- a/pyamg/aggregation/tests/test_pairwise.py
+++ b/pyamg/aggregation/tests/test_pairwise.py
@@ -13,7 +13,7 @@ class TestPairwise(TestCase):
         cases = []
         cases.append(poisson((500,), format='csr'))
         cases.append(poisson((50, 50), format='csr'))
-        #cases.append(linear_elasticity((7, 7), format='bsr')[0])
+        cases.append(linear_elasticity((7, 7), format='bsr')[0])
         cases.append(load_example('airfoil')['A'].tocsr())
         
         for A in cases:

--- a/pyamg/aggregation/tests/test_pairwise.py
+++ b/pyamg/aggregation/tests/test_pairwise.py
@@ -14,7 +14,7 @@ class TestPairwise(TestCase):
         cases.append(poisson((500,), format='csr'))
         cases.append(poisson((50, 50), format='csr'))
         #cases.append(linear_elasticity((7, 7), format='bsr')[0])
-        cases.append(load_example('airfoil')['A'])
+        cases.append(load_example('airfoil')['A'].tocsr())
         
         for A in cases:
             for agg, expected in [(('pairwise', {'theta': 0.25, 'matchings': 2}), 0.75),

--- a/pyamg/amg_core/__init__.py
+++ b/pyamg/amg_core/__init__.py
@@ -97,6 +97,7 @@ __all__ = [
     'symmetric_strength_of_connection',
     'standard_aggregation',
     'naive_aggregation',
+    'pairwise_aggregation',
     'fit_candidates',
     'satisfy_constraints_helper',
     'calc_BtB',

--- a/pyamg/amg_core/__init__.py
+++ b/pyamg/amg_core/__init__.py
@@ -30,7 +30,7 @@ from .ruge_stuben import (classical_strength_of_connection_abs,
                           rs_classical_interpolation_pass2,
                           remove_strong_FF_connections)
 from .smoothed_aggregation import (symmetric_strength_of_connection, standard_aggregation,
-                                   naive_aggregation,
+                                   naive_aggregation, pairwise_aggregation,
                                    fit_candidates,
                                    satisfy_constraints_helper, calc_BtB,
                                    incomplete_mat_mult_bsr, truncate_rows_csr)

--- a/pyamg/amg_core/instantiate.yml
+++ b/pyamg/amg_core/instantiate.yml
@@ -106,6 +106,12 @@ instantiate:
   functions:
     - csr_matvec
 
+- types:
+    - [int, float]
+    - [int, double]
+  functions:
+    - pairwise_aggregation
+
 remaps:
     - fit_candidates_real: fit_candidates
     - fit_candidates_complex: fit_candidates

--- a/pyamg/amg_core/instantiate.yml
+++ b/pyamg/amg_core/instantiate.yml
@@ -107,6 +107,8 @@ instantiate:
     - csr_matvec
 
 - types:
+    - [int, int]
+    - [int, long]
     - [int, float]
     - [int, double]
   functions:

--- a/pyamg/amg_core/smoothed_aggregation.h
+++ b/pyamg/amg_core/smoothed_aggregation.h
@@ -361,7 +361,7 @@ I pairwise_aggregation(const I n_row,
 
         I j = 0;
         bool found = false;
-        T min_val = std::numeric_limits<T>::max();
+        T max_val = 0;
 
         // x stores a list of the aggregate numbers
         x[i] = next_aggregate;
@@ -371,8 +371,8 @@ I pairwise_aggregation(const I n_row,
         // strength matrix only since a_ij less than a strongly connected j' implies
         // j is also strongly connected.
         for (I jj = row_start; jj < row_end; jj++) {
-            if (!x[Aj[jj]] && Ax[jj] < min_val) {
-                min_val = Ax[jj];
+            if (!x[Aj[jj]] && Ax[jj] >= max_val) {
+                max_val = Ax[jj];
                 j = Aj[jj];
                 found = true;
             }

--- a/pyamg/amg_core/smoothed_aggregation.h
+++ b/pyamg/amg_core/smoothed_aggregation.h
@@ -363,6 +363,9 @@ I pairwise_aggregation(const I n_row,
         bool found = false;
         T min_val = std::numeric_limits<T>::max();
 
+        // x stores a list of the aggregate numbers
+        x[i] = next_aggregate;
+
         // select minimum of a_ij. (algorithm looks for minimum j in original matrix,
         // and checks whether it is strongly connected. In the code we look in
         // strength matrix only since a_ij less than a strongly connected j' implies
@@ -374,10 +377,11 @@ I pairwise_aggregation(const I n_row,
                 found = true;
             }
         }
-        // x stores a list of the aggregate numbers
-        x[i] = next_aggregate;
+        if (found) {
+            x[j] = next_aggregate;
+        }
         // y stores a list of the Cpts
-        y[next_aggregate] = i;
+        y[next_aggregate-1] = i;
         for (I jj = row_start; jj < row_end; jj++) {
             if (x[Aj[jj]] == 0) {
                 // to change the key of a multimap, add a new entry and remove the old entry.

--- a/pyamg/amg_core/smoothed_aggregation.h
+++ b/pyamg/amg_core/smoothed_aggregation.h
@@ -309,6 +309,7 @@ I naive_aggregation(const I n_row,
  *   Aj[nnz]       - CSR column indices
  *   Ax[nnz]       - CSR data array
  *    x[n_row]     - aggregate numbers for each node
+ *    y[n_row]     - will hold Cpts upon return
  *
  * Returns:
  *  The number of aggregates (== max(x[:]) + 1 )
@@ -322,7 +323,8 @@ I pairwise_aggregation(const I n_row,
                        const I Ap[], const int Ap_size,
                        const I Aj[], const int Aj_size,
                        const T Ax[], const int Ax_size,
-                             I  x[], const int  x_size)
+                             I  x[], const int  x_size,
+                             I  y[], const int  y_size)
 {
     // x[n] == 0 means i-th node has not been aggregated
     std::fill(x, x + n_row, 0);
@@ -361,6 +363,8 @@ I pairwise_aggregation(const I n_row,
             }
         }
         x[i] = next_aggregate;
+        // y stores a list of the Cpts
+        y[next_aggregate] = i;
         for (I jj = row_start; jj < row_end; jj++) {
             m[Aj[jj]]--;
         }

--- a/pyamg/amg_core/smoothed_aggregation.h
+++ b/pyamg/amg_core/smoothed_aggregation.h
@@ -302,13 +302,13 @@ I naive_aggregation(const I n_row,
 
 
 /*
- * Compute aggregates for a matrix A stored in CSR format
+ * Compute aggregates for a matrix S stored in CSR format
  *
  * Parameters:
- *   n_row         - number of rows in A
- *   Ap[n_row + 1] - CSR row pointer
- *   Aj[nnz]       - CSR column indices
- *   Ax[nnz]       - CSR data array
+ *   n_row         - number of rows in S
+ *   Sp[n_row + 1] - CSR row pointer
+ *   Sj[nnz]       - CSR column indices
+ *   Sx[nnz]       - CSR data array
  *    x[n_row]     - aggregate numbers for each node
  *    y[n_row]     - will hold Cpts upon return
  *
@@ -316,14 +316,14 @@ I naive_aggregation(const I n_row,
  *  The number of aggregates (== max(x[:]) + 1 )
  *
  * Notes:
- * A is the strength matrix. Assume that the strength matrix is for
+ * S is the strength matrix. Assumes that the strength matrix is for
  * classic strength with min norm.
  */
 template <class I, class T>
 I pairwise_aggregation(const I n_row,
-                       const I Ap[], const int Ap_size,
-                       const I Aj[], const int Aj_size,
-                       const T Ax[], const int Ax_size,
+                       const I Sp[], const int Sp_size,
+                       const I Sj[], const int Sj_size,
+                       const T Sx[], const int Sx_size,
                              I  x[], const int  x_size,
                              I  y[], const int  y_size)
 {
@@ -332,11 +332,11 @@ I pairwise_aggregation(const I n_row,
 
     std::vector<I> m(n_row, 0);
     for(I i = 0; i < n_row; i++){
-        const I row_start = Ap[i];
-        const I row_end   = Ap[i+1];
+        const I row_start = Sp[i];
+        const I row_end   = Sp[i+1];
         for (I jj = row_start; jj < row_end; jj++) {
-            if (Aj[jj] != i) {
-                m[Aj[jj]]++;
+            if (Sj[jj] != i) {
+                m[Sj[jj]]++;
             }
         }
     }
@@ -356,8 +356,8 @@ I pairwise_aggregation(const I n_row,
         // Since mmap is a sorted container, first element is the minimum
         I i = mmap.begin()->second;
 
-        const I row_start = Ap[i];
-        const I row_end   = Ap[i+1];
+        const I row_start = Sp[i];
+        const I row_end   = Sp[i+1];
 
         I j = 0;
         bool found = false;
@@ -371,9 +371,9 @@ I pairwise_aggregation(const I n_row,
         // strength matrix only since a_ij less than a strongly connected j' implies
         // j is also strongly connected.
         for (I jj = row_start; jj < row_end; jj++) {
-            if (!x[Aj[jj]] && Ax[jj] >= max_val) {
-                max_val = Ax[jj];
-                j = Aj[jj];
+            if (!x[Sj[jj]] && Sx[jj] >= max_val) {
+                max_val = Sx[jj];
+                j = Sj[jj];
                 found = true;
             }
         }
@@ -383,27 +383,27 @@ I pairwise_aggregation(const I n_row,
         // y stores a list of the Cpts
         y[next_aggregate-1] = i;
         for (I jj = row_start; jj < row_end; jj++) {
-            if (x[Aj[jj]] == 0) {
+            if (x[Sj[jj]] == 0) {
                 // to change the key of a multimap, add a new entry and remove the old entry.
                 // finally update mmap_iterators with the iterator to the new entry
-                auto old_it = mmap_iterators[Aj[jj]];
-                auto new_it = mmap.insert({old_it->first-1, Aj[jj]});
+                auto old_it = mmap_iterators[Sj[jj]];
+                auto new_it = mmap.insert({old_it->first-1, Sj[jj]});
                 mmap.erase(old_it);
-                mmap_iterators[Aj[jj]] = new_it;
+                mmap_iterators[Sj[jj]] = new_it;
             }
         }
         // Remove node i from mmap
         mmap.erase(mmap_iterators[i]);
         if (found) {
             x[j] = next_aggregate;
-            const I row_start2 = Ap[j];
-            const I row_end2   = Ap[j+1];
+            const I row_start2 = Sp[j];
+            const I row_end2   = Sp[j+1];
             for (I jj = row_start2; jj < row_end2; jj++) {
-                if (x[Aj[jj]] == 0) {
-                    auto old_it = mmap_iterators[Aj[jj]];
-                    auto new_it = mmap.insert({old_it->first-1, Aj[jj]});
+                if (x[Sj[jj]] == 0) {
+                    auto old_it = mmap_iterators[Sj[jj]];
+                    auto new_it = mmap.insert({old_it->first-1, Sj[jj]});
                     mmap.erase(old_it);
-                    mmap_iterators[Aj[jj]] = new_it;
+                    mmap_iterators[Sj[jj]] = new_it;
                 }
             }
             // Remove node j from mmap

--- a/pyamg/amg_core/smoothed_aggregation.h
+++ b/pyamg/amg_core/smoothed_aggregation.h
@@ -304,18 +304,28 @@ I naive_aggregation(const I n_row,
 /*
  * Compute aggregates for a matrix S stored in CSR format
  *
- * Parameters:
- *   n_row         - number of rows in S
- *   Sp[n_row + 1] - CSR row pointer
- *   Sj[nnz]       - CSR column indices
- *   Sx[nnz]       - CSR data array
- *    x[n_row]     - aggregate numbers for each node
- *    y[n_row]     - will hold Cpts upon return
+ * Parameters
+ * ----------
+ * n_row : int
+ *     number of rows in S
+ * Sp : array, n_row+1
+ *     CSR row pointer
+ * Sj : array, nnz
+ *     CSR column indices
+ * Sx : array, nnz
+ *     CSR data array
+ * x : array, n_row, inplace
+ *     aggregate numbers for each node
+ * y : array, n_row, inplace
+ *     will hold Cpts upon return
  *
- * Returns:
+ * Returns
+ * -------
+ * int
  *  The number of aggregates (== max(x[:]) + 1 )
  *
- * Notes:
+ * Notes
+ * -----
  * S is the strength matrix. Assumes that the strength matrix is for
  * classic strength with min norm.
  */

--- a/pyamg/amg_core/smoothed_aggregation.h
+++ b/pyamg/amg_core/smoothed_aggregation.h
@@ -329,12 +329,14 @@ I pairwise_aggregation(const I n_row,
     // x[n] == 0 means i-th node has not been aggregated
     std::fill(x, x + n_row, 0);
 
-    std::vector<T> m(0, n_row);
+    std::vector<T> m(n_row, 0);
     for(I i = 0; i < n_row; i++){
         const I row_start = Ap[i];
         const I row_end   = Ap[i+1];
         for (I jj = row_start; jj < row_end; jj++) {
-            m[Aj[jj]]++;
+            if (Aj[jj] != i) {
+                m[Aj[jj]]++;
+            }
         }
     }
 

--- a/pyamg/amg_core/smoothed_aggregation.h
+++ b/pyamg/amg_core/smoothed_aggregation.h
@@ -361,7 +361,7 @@ I pairwise_aggregation(const I n_row,
 
         I j = 0;
         bool found = false;
-        T max_val = 0;
+        T max_val = std::numeric_limits<T>::lowest();
 
         // x stores a list of the aggregate numbers
         x[i] = next_aggregate;

--- a/pyamg/amg_core/smoothed_aggregation_bind.cpp
+++ b/pyamg/amg_core/smoothed_aggregation_bind.cpp
@@ -487,6 +487,10 @@ If it has been aggregated, skip over.  Otherwise, put dof
 and any unaggregated neighbors in an aggregate.  Results
 in possibly much higher complexities.)pbdoc");
 
+    m.def("pairwise_aggregation", &_pairwise_aggregation<int, int>,
+        py::arg("n_row"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("x").noconvert(), py::arg("y").noconvert());
+    m.def("pairwise_aggregation", &_pairwise_aggregation<int, long>,
+        py::arg("n_row"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("x").noconvert(), py::arg("y").noconvert());
     m.def("pairwise_aggregation", &_pairwise_aggregation<int, float>,
         py::arg("n_row"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("x").noconvert(), py::arg("y").noconvert());
     m.def("pairwise_aggregation", &_pairwise_aggregation<int, double>,

--- a/pyamg/amg_core/smoothed_aggregation_bind.cpp
+++ b/pyamg/amg_core/smoothed_aggregation_bind.cpp
@@ -105,24 +105,28 @@ I _pairwise_aggregation(
       py::array_t<I> & Ap,
       py::array_t<I> & Aj,
       py::array_t<T> & Ax,
-       py::array_t<I> & x
+       py::array_t<I> & x,
+       py::array_t<I> & y
                         )
 {
     auto py_Ap = Ap.unchecked();
     auto py_Aj = Aj.unchecked();
     auto py_Ax = Ax.unchecked();
     auto py_x = x.mutable_unchecked();
+    auto py_y = y.mutable_unchecked();
     const I *_Ap = py_Ap.data();
     const I *_Aj = py_Aj.data();
     const T *_Ax = py_Ax.data();
     I *_x = py_x.mutable_data();
+    I *_y = py_y.mutable_data();
 
     return pairwise_aggregation <I, T>(
                     n_row,
                       _Ap, Ap.shape(0),
                       _Aj, Aj.shape(0),
                       _Ax, Ax.shape(0),
-                       _x, x.shape(0)
+                       _x, x.shape(0),
+                       _y, y.shape(0)
                                        );
 }
 
@@ -484,9 +488,9 @@ and any unaggregated neighbors in an aggregate.  Results
 in possibly much higher complexities.)pbdoc");
 
     m.def("pairwise_aggregation", &_pairwise_aggregation<int, float>,
-        py::arg("n_row"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("x").noconvert());
+        py::arg("n_row"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("x").noconvert(), py::arg("y").noconvert());
     m.def("pairwise_aggregation", &_pairwise_aggregation<int, double>,
-        py::arg("n_row"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("x").noconvert(),
+        py::arg("n_row"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("x").noconvert(), py::arg("y").noconvert(),
 R"pbdoc(
 Compute aggregates for a matrix A stored in CSR format
 
@@ -496,6 +500,7 @@ Parameters:
   Aj[nnz]       - CSR column indices
   Ax[nnz]       - CSR data array
    x[n_row]     - aggregate numbers for each node
+   y[n_row]     - will hold Cpts upon return
 
 Returns:
  The number of aggregates (== max(x[:]) + 1 )

--- a/pyamg/amg_core/smoothed_aggregation_bind.cpp
+++ b/pyamg/amg_core/smoothed_aggregation_bind.cpp
@@ -102,29 +102,29 @@ I _naive_aggregation(
 template <class I, class T>
 I _pairwise_aggregation(
             const I n_row,
-      py::array_t<I> & Ap,
-      py::array_t<I> & Aj,
-      py::array_t<T> & Ax,
+      py::array_t<I> & Sp,
+      py::array_t<I> & Sj,
+      py::array_t<T> & Sx,
        py::array_t<I> & x,
        py::array_t<I> & y
                         )
 {
-    auto py_Ap = Ap.unchecked();
-    auto py_Aj = Aj.unchecked();
-    auto py_Ax = Ax.unchecked();
+    auto py_Sp = Sp.unchecked();
+    auto py_Sj = Sj.unchecked();
+    auto py_Sx = Sx.unchecked();
     auto py_x = x.mutable_unchecked();
     auto py_y = y.mutable_unchecked();
-    const I *_Ap = py_Ap.data();
-    const I *_Aj = py_Aj.data();
-    const T *_Ax = py_Ax.data();
+    const I *_Sp = py_Sp.data();
+    const I *_Sj = py_Sj.data();
+    const T *_Sx = py_Sx.data();
     I *_x = py_x.mutable_data();
     I *_y = py_y.mutable_data();
 
     return pairwise_aggregation <I, T>(
                     n_row,
-                      _Ap, Ap.shape(0),
-                      _Aj, Aj.shape(0),
-                      _Ax, Ax.shape(0),
+                      _Sp, Sp.shape(0),
+                      _Sj, Sj.shape(0),
+                      _Sx, Sx.shape(0),
                        _x, x.shape(0),
                        _y, y.shape(0)
                                        );
@@ -488,21 +488,21 @@ and any unaggregated neighbors in an aggregate.  Results
 in possibly much higher complexities.)pbdoc");
 
     m.def("pairwise_aggregation", &_pairwise_aggregation<int, int>,
-        py::arg("n_row"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("x").noconvert(), py::arg("y").noconvert());
+        py::arg("n_row"), py::arg("Sp").noconvert(), py::arg("Sj").noconvert(), py::arg("Sx").noconvert(), py::arg("x").noconvert(), py::arg("y").noconvert());
     m.def("pairwise_aggregation", &_pairwise_aggregation<int, long>,
-        py::arg("n_row"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("x").noconvert(), py::arg("y").noconvert());
+        py::arg("n_row"), py::arg("Sp").noconvert(), py::arg("Sj").noconvert(), py::arg("Sx").noconvert(), py::arg("x").noconvert(), py::arg("y").noconvert());
     m.def("pairwise_aggregation", &_pairwise_aggregation<int, float>,
-        py::arg("n_row"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("x").noconvert(), py::arg("y").noconvert());
+        py::arg("n_row"), py::arg("Sp").noconvert(), py::arg("Sj").noconvert(), py::arg("Sx").noconvert(), py::arg("x").noconvert(), py::arg("y").noconvert());
     m.def("pairwise_aggregation", &_pairwise_aggregation<int, double>,
-        py::arg("n_row"), py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("x").noconvert(), py::arg("y").noconvert(),
+        py::arg("n_row"), py::arg("Sp").noconvert(), py::arg("Sj").noconvert(), py::arg("Sx").noconvert(), py::arg("x").noconvert(), py::arg("y").noconvert(),
 R"pbdoc(
-Compute aggregates for a matrix A stored in CSR format
+Compute aggregates for a matrix S stored in CSR format
 
 Parameters:
-  n_row         - number of rows in A
-  Ap[n_row + 1] - CSR row pointer
-  Aj[nnz]       - CSR column indices
-  Ax[nnz]       - CSR data array
+  n_row         - number of rows in S
+  Sp[n_row + 1] - CSR row pointer
+  Sj[nnz]       - CSR column indices
+  Sx[nnz]       - CSR data array
    x[n_row]     - aggregate numbers for each node
    y[n_row]     - will hold Cpts upon return
 
@@ -510,7 +510,7 @@ Returns:
  The number of aggregates (== max(x[:]) + 1 )
 
 Notes:
-A is the strength matrix. Assume that the strength matrix is for
+S is the strength matrix. Assumes that the strength matrix is for
 classic strength with min norm.)pbdoc");
 
     m.def("fit_candidates", &_fit_candidates_real<int, float>,

--- a/setup.cfg
+++ b/setup.cfg
@@ -91,7 +91,7 @@ per-file-ignores =
 ignore-names =
   A, M, Dinv, G, S, B, T, V, E, C, R, W, F, AggOp    # matrix and set-like names
   U, Q, BtBinv, B_old, BH, scale_T, Cnodes
-  Cpt_params, get_Cpt_params
+  Cpt_params, get_Cpt_params, compute_P
   E2V
   compute_BtBinv, Atilde, Findex, Cindex
   Bf, P_I, I_F, rho_D_inv_A, rho_block_D_inv_A,

--- a/setup.cfg
+++ b/setup.cfg
@@ -79,23 +79,30 @@ exclude =
   pyamg/version.py
   pyamg/amg_core/bindthem.py
 ignore =
-  E741, # do not use variables named ‘l’, ‘O’, or ‘I’
-  E226, # missing whitespace around arithmetic operator
-  E241, # multiple spaces after ','
-  W503, # line break before binary operator
-  N806, # variable in function should be lowercase
+  # do not use variables named ‘l’, ‘O’, or ‘I’
+  E741,
+  # missing whitespace around arithmetic operator
+  E226,
+  # multiple spaces after ','
+  E241,
+  # line break before binary operator
+  W503,
+  # variable in function should be lowercase
+  N806,
 per-file-ignores =
   pyamg/gallery/tests/test_fem.py: E201, E202, E203
   test*.py: N802, N803, D101, D102, D103
   **/tests/__init__.py: D104
 ignore-names =
-  A, M, Dinv, G, S, B, T, V, E, C, R, W, F, AggOp    # matrix and set-like names
+  # matrix and set-like names
+  A, M, Dinv, G, S, B, T, V, E, C, R, W, F, AggOp
   U, Q, BtBinv, B_old, BH, scale_T, Cnodes
   Cpt_params, get_Cpt_params, compute_P
   E2V
   compute_BtBinv, Atilde, Findex, Cindex
   Bf, P_I, I_F, rho_D_inv_A, rho_block_D_inv_A,
-  CF, RS, PMIS, PMISc, CLJP, CLJPc, CR, MIS          # well-known methods with acronyms
+  # well-known methods with acronyms
+  CF, RS, PMIS, PMISc, CLJP, CLJPc, CR, MIS
   Cpts, Fpts
   _CRsweep
 


### PR DESCRIPTION
- [x] add `pairwise_aggregation`
- [x] add test for `pairwise_aggregation`
- [x] add pairwise as independent solver (separate from smoothed_aggregation_solver)
- [x] add support to pairwise aggregation or solver for BSR matrices
- [x] add support for multiple pairwise passes as coarsening, as used in most papers by Notay and D'Ambra