### PR TITLE
change restrt to restart; deprecate restrt

### DIFF
--- a/pyamg/krylov/_fgmres.py
+++ b/pyamg/krylov/_fgmres.py
@@ -110,14 +110,14 @@ def fgmres(A, b, x0=None, tol=1e-5,
        http://www-users.cs.umn.edu/~saad/books.html
 
     """
-    if restrt is None:
-        restrt = restart
-    elif restart is not None:
-        raise ValueError('Only use restart, not restrt (deprecated).')
-    else:
-        msg = ('The keyword argument "restrt" is deprecated and will '
-               'be removed in 2024.   Use "restart" instead.')
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    if restrt is not None:
+        if restart is not None:
+            raise ValueError('Only use restart, not restrt (deprecated).')
+        else:
+            restart = restrt
+            msg = ('The keyword argument "restrt" is deprecated and will '
+                   'be removed in 2024.   Use "restart" instead.')
+            warnings.warn(msg, DeprecationWarning, stacklevel=1)
 
     # Convert inputs to linear system, with error checking
     A, M, x, b, postprocess = make_system(A, M, x0, b)

--- a/pyamg/krylov/_fgmres.py
+++ b/pyamg/krylov/_fgmres.py
@@ -113,11 +113,10 @@ def fgmres(A, b, x0=None, tol=1e-5,
     if restrt is not None:
         if restart is not None:
             raise ValueError('Only use restart, not restrt (deprecated).')
-        else:
-            restart = restrt
-            msg = ('The keyword argument "restrt" is deprecated and will '
-                   'be removed in 2024.   Use "restart" instead.')
-            warnings.warn(msg, DeprecationWarning, stacklevel=1)
+        restart = restrt
+        msg = ('The keyword argument "restrt" is deprecated and will '
+               'be removed in 2024.   Use "restart" instead.')
+        warnings.warn(msg, DeprecationWarning, stacklevel=1)
 
     # Convert inputs to linear system, with error checking
     A, M, x, b, postprocess = make_system(A, M, x0, b)

--- a/pyamg/krylov/_fgmres.py
+++ b/pyamg/krylov/_fgmres.py
@@ -19,8 +19,8 @@ def _mysign(x):
 
 
 def fgmres(A, b, x0=None, tol=1e-5,
-           restrt=None, maxiter=None,
-           M=None, callback=None, residuals=None):
+           restart=None, maxiter=None,
+           M=None, callback=None, residuals=None, restrt=None):
     """Flexible Generalized Minimum Residual Method (fGMRES).
 
     fGMRES iteratively refines the initial solution guess to the
@@ -39,16 +39,16 @@ def fgmres(A, b, x0=None, tol=1e-5,
         Tolerance for stopping criteria, let r=r_k
         ||r|| < tol ||b||
         if ||b||=0, then set ||b||=1 for these tests.
-    restrt : None, int
-        - if int, restrt is max number of inner iterations
+    restart : None, int
+        - if int, restart is max number of inner iterations
           and maxiter is the max number of outer iterations
         - if None, do not restart GMRES, and max number of inner iterations
           is maxiter
     maxiter : None, int
-        - if restrt is None, maxiter is the max number of inner iterations
+        - if restart is None, maxiter is the max number of inner iterations
           and GMRES does not restart
-        - if restrt is int, maxiter is the max number of outer iterations,
-          and restrt is the max number of inner iterations
+        - if restart is int, maxiter is the max number of outer iterations,
+          and restart is the max number of inner iterations
         - defaults to min(n,40) if restart=None
     M : array, matrix, sparse matrix, LinearOperator
         n x n, inverted preconditioner, i.e. solve M A x = M b.
@@ -61,6 +61,8 @@ def fgmres(A, b, x0=None, tol=1e-5,
     reorth : boolean
         If True, then a check is made whether to re-orthogonalize the Krylov
         space each GMRES iteration
+    restrt : None, int
+        Deprecated.  See restart.
 
     Returns
     -------
@@ -108,6 +110,15 @@ def fgmres(A, b, x0=None, tol=1e-5,
        http://www-users.cs.umn.edu/~saad/books.html
 
     """
+    if restrt is None:
+        restrt = restart
+    elif restart is not None:
+        raise ValueError('Only use restart, not restrt (deprecated).')
+    else:
+        msg = ('The keyword argument "restrt" is deprecated and will '
+               'be removed in 2024.   Use "restart" instead.')
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
     # Convert inputs to linear system, with error checking
     A, M, x, b, postprocess = make_system(A, M, x0, b)
     n = A.shape[0]
@@ -123,15 +134,15 @@ def fgmres(A, b, x0=None, tol=1e-5,
     #     then set max_inner=maxiter and max_outer=n
     # If restarts are set,
     #     then set max_inner=restart and max_outer=maxiter
-    if restrt:
+    if restart:
         if maxiter:
             max_outer = maxiter
         else:
             max_outer = 1
-        if restrt > n:
-            warn('Setting restrt to maximum allowed, n.')
-            restrt = n
-        max_inner = restrt
+        if restart > n:
+            warn('Setting restart to maximum allowed, n.')
+            restart = n
+        max_inner = restart
     else:
         max_outer = 1
         if maxiter is None:

--- a/pyamg/krylov/_gmres.py
+++ b/pyamg/krylov/_gmres.py
@@ -102,11 +102,10 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None,
     if restrt is not None:
         if restart is not None:
             raise ValueError('Only use restart, not restrt (deprecated).')
-        else:
-            restart = restrt
-            msg = ('The keyword argument "restrt" is deprecated and will '
-                   'be removed in 2024.   Use "restart" instead.')
-            warnings.warn(msg, DeprecationWarning, stacklevel=1)
+        restart = restrt
+        msg = ('The keyword argument "restrt" is deprecated and will '
+               'be removed in 2024.   Use "restart" instead.')
+        warnings.warn(msg, DeprecationWarning, stacklevel=1)
 
     # pass along **kwargs
     if orthog == 'householder':

--- a/pyamg/krylov/_gmres.py
+++ b/pyamg/krylov/_gmres.py
@@ -99,14 +99,14 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None,
        http://www-users.cs.umn.edu/~saad/books.html
 
     """
-    if restrt is None:
-        restrt = restart
-    elif restart is not None:
-        raise ValueError('Only use restart, not restrt (deprecated).')
-    else:
-        msg = ('The keyword argument "restrt" is deprecated and will '
-               'be removed in 2024.   Use "restart" instead.')
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    if restrt is not None:
+        if restart is not None:
+            raise ValueError('Only use restart, not restrt (deprecated).')
+        else:
+            restart = restrt
+            msg = ('The keyword argument "restrt" is deprecated and will '
+                   'be removed in 2024.   Use "restart" instead.')
+            warnings.warn(msg, DeprecationWarning, stacklevel=1)
 
     # pass along **kwargs
     if orthog == 'householder':

--- a/pyamg/krylov/_gmres_householder.py
+++ b/pyamg/krylov/_gmres_householder.py
@@ -19,8 +19,8 @@ def _mysign(x):
 
 
 def gmres_householder(A, b, x0=None, tol=1e-5,
-                      restrt=None, maxiter=None,
-                      M=None, callback=None, residuals=None):
+                      restart=None, maxiter=None,
+                      M=None, callback=None, residuals=None, restrt=None):
     """Generalized Minimum Residual Method (GMRES) based on Housholder.
 
     GMRES iteratively refines the initial solution guess to the
@@ -39,16 +39,16 @@ def gmres_householder(A, b, x0=None, tol=1e-5,
         Tolerance for stopping criteria, let r=r_k
         ||M r|| < tol ||M b||
         if ||b||=0, then set ||M b||=1 for these tests.
-    restrt : None, int
-        - if int, restrt is max number of inner iterations
+    restart : None, int
+        - if int, restart is max number of inner iterations
           and maxiter is the max number of outer iterations
         - if None, do not restart GMRES, and max number of inner iterations
           is maxiter
     maxiter : None, int
-        - if restrt is None, maxiter is the max number of inner iterations
+        - if restart is None, maxiter is the max number of inner iterations
           and GMRES does not restart
-        - if restrt is int, maxiter is the max number of outer iterations,
-          and restrt is the max number of inner iterations
+        - if restart is int, maxiter is the max number of outer iterations,
+          and restart is the max number of inner iterations
         - defaults to min(n,40) if restart=None
     M : array, matrix, sparse matrix, LinearOperator
         n x n, inverted preconditioner, i.e. solve M A x = M b.
@@ -61,6 +61,8 @@ def gmres_householder(A, b, x0=None, tol=1e-5,
     reorth : boolean
         If True, then a check is made whether to re-orthogonalize the Krylov
         space each GMRES iteration
+    restrt : None, int
+        Deprecated.  See restart.
 
     Returns
     -------
@@ -106,6 +108,15 @@ def gmres_householder(A, b, x0=None, tol=1e-5,
        http://www-users.cs.umn.edu/~saad/books.html
 
     """
+    if restrt is None:
+        restrt = restart
+    elif restart is not None:
+        raise ValueError('Only use restart, not restrt (deprecated).')
+    else:
+        msg = ('The keyword argument "restrt" is deprecated and will '
+               'be removed in 2024.   Use "restart" instead.')
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
     # Convert inputs to linear system, with error checking
     A, M, x, b, postprocess = make_system(A, M, x0, b)
     n = A.shape[0]
@@ -121,15 +132,15 @@ def gmres_householder(A, b, x0=None, tol=1e-5,
     #     then set max_inner=maxiter and max_outer=n
     # If restarts are set,
     #     then set max_inner=restart and max_outer=maxiter
-    if restrt:
+    if restart:
         if maxiter:
             max_outer = maxiter
         else:
             max_outer = 1
-        if restrt > n:
-            warn('Setting restrt to maximum allowed, n.')
-            restrt = n
-        max_inner = restrt
+        if restart > n:
+            warn('Setting restart to maximum allowed, n.')
+            restart = n
+        max_inner = restart
     else:
         max_outer = 1
         if maxiter is None:

--- a/pyamg/krylov/_gmres_householder.py
+++ b/pyamg/krylov/_gmres_householder.py
@@ -111,11 +111,10 @@ def gmres_householder(A, b, x0=None, tol=1e-5,
     if restrt is not None:
         if restart is not None:
             raise ValueError('Only use restart, not restrt (deprecated).')
-        else:
-            restart = restrt
-            msg = ('The keyword argument "restrt" is deprecated and will '
-                   'be removed in 2024.   Use "restart" instead.')
-            warnings.warn(msg, DeprecationWarning, stacklevel=1)
+        restart = restrt
+        msg = ('The keyword argument "restrt" is deprecated and will '
+               'be removed in 2024.   Use "restart" instead.')
+        warnings.warn(msg, DeprecationWarning, stacklevel=1)
 
     # Convert inputs to linear system, with error checking
     A, M, x, b, postprocess = make_system(A, M, x0, b)

--- a/pyamg/krylov/_gmres_householder.py
+++ b/pyamg/krylov/_gmres_householder.py
@@ -108,14 +108,14 @@ def gmres_householder(A, b, x0=None, tol=1e-5,
        http://www-users.cs.umn.edu/~saad/books.html
 
     """
-    if restrt is None:
-        restrt = restart
-    elif restart is not None:
-        raise ValueError('Only use restart, not restrt (deprecated).')
-    else:
-        msg = ('The keyword argument "restrt" is deprecated and will '
-               'be removed in 2024.   Use "restart" instead.')
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    if restrt is not None:
+        if restart is not None:
+            raise ValueError('Only use restart, not restrt (deprecated).')
+        else:
+            restart = restrt
+            msg = ('The keyword argument "restrt" is deprecated and will '
+                   'be removed in 2024.   Use "restart" instead.')
+            warnings.warn(msg, DeprecationWarning, stacklevel=1)
 
     # Convert inputs to linear system, with error checking
     A, M, x, b, postprocess = make_system(A, M, x0, b)

--- a/pyamg/krylov/_gmres_mgs.py
+++ b/pyamg/krylov/_gmres_mgs.py
@@ -133,11 +133,10 @@ def gmres_mgs(A, b, x0=None, tol=1e-5,
     if restrt is not None:
         if restart is not None:
             raise ValueError('Only use restart, not restrt (deprecated).')
-        else:
-            restart = restrt
-            msg = ('The keyword argument "restrt" is deprecated and will '
-                   'be removed in 2024.   Use "restart" instead.')
-            warnings.warn(msg, DeprecationWarning, stacklevel=1)
+        restart = restrt
+        msg = ('The keyword argument "restrt" is deprecated and will '
+               'be removed in 2024.   Use "restart" instead.')
+        warnings.warn(msg, DeprecationWarning, stacklevel=1)
 
     # Convert inputs to linear system, with error checking
     A, M, x, b, postprocess = make_system(A, M, x0, b)

--- a/pyamg/krylov/_gmres_mgs.py
+++ b/pyamg/krylov/_gmres_mgs.py
@@ -130,14 +130,14 @@ def gmres_mgs(A, b, x0=None, tol=1e-5,
     .. [2] C. T. Kelley, http://www4.ncsu.edu/~ctk/matlab_roots.html
 
     """
-    if restrt is None:
-        restrt = restart
-    elif restart is not None:
-        raise ValueError('Only use restart, not restrt (deprecated).')
-    else:
-        msg = ('The keyword argument "restrt" is deprecated and will '
-               'be removed in 2024.   Use "restart" instead.')
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+    if restrt is not None:
+        if restart is not None:
+            raise ValueError('Only use restart, not restrt (deprecated).')
+        else:
+            restart = restrt
+            msg = ('The keyword argument "restrt" is deprecated and will '
+                   'be removed in 2024.   Use "restart" instead.')
+            warnings.warn(msg, DeprecationWarning, stacklevel=1)
 
     # Convert inputs to linear system, with error checking
     A, M, x, b, postprocess = make_system(A, M, x0, b)

--- a/pyamg/krylov/tests/test_krylov.py
+++ b/pyamg/krylov/tests/test_krylov.py
@@ -165,7 +165,7 @@ class TestKrylov(TestCase):
                     residuals2 = []
                     (x2, flag2) = gmres_mgs(A_symm, b_symm, x0=x0_symm,
                                             maxiter=maxiter,
-                                            restrt=None,
+                                            restart=None,
                                             residuals=residuals2)
                     residuals3 = []
                     (x3, flag2) = cr(A_symm, b_symm, x0=x0_symm,

--- a/pyamg/krylov/tests/test_scipy.py
+++ b/pyamg/krylov/tests/test_scipy.py
@@ -39,11 +39,11 @@ class TestScipy(TestCase):
 
             mgsres = []
             _ = gmres_mgs(A, b, x0, residuals=mgsres,
-                          tol=tol, restrt=3, maxiter=2)
+                          tol=tol, restart=3, maxiter=2)
 
             hhres = []
             _ = gmres_householder(A, b, x0, residuals=hhres,
-                                  tol=tol, restrt=3, maxiter=2)
+                                  tol=tol, restart=3, maxiter=2)
 
             scipyres = []
             normb = np.linalg.norm(b)

--- a/pyamg/relaxation/smoothing.py
+++ b/pyamg/relaxation/smoothing.py
@@ -789,11 +789,11 @@ def setup_fc_block_jacobi(lvl, f_iterations=DEFAULT_NITER, c_iterations=DEFAULT_
     return smoother
 
 
-def setup_gmres(lvl, tol=1e-12, maxiter=DEFAULT_NITER, restrt=None, M=None, callback=None,
+def setup_gmres(lvl, tol=1e-12, maxiter=DEFAULT_NITER, restart=None, M=None, callback=None,
                 residuals=None):
     """Set up GMRES smoothing."""
     def smoother(A, x, b):
-        x[:] = gmres(A, b, x0=x, tol=tol, maxiter=maxiter, restrt=restrt, M=M,
+        x[:] = gmres(A, b, x0=x, tol=tol, maxiter=maxiter, restart=restart, M=M,
                      callback=callback, residuals=residuals)[0].reshape(x.shape)
     update_wrapper(smoother, gmres)  # set __name__
     return smoother


### PR DESCRIPTION
`restrt` is deprecated in SciPy 1.10.0: https://docs.scipy.org/doc/scipy/release/1.10.0-notes.html

This follows the approach in https://github.com/scipy/scipy/pull/16392

Fixes #395 