### PR TITLE
update to 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, macos-latest]
 
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.12.1
         env:
-          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-*"
+          CIBW_BUILD: "cp37-* cp38-* cp39-* cp310-* cp311-* cp312"
           CIBW_SKIP: pp*
           CIBW_ARCHS_MACOS: "x86_64 arm64 universal2"
           CIBW_ARCHS_WINDOWS: "AMD64 x86"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-[![CI](https://github.com/pyamg/pyamg/workflows/CI/badge.svg)](https://github.com/pyamg/pyamg/actions?query=workflow%3Aci+branch%3Amain)
-[![PyPi](https://img.shields.io/pypi/pyversions/pyamg.svg?style=flat-square)](https://pypi.python.org/pypi/pyamg/)
-[![codecov](https://codecov.io/gh/pyamg/pyamg/branch/main/graph/badge.svg?token=JpRo1gdALC?style=flat-square)](https://codecov.io/gh/pyamg/pyamg)
-[![DOI](https://joss.theoj.org/papers/10.21105/joss.05495/status.svg?style=flat-square)](https://doi.org/10.21105/joss.05495)
+![ci](https://img.shields.io/github/actions/workflow/status/pyamg/pyamg/ci.yml?style=flat-square&label=tests)
+![lint](https://img.shields.io/github/actions/workflow/status/pyamg/pyamg/lint.yml?style=flat-square&label=lint)
+![PyPI - Version](https://img.shields.io/pypi/v/pyamg?style=flat-square)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pyamg?style=flat-square)
+![Codecov](https://img.shields.io/codecov/c/github/pyamg/pyamg?style=flat-square)
+[![joss](https://joss.theoj.org/papers/10.21105/joss.05495/status.svg?style=flat-square)](https://doi.org/10.21105/joss.05495)
 
 # Installation
 PyAMG requires `numpy` and `scipy`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CI](https://github.com/pyamg/pyamg/workflows/CI/badge.svg)](https://github.com/pyamg/pyamg/actions?query=workflow%3Aci+branch%3Amain)
 [![PyPi](https://img.shields.io/pypi/pyversions/pyamg.svg?style=flat-square)](https://pypi.python.org/pypi/pyamg/)
 [![codecov](https://codecov.io/gh/pyamg/pyamg/branch/main/graph/badge.svg?token=JpRo1gdALC)](https://codecov.io/gh/pyamg/pyamg)
-[![DOI](https://joss.theoj.org/papers/10.21105/joss.05495/status.svg)](https://doi.org/10.21105/joss.05495)
+[![DOI](https://joss.theoj.org/papers/10.21105/joss.05495/status.svg~style=flat-square)](https://doi.org/10.21105/joss.05495)
 
 # Installation
 PyAMG requires `numpy` and `scipy`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CI](https://github.com/pyamg/pyamg/workflows/CI/badge.svg)](https://github.com/pyamg/pyamg/actions?query=workflow%3ACI+branch%3Amain)
+[![CI](https://github.com/pyamg/pyamg/workflows/CI/badge.svg)](https://github.com/pyamg/pyamg/actions?query=workflow%3Aci+branch%3Amain)
 [![PyPi](https://img.shields.io/pypi/pyversions/pyamg.svg?style=flat-square)](https://pypi.python.org/pypi/pyamg/)
 [![codecov](https://codecov.io/gh/pyamg/pyamg/branch/main/graph/badge.svg?token=JpRo1gdALC)](https://codecov.io/gh/pyamg/pyamg)
 [![DOI](https://joss.theoj.org/papers/10.21105/joss.05495/status.svg)](https://doi.org/10.21105/joss.05495)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CI](https://github.com/pyamg/pyamg/workflows/CI/badge.svg)](https://github.com/pyamg/pyamg/actions?query=workflow%3Aci+branch%3Amain)
 [![PyPi](https://img.shields.io/pypi/pyversions/pyamg.svg?style=flat-square)](https://pypi.python.org/pypi/pyamg/)
-[![codecov](https://codecov.io/gh/pyamg/pyamg/branch/main/graph/badge.svg?token=JpRo1gdALC)](https://codecov.io/gh/pyamg/pyamg)
-[![DOI](https://joss.theoj.org/papers/10.21105/joss.05495/status.svg~style=flat-square)](https://doi.org/10.21105/joss.05495)
+[![codecov](https://codecov.io/gh/pyamg/pyamg/branch/main/graph/badge.svg?token=JpRo1gdALC?style=flat-square)](https://codecov.io/gh/pyamg/pyamg)
+[![DOI](https://joss.theoj.org/papers/10.21105/joss.05495/status.svg?style=flat-square)](https://doi.org/10.21105/joss.05495)
 
 # Installation
 PyAMG requires `numpy` and `scipy`

--- a/pyamg/aggregation/adaptive.py
+++ b/pyamg/aggregation/adaptive.py
@@ -2,22 +2,22 @@
 
 from warnings import warn
 import numpy as np
-from scipy.sparse import csr_matrix, bsr_matrix, isspmatrix_csr,\
+from scipy.sparse import csr_matrix, bsr_matrix, isspmatrix_csr, \
     isspmatrix_csc, isspmatrix_bsr, eye, SparseEfficiencyWarning
 
 from ..multilevel import MultilevelSolver
-from ..strength import symmetric_strength_of_connection,\
+from ..strength import symmetric_strength_of_connection, \
     classical_strength_of_connection, evolution_strength_of_connection
 from ..krylov import gmres
 from ..util.linalg import norm, approximate_spectral_radius
 from ..util.utils import amalgamate, levelize_strength_or_aggregation, \
     levelize_smooth_or_improve_candidates
 from ..relaxation.smoothing import change_smoothers, rho_D_inv_A
-from ..relaxation.relaxation import gauss_seidel, gauss_seidel_nr,\
+from ..relaxation.relaxation import gauss_seidel, gauss_seidel_nr, \
     gauss_seidel_ne, gauss_seidel_indexed, jacobi, polynomial
 from .aggregation import smoothed_aggregation_solver
 from .aggregate import standard_aggregation, lloyd_aggregation
-from .smooth import jacobi_prolongation_smoother,\
+from .smooth import jacobi_prolongation_smoother, \
     energy_prolongation_smoother, richardson_prolongation_smoother
 from .tentative import fit_candidates
 

--- a/pyamg/aggregation/aggregate.py
+++ b/pyamg/aggregation/aggregate.py
@@ -76,7 +76,7 @@ def standard_aggregation(C):
     # no nodes aggregated
     if num_aggregates == 0:
         # return all zero matrix and no Cpts
-        return sparse.csr_matrix((num_rows, 1), dtype='int8'),\
+        return sparse.csr_matrix((num_rows, 1), dtype='int8'), \
             np.array([], dtype=index_type)
 
     shape = (num_rows, num_aggregates)

--- a/pyamg/aggregation/aggregation.py
+++ b/pyamg/aggregation/aggregation.py
@@ -3,21 +3,21 @@
 
 from warnings import warn
 import numpy as np
-from scipy.sparse import csr_matrix, isspmatrix_csr, isspmatrix_bsr,\
+from scipy.sparse import csr_matrix, isspmatrix_csr, isspmatrix_bsr, \
     SparseEfficiencyWarning
 
 from pyamg.multilevel import MultilevelSolver
 from pyamg.relaxation.smoothing import change_smoothers
-from pyamg.util.utils import eliminate_diag_dom_nodes, get_blocksize,\
+from pyamg.util.utils import eliminate_diag_dom_nodes, get_blocksize, \
     levelize_strength_or_aggregation, levelize_smooth_or_improve_candidates
-from pyamg.strength import classical_strength_of_connection,\
-    symmetric_strength_of_connection, evolution_strength_of_connection,\
-    energy_based_strength_of_connection, distance_strength_of_connection,\
+from pyamg.strength import classical_strength_of_connection, \
+    symmetric_strength_of_connection, evolution_strength_of_connection, \
+    energy_based_strength_of_connection, distance_strength_of_connection, \
     algebraic_distance, affinity_distance
-from .aggregate import standard_aggregation, naive_aggregation,\
+from .aggregate import standard_aggregation, naive_aggregation, \
     lloyd_aggregation, pairwise_aggregation
 from .tentative import fit_candidates
-from .smooth import jacobi_prolongation_smoother,\
+from .smooth import jacobi_prolongation_smoother, \
     richardson_prolongation_smoother, energy_prolongation_smoother
 
 from ..relaxation.utils import relaxation_as_linear_operator

--- a/pyamg/aggregation/pairwise.py
+++ b/pyamg/aggregation/pairwise.py
@@ -3,7 +3,7 @@
 
 from warnings import warn
 import numpy as np
-from scipy.sparse import csr_matrix, isspmatrix_csr, isspmatrix_bsr,\
+from scipy.sparse import csr_matrix, isspmatrix_csr, isspmatrix_bsr, \
     SparseEfficiencyWarning
 
 from pyamg.multilevel import MultilevelSolver

--- a/pyamg/aggregation/rootnode.py
+++ b/pyamg/aggregation/rootnode.py
@@ -3,7 +3,7 @@
 
 from warnings import warn
 import numpy as np
-from scipy.sparse import csr_matrix, isspmatrix_csr, isspmatrix_bsr,\
+from scipy.sparse import csr_matrix, isspmatrix_csr, isspmatrix_bsr, \
     SparseEfficiencyWarning
 
 from ..multilevel import MultilevelSolver
@@ -13,9 +13,9 @@ from ..util.utils import scale_T, get_Cpt_params, \
     eliminate_diag_dom_nodes, get_blocksize, \
     levelize_strength_or_aggregation, \
     levelize_smooth_or_improve_candidates
-from ..strength import classical_strength_of_connection,\
-    symmetric_strength_of_connection, evolution_strength_of_connection,\
-    energy_based_strength_of_connection, distance_strength_of_connection,\
+from ..strength import classical_strength_of_connection, \
+    symmetric_strength_of_connection, evolution_strength_of_connection, \
+    energy_based_strength_of_connection, distance_strength_of_connection, \
     algebraic_distance, affinity_distance
 from .aggregate import standard_aggregation, naive_aggregation, \
     lloyd_aggregation, pairwise_aggregation

--- a/pyamg/aggregation/tests/test_aggregation.py
+++ b/pyamg/aggregation/tests/test_aggregation.py
@@ -1,14 +1,14 @@
 """Test smoothed aggregation solver."""
 import warnings
 import numpy as np
-from numpy.testing import TestCase, assert_approx_equal,\
+from numpy.testing import TestCase, assert_approx_equal, \
     assert_array_almost_equal
 from scipy import sparse
 import scipy.linalg as sla
 from scipy.sparse import SparseEfficiencyWarning
 
 from pyamg.util.utils import diag_sparse
-from pyamg.gallery import poisson, linear_elasticity,\
+from pyamg.gallery import poisson, linear_elasticity, \
     gauge_laplacian, load_example
 from pyamg.aggregation.aggregation import smoothed_aggregation_solver
 

--- a/pyamg/aggregation/tests/test_rootnode.py
+++ b/pyamg/aggregation/tests/test_rootnode.py
@@ -5,11 +5,11 @@ from scipy import sparse
 import scipy.linalg as sla
 from scipy.sparse import SparseEfficiencyWarning
 
-from numpy.testing import TestCase, assert_approx_equal,\
+from numpy.testing import TestCase, assert_approx_equal, \
     assert_array_almost_equal
 
 from pyamg.util.utils import diag_sparse
-from pyamg.gallery import poisson, linear_elasticity, gauge_laplacian,\
+from pyamg.gallery import poisson, linear_elasticity, gauge_laplacian, \
     load_example
 
 from pyamg.aggregation.rootnode import rootnode_solver

--- a/pyamg/aggregation/tests/test_smooth.py
+++ b/pyamg/aggregation/tests/test_smooth.py
@@ -1,11 +1,11 @@
 """Test prolongation smoothing."""
 import warnings
 import numpy as np
-from numpy.testing import TestCase, assert_array_almost_equal,\
+from numpy.testing import TestCase, assert_array_almost_equal, \
     assert_equal, assert_almost_equal
 from scipy import sparse
 
-from pyamg.gallery import poisson, linear_elasticity, load_example,\
+from pyamg.gallery import poisson, linear_elasticity, load_example, \
     gauge_laplacian
 from pyamg.aggregation import smoothed_aggregation_solver, rootnode_solver
 from pyamg.amg_core import incomplete_mat_mult_bsr

--- a/pyamg/classical/classical.py
+++ b/pyamg/classical/classical.py
@@ -7,9 +7,9 @@ import numpy as np
 
 from pyamg.multilevel import MultilevelSolver
 from pyamg.relaxation.smoothing import change_smoothers
-from pyamg.strength import classical_strength_of_connection,\
-    symmetric_strength_of_connection, evolution_strength_of_connection,\
-    distance_strength_of_connection, energy_based_strength_of_connection,\
+from pyamg.strength import classical_strength_of_connection, \
+    symmetric_strength_of_connection, evolution_strength_of_connection, \
+    distance_strength_of_connection, energy_based_strength_of_connection, \
     algebraic_distance, affinity_distance
 from pyamg.classical.interpolate import direct_interpolation, classical_interpolation
 from . import split

--- a/pyamg/krylov/tests/test_scipy.py
+++ b/pyamg/krylov/tests/test_scipy.py
@@ -50,7 +50,7 @@ class TestScipy(TestCase):
             callback = partial(cb, normb=normb)
 
             _ = sla.gmres(A, b, x0, callback=callback, callback_type='pr_norm',
-                          tol=tol, atol=0, restrt=3, maxiter=2)
+                          tol=tol, atol=0, restart=3, maxiter=2)
 
             assert_array_almost_equal(mgsres[1:], scipyres)
             assert_array_almost_equal(hhres[1:], scipyres)

--- a/pyamg/multilevel.py
+++ b/pyamg/multilevel.py
@@ -3,7 +3,6 @@
 from warnings import warn
 
 import scipy as sp
-from scipy.linalg import pinv
 import scipy.sparse.linalg as sla
 from scipy.sparse.linalg import LinearOperator
 import numpy as np
@@ -13,6 +12,14 @@ from .util.utils import to_type
 from .util.params import set_tol
 from .relaxation import smoothing
 from .util import upcast
+
+# hack to compare the version of scipy
+# int(''.join('1.7'.split('.')[:2])) = 17
+spversion = sp.__version__
+if int(''.join(spversion.split('.')[:2])) >= 17:
+    from scipy.linalg import pinv           # pylint: disable=ungrouped-imports
+else:
+    from scipy.linalg import pinv2 as pinv  # pylint: disable=no-name-in-module
 
 
 class MultilevelSolver:

--- a/pyamg/multilevel.py
+++ b/pyamg/multilevel.py
@@ -3,6 +3,7 @@
 from warnings import warn
 
 import scipy as sp
+from scipy.linalg import pinv
 import scipy.sparse.linalg as sla
 from scipy.sparse.linalg import LinearOperator
 import numpy as np
@@ -12,14 +13,6 @@ from .util.utils import to_type
 from .util.params import set_tol
 from .relaxation import smoothing
 from .util import upcast
-
-# hack to compare the version of scipy
-# int(''.join('1.7'.split('.')[:2])) = 17
-spversion = sp.__version__
-if int(''.join(spversion.split('.')[:2])) >= 17:
-    from scipy.linalg import pinv           # pylint: disable=ungrouped-imports
-else:
-    from scipy.linalg import pinv2 as pinv  # pylint: disable=no-name-in-module
 
 
 class MultilevelSolver:

--- a/pyamg/multilevel.py
+++ b/pyamg/multilevel.py
@@ -3,22 +3,16 @@
 from warnings import warn
 
 import scipy as sp
+from scipy.linalg import pinv
 import scipy.sparse.linalg as sla
 from scipy.sparse.linalg import LinearOperator
 import numpy as np
-
-from pkg_resources import parse_version  # included with setuptools
 
 from . import krylov
 from .util.utils import to_type
 from .util.params import set_tol
 from .relaxation import smoothing
 from .util import upcast
-
-if parse_version(sp.__version__) >= parse_version('1.7'):
-    from scipy.linalg import pinv           # pylint: disable=ungrouped-imports
-else:
-    from scipy.linalg import pinv2 as pinv  # pylint: disable=no-name-in-module
 
 
 class MultilevelSolver:

--- a/pyamg/relaxation/tests/test_relaxation.py
+++ b/pyamg/relaxation/tests/test_relaxation.py
@@ -10,10 +10,10 @@ from scipy.linalg import solve
 from pyamg.classical.split import RS
 from pyamg.classical import ruge_stuben_solver
 from pyamg.gallery import poisson, sprand, elasticity
-from pyamg.relaxation.relaxation import gauss_seidel, jacobi,\
-    block_jacobi, block_gauss_seidel, jacobi_ne, schwarz, sor,\
-    gauss_seidel_indexed, polynomial, gauss_seidel_ne,\
-    gauss_seidel_nr,\
+from pyamg.relaxation.relaxation import gauss_seidel, jacobi, \
+    block_jacobi, block_gauss_seidel, jacobi_ne, schwarz, sor, \
+    gauss_seidel_indexed, polynomial, gauss_seidel_ne, \
+    gauss_seidel_nr, \
     jacobi_indexed, cf_jacobi, fc_jacobi, cf_block_jacobi, fc_block_jacobi
 from pyamg.util.utils import get_block_diag
 

--- a/pyamg/tests/test_strength.py
+++ b/pyamg/tests/test_strength.py
@@ -1,14 +1,14 @@
 """Test strength of connection."""
 import numpy as np
-from numpy.testing import TestCase, assert_equal, assert_array_almost_equal,\
+from numpy.testing import TestCase, assert_equal, assert_array_almost_equal, \
     assert_array_equal, assert_allclose
 from scipy import sparse
 import scipy.linalg as sla
 
-from pyamg.gallery import poisson, linear_elasticity, load_example,\
+from pyamg.gallery import poisson, linear_elasticity, load_example, \
     stencil_grid
-from pyamg.strength import classical_strength_of_connection,\
-    symmetric_strength_of_connection, evolution_strength_of_connection,\
+from pyamg.strength import classical_strength_of_connection, \
+    symmetric_strength_of_connection, evolution_strength_of_connection, \
     distance_strength_of_connection
 from pyamg.amg_core import incomplete_mat_mult_csr
 from pyamg.util.linalg import approximate_spectral_radius

--- a/pyamg/util/linalg.py
+++ b/pyamg/util/linalg.py
@@ -526,11 +526,11 @@ def ishermitian(A, fast_check=True, tol=1e-6, verbose=False):
         A = np.asarray(A)
 
     if fast_check:
-        x = np.random.rand(A.shape[0], 1)
-        y = np.random.rand(A.shape[0], 1)
+        x = np.random.rand(A.shape[0])
+        y = np.random.rand(A.shape[0])
         if A.dtype == complex:
-            x = x + 1.0j*np.random.rand(A.shape[0], 1)
-            y = y + 1.0j*np.random.rand(A.shape[0], 1)
+            x = x + 1.0j*np.random.rand(A.shape[0])
+            y = y + 1.0j*np.random.rand(A.shape[0])
         xAy = np.dot((A.dot(x)).conjugate().T, y)
         xAty = np.dot(x.conjugate().T, A.dot(y))
         diff = float(np.abs(xAy - xAty) / np.sqrt(np.abs(xAy*xAty)))

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 numpy
-scipy
+scipy>=1.7.0
 pytest
 pep8-naming
 flake8-quotes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 numpy
-scipy
+scipy>=1.7.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ platforms = any
 python_requires = >=3.7
 install_requires =
     numpy>=1.7.0
-    scipy>=0.12.0
+    scipy>=1.7.0
 tests_require =
     pytest>=2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Education
     Topic :: Scientific/Engineering
     Topic :: Scientific/Engineering :: Mathematics


### PR DESCRIPTION
- [x] fix lint warning
- [x] fix deprecated use of `restrt`
- [x] drop <1.7 scipy support
- [x] add Python 3.12 to testing