### PR TITLE
Remove duplicate COO conversion in divform

### DIFF
--- a/pyamg/gallery/fem.py
+++ b/pyamg/gallery/fem.py
@@ -844,14 +844,18 @@ def divform(mesh):
         DX[ei, :] = DXelem.ravel()
         DXI[ei, :] = np.repeat(K[np.arange(m2)], m1)
         DXJ[ei, :] = np.tile(K[np.arange(m1)], m2)
-        BX = sparse.coo_matrix((DX.ravel(), (DXI.ravel(), DXJ.ravel())))
-        BX.sum_duplicates()
 
         DY[ei, :] = DYelem.ravel()
         DYI[ei, :] = np.repeat(K[np.arange(m2)], m1)
         DYJ[ei, :] = np.tile(K[np.arange(m1)], m2)
-        BY = sparse.coo_matrix((DY.ravel(), (DYI.ravel(), DYJ.ravel())))
-        BY.sum_duplicates()
+
+    # Convert representation to COO
+    BX = sparse.coo_matrix((DX.ravel(), (DXI.ravel(), DXJ.ravel())))
+    BX.sum_duplicates()
+
+    BY = sparse.coo_matrix((DY.ravel(), (DYI.ravel(), DYJ.ravel())))
+    BY.sum_duplicates()
+
     return BX, BY
 
 


### PR DESCRIPTION
Speeds up the `divform()` computation by pulling `BX` and `BY` out of the loop and only computing their full form at the end (something similar is being done in `gradgradform`: https://github.com/nicknytko/pyamg/blob/b1e1dacdfe55b69c501805b928440c1074d94fac/pyamg/gallery/fem.py#L750)