### PR TITLE
Use np.result_type instead of deprecated np.find_common_type

### DIFF
--- a/pyamg/util/linalg.py
+++ b/pyamg/util/linalg.py
@@ -189,7 +189,7 @@ def _approximate_eigenvalues(A, maxiter, symmetric=None, initial_guess=None):
     # Important to type H based on v0, so that a real nonsymmetric matrix, can
     # have an imaginary initial guess for its Arnoldi Krylov space
     H = np.zeros((maxiter+1, maxiter),
-                 dtype=np.find_common_type([v0.dtype, A.dtype], []))
+                 dtype=np.result_type(v0.dtype, A.dtype)
 
     V = [v0]
 

--- a/pyamg/util/linalg.py
+++ b/pyamg/util/linalg.py
@@ -189,7 +189,7 @@ def _approximate_eigenvalues(A, maxiter, symmetric=None, initial_guess=None):
     # Important to type H based on v0, so that a real nonsymmetric matrix, can
     # have an imaginary initial guess for its Arnoldi Krylov space
     H = np.zeros((maxiter+1, maxiter),
-                 dtype=np.result_type(v0.dtype, A.dtype)
+                 dtype=np.result_type(v0.dtype, A.dtype))
 
     V = [v0]
 


### PR DESCRIPTION
We are seeing this warning show up in the scikit-learn CI with numpy 1.25.

The same change was done (by a Numpy developer) in scikit-learn in https://github.com/scikit-learn/scikit-learn/pull/24858, so it should be reasonably safe to merge.