### PR TITLE
add np 2.0 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         os: [ubuntu-latest, macos-latest]
 
     steps:

--- a/pyamg/aggregation/adaptive.py
+++ b/pyamg/aggregation/adaptive.py
@@ -504,7 +504,7 @@ def initial_setup_stage(A, symmetry, pdef, candidate_iters, epsilon,
         if symmetry == 'symmetric':
             A_l = P_l.T.asformat(P_l.format) * A_l * P_l
         elif symmetry == 'hermitian':
-            A_l = P_l.H.asformat(P_l.format) * A_l * P_l
+            A_l = P_l.T.conjugate().asformat(P_l.format) * A_l * P_l
         else:
             raise ValueError(f'aSA not implemented for symmetry={symmetry}.')
 
@@ -666,7 +666,7 @@ def general_setup_stage(ml, symmetry, candidate_iters, prepostsmoother,
         if symmetry == 'symmetric':  # R should reflect A's structure
             levels[i].R = levels[i].P.T.asformat(levels[i].P.format)
         elif symmetry == 'hermitian':
-            levels[i].R = levels[i].P.H.asformat(levels[i].P.format)
+            levels[i].R = levels[i].P.T.conjugate().asformat(levels[i].P.format)
 
         # construct coarse A
         levels[i+1].A = levels[i].R * levels[i].A * levels[i].P
@@ -701,7 +701,7 @@ def general_setup_stage(ml, symmetry, candidate_iters, prepostsmoother,
         if symmetry == 'symmetric':  # R should reflect A's structure
             levels[i+1].R = levels[i+1].P.T.asformat(levels[i+1].P.format)
         elif symmetry == 'hermitian':
-            levels[i+1].R = levels[i+1].P.H.asformat(levels[i+1].P.format)
+            levels[i+1].R = levels[i+1].P.T.conjugate().asformat(levels[i+1].P.format)
 
         # run solver on candidate
         solver = MultilevelSolver(levels[i+1:], coarse_solver=coarse_solver)

--- a/pyamg/aggregation/aggregation.py
+++ b/pyamg/aggregation/aggregation.py
@@ -302,7 +302,7 @@ def _extend_hierarchy(levels, strength, aggregate, smooth, improve_candidates,
     A = levels[-1].A
     B = levels[-1].B
     if A.symmetry == 'nonsymmetric':
-        AH = A.H.asformat(A.format)
+        AH = A.T.conjugate().asformat(A.format)
         BH = levels[-1].BH
 
     # Compute the strength-of-connection matrix C, where larger
@@ -391,21 +391,21 @@ def _extend_hierarchy(levels, strength, aggregate, smooth, improve_candidates,
     # based on A.H.  Otherwise R = P.H or P.T.
     symmetry = A.symmetry
     if symmetry == 'hermitian':
-        R = P.H
+        R = P.T.conjugate()
     elif symmetry == 'symmetric':
         R = P.T
     elif symmetry == 'nonsymmetric':
         fn, kwargs = unpack_arg(smooth[len(levels)-1])
         if fn == 'jacobi':
-            R = jacobi_prolongation_smoother(AH, TH, C, BH, **kwargs).H
+            R = jacobi_prolongation_smoother(AH, TH, C, BH, **kwargs).T.conjugate()
         elif fn == 'richardson':
-            R = richardson_prolongation_smoother(AH, TH, **kwargs).H
+            R = richardson_prolongation_smoother(AH, TH, **kwargs).T.conjugate()
         elif fn == 'energy':
             R = energy_prolongation_smoother(AH, TH, C, BH, None, (False, {}),
                                              **kwargs)
-            R = R.H
+            R = R.T.conjugate()
         elif fn is None:
-            R = T.H
+            R = T.T.conjugate()
         else:
             raise ValueError(f'Unrecognized prolongation smoother method {str(fn)}')
 

--- a/pyamg/aggregation/aggregation.py
+++ b/pyamg/aggregation/aggregation.py
@@ -301,6 +301,9 @@ def _extend_hierarchy(levels, strength, aggregate, smooth, improve_candidates,
 
     A = levels[-1].A
     B = levels[-1].B
+    AH = None
+    BH = None
+    TH = None
     if A.symmetry == 'nonsymmetric':
         AH = A.T.conjugate().asformat(A.format)
         BH = levels[-1].BH
@@ -408,6 +411,8 @@ def _extend_hierarchy(levels, strength, aggregate, smooth, improve_candidates,
             R = T.T.conjugate()
         else:
             raise ValueError(f'Unrecognized prolongation smoother method {str(fn)}')
+    else:
+        raise ValueError(f'Unrecognized symmetry.')
 
     if keep:
         levels[-1].C = C  # strength of connection matrix

--- a/pyamg/aggregation/aggregation.py
+++ b/pyamg/aggregation/aggregation.py
@@ -412,7 +412,7 @@ def _extend_hierarchy(levels, strength, aggregate, smooth, improve_candidates,
         else:
             raise ValueError(f'Unrecognized prolongation smoother method {str(fn)}')
     else:
-        raise ValueError(f'Unrecognized symmetry.')
+        raise ValueError('Unrecognized symmetry.')
 
     if keep:
         levels[-1].C = C  # strength of connection matrix

--- a/pyamg/aggregation/pairwise.py
+++ b/pyamg/aggregation/pairwise.py
@@ -129,7 +129,7 @@ def _extend_hierarchy(levels, aggregate):
     # Compute pairwise interpolation and restriction matrices, R=P^*
     _, kwargs = unpack_arg(aggregate[len(levels)-1])
     P = pairwise_aggregation(A, **kwargs, compute_P=True)[0]
-    R = P.H
+    R = P.T.conjugate()
     if isspmatrix_csr(P):
         # In this case, R will be CSC, which must be changed
         R = R.tocsr()

--- a/pyamg/aggregation/rootnode.py
+++ b/pyamg/aggregation/rootnode.py
@@ -323,7 +323,7 @@ def _extend_hierarchy(levels, strength, aggregate, smooth, improve_candidates,
     A = levels[-1].A
     B = levels[-1].B
     if A.symmetry == 'nonsymmetric':
-        AH = A.H.asformat(A.format)
+        AH = A.T.conjugate().asformat(A.format)
         BH = levels[-1].BH
 
     # Compute the strength-of-connection matrix C, where larger
@@ -423,7 +423,7 @@ def _extend_hierarchy(levels, strength, aggregate, smooth, improve_candidates,
     # based on A.H.  Otherwise R = P.H or P.T.
     symmetry = A.symmetry
     if symmetry == 'hermitian':
-        R = P.H
+        R = P.T.conjugate()
     elif symmetry == 'symmetric':
         R = P.T
     elif symmetry == 'nonsymmetric':
@@ -431,9 +431,9 @@ def _extend_hierarchy(levels, strength, aggregate, smooth, improve_candidates,
         if fn == 'energy':
             R = energy_prolongation_smoother(AH, TH, C, BH, levels[-1].BH,
                                              Cpt_params=Cpt_params, **kwargs)
-            R = R.H
+            R = R.T.conjugate()
         elif fn is None:
-            R = T.H
+            R = T.T.conjugate()
         else:
             raise ValueError(f'Unrecognized prolongation smoother method: {str(fn)}')
 

--- a/pyamg/aggregation/smooth.py
+++ b/pyamg/aggregation/smooth.py
@@ -495,7 +495,7 @@ def cgnr_prolongation_smoothing(A, T, B, BtBinv, pattern, maxiter,
 
     # For non-SPD system, apply CG on Normal Equations with Diagonal
     # Preconditioning (requires transpose)
-    Ah = A.H
+    Ah = A.T.conjugate()
     Ah.sort_indices()
 
     # Preallocate

--- a/pyamg/aggregation/tests/test_tentative.py
+++ b/pyamg/aggregation/tests/test_tentative.py
@@ -182,4 +182,4 @@ class TestFitCandidates(TestCase):
 
             # each fine level candidate should be fit (almost) exactly
             assert_almost_equal(fine_candidates, Q * coarse_candidates)
-            assert_almost_equal(Q * (Q.H * fine_candidates), fine_candidates)
+            assert_almost_equal(Q * (Q.T.conjugate() * fine_candidates), fine_candidates)

--- a/pyamg/gallery/diffusion.py
+++ b/pyamg/gallery/diffusion.py
@@ -148,6 +148,8 @@ def diffusion_stencil_2d(epsilon=1.0, theta=0.0, type='FE'):
         stencil = np.array([[a, b, c],
                             [d, e, d],
                             [c, b, a]])
+    else:
+        raise ValueError('only stencil types "FE" and "FD" are supported')
 
     return stencil
 

--- a/pyamg/gallery/elasticity.py
+++ b/pyamg/gallery/elasticity.py
@@ -260,13 +260,12 @@ def linear_elasticity_p1(vertices, elements, E=1e5, nu=0.3, format=None):
     if elements.shape[1] != D + 1:
         raise ValueError('dimension mismatch')
 
-    if D not in (2, 3):
-        raise ValueError('only dimension 2 and 3 are supported')
-
     if D == 2:
         local_K = p12d_local
     elif D == 3:
         local_K = p13d_local
+    else:
+        raise ValueError('only dimension 2 and 3 are supported')
 
     row = elements.repeat(D).reshape(-1, D)
     row *= D

--- a/pyamg/gallery/fem.py
+++ b/pyamg/gallery/fem.py
@@ -319,10 +319,11 @@ def l2norm(u, mesh):
     if mesh.degree == 1:
         V = mesh.V
         E = mesh.E
-
-    if mesh.degree == 2:
+    elif mesh.degree == 2:
         V = mesh.V2
         E = mesh.E2
+    else:
+        raise ValueError('only mesh.degree 1 or 2 supported')
 
     if not isinstance(u, np.ndarray):
         raise ValueError('u must be ndarray')
@@ -361,8 +362,7 @@ def l2norm(u, mesh):
                              x,
                              y])
         basis = basis1
-
-    if mesh.degree == 2:
+    elif mesh.degree == 2:
         I = np.arange(6)
 
         def basis2(x, y):
@@ -373,6 +373,8 @@ def l2norm(u, mesh):
                              4*x*y,
                              4*y*(1-x-y)])
         basis = basis2
+    else:
+        raise ValueError('only mesh.degree 1 or 2 supported')
 
     for e in E:
         x = V[e, 0]
@@ -663,11 +665,12 @@ def gradgradform(mesh, kappa=None, f=None, degree=1):
         E = mesh.E
         X = mesh.X
         Y = mesh.Y
-
-    if degree == 2:
+    elif degree == 2:
         E = mesh.E2
         X = mesh.X2
         Y = mesh.Y2
+    else:
+        raise ValueError('only mesh.degree 1 or 2 supported')
 
     # allocate sparse matrix arrays
     m = 3 if degree == 1 else 6
@@ -918,6 +921,8 @@ def applybc(A, b, mesh, bc):
         elif c['degree'] == 2:
             X = mesh.X2
             Y = mesh.Y2
+        else:
+            raise ValueError('only mesh.degree 1 or 2 supported')
         u0[idx] = c['g'](X[idx], Y[idx])
 
     # lift (2 of 3)

--- a/pyamg/gallery/tests/test_laplacian.py
+++ b/pyamg/gallery/tests/test_laplacian.py
@@ -76,7 +76,7 @@ class TestGaugeLaplacian(TestCase):
 
         for A, beta in cases:
             # Check Hermitian
-            diff = A - A.H
+            diff = A - A.T.conjugate()
             assert_equal(diff.data, np.array([]))
 
             # Check for definiteness

--- a/pyamg/krylov/_cgne.py
+++ b/pyamg/krylov/_cgne.py
@@ -85,7 +85,7 @@ def cgne(A, b, x0=None, tol=1e-5, criteria='rr',
     """
     # Store the conjugate transpose explicitly as it will be used much later on
     if sparse.isspmatrix(A):
-        AH = A.H
+        AH = A.T.conjugate()
     else:
         # avoid doing this since A may be a different sparse type
         AH = aslinearoperator(np.asarray(A).conj().T)

--- a/pyamg/krylov/_cgnr.py
+++ b/pyamg/krylov/_cgnr.py
@@ -85,7 +85,7 @@ def cgnr(A, b, x0=None, tol=1e-5, criteria='rr',
     """
     # Store the conjugate transpose explicitly as it will be used much later on
     if sparse.isspmatrix(A):
-        AH = A.H
+        AH = A.T.conjugate()
     else:
         # avoid doing this since A may be a different sparse type
         AH = aslinearoperator(np.asarray(A).conj().T)

--- a/pyamg/krylov/_gmres.py
+++ b/pyamg/krylov/_gmres.py
@@ -117,5 +117,7 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None,
         (x, flag) = gmres_mgs(A, b, x0=x0, tol=tol, restart=restart,
                               maxiter=maxiter, M=M,
                               callback=callback, residuals=residuals, **kwargs)
+    else:
+        raise ValueError('orthog must be either "mgs" or "householder"')
 
     return (x, flag)

--- a/pyamg/krylov/tests/test_scipy.py
+++ b/pyamg/krylov/tests/test_scipy.py
@@ -1,5 +1,4 @@
 """Test scipy methods."""
-import inspect
 from functools import partial
 
 import numpy as np
@@ -37,6 +36,7 @@ class TestScipy(TestCase):
             b = case['b']
             x0 = case['x0']
             tol = case['tol']
+            rtol = tol
 
             kwargs = dict(tol=tol, restart=3, maxiter=2)
 
@@ -52,8 +52,8 @@ class TestScipy(TestCase):
 
             # check if scipy gmres has rtol
             kwargs['atol'] = 0
-            if 'rtol' in inspect.getfullargspec(sla.gmres).args:
-                kwargs['rtol'] = kwargs.pop(tol)
+            kwargs['rtol'] = rtol
+            del kwargs['tol']
 
             _ = sla.gmres(A, b, x0, callback=callback, callback_type='pr_norm', **kwargs)
 

--- a/pyamg/multilevel.py
+++ b/pyamg/multilevel.py
@@ -173,7 +173,7 @@ class MultilevelSolver:
 
         for level in levels[:-1]:
             if not hasattr(level, 'R'):
-                level.R = level.P.H
+                level.R = level.P.T.conjugate()
 
     def __repr__(self):
         """Print basic statistics about the multigrid hierarchy."""

--- a/pyamg/multilevel.py
+++ b/pyamg/multilevel.py
@@ -1,6 +1,4 @@
 """Generic AMG solver."""
-import inspect
-
 from warnings import warn
 
 import scipy as sp

--- a/pyamg/multilevel.py
+++ b/pyamg/multilevel.py
@@ -486,10 +486,8 @@ class MultilevelSolver:
                     callback_wrapper = callback
 
                 # for scipy solvers, see if rtol is available
-                kwargs['tol'] = tol
+                kwargs['rtol'] = tol
                 kwargs['atol'] = 0
-                if 'rtol' in inspect.getfullargspec(accel).args:
-                    kwargs['rtol'] = kwargs.pop(tol)
 
                 x, info = accel(A, b, x0=x0, maxiter=maxiter, M=M,
                                 callback=callback_wrapper, **kwargs)

--- a/pyamg/relaxation/relaxation.py
+++ b/pyamg/relaxation/relaxation.py
@@ -246,9 +246,6 @@ def schwarz(A, x, b, iterations=1, subdomain=None, subdomain_ptr=None,
         schwarz_parameters(A, subdomain, subdomain_ptr,
                            inv_subblock, inv_subblock_ptr)
 
-    if sweep not in ('forward', 'backward', 'symmetric'):
-        raise ValueError("valid sweep directions: 'forward', 'backward', and 'symmetric'")
-
     if sweep == 'forward':
         row_start, row_stop, row_step = 0, subdomain_ptr.shape[0]-1, 1
     elif sweep == 'backward':
@@ -262,6 +259,8 @@ def schwarz(A, x, b, iterations=1, subdomain=None, subdomain_ptr=None,
                     subdomain_ptr=subdomain_ptr, inv_subblock=inv_subblock,
                     inv_subblock_ptr=inv_subblock_ptr, sweep='backward')
         return
+    else:
+        raise ValueError("valid sweep directions: 'forward', 'backward', and 'symmetric'")
 
     # Call C code, need to make sure that subdomains are sorted and unique
     for _iter in range(iterations):
@@ -327,9 +326,6 @@ def gauss_seidel(A, x, b, iterations=1, sweep='forward'):
             raise ValueError('BSR blocks must be square')
         blocksize = R
 
-    if sweep not in ('forward', 'backward', 'symmetric'):
-        raise ValueError('valid sweep directions: "forward", "backward", and "symmetric"')
-
     if sweep == 'forward':
         row_start, row_stop, row_step = 0, int(len(x)/blocksize), 1
     elif sweep == 'backward':
@@ -339,6 +335,8 @@ def gauss_seidel(A, x, b, iterations=1, sweep='forward'):
             gauss_seidel(A, x, b, iterations=1, sweep='forward')
             gauss_seidel(A, x, b, iterations=1, sweep='backward')
         return
+    else:
+        raise ValueError('valid sweep directions: "forward", "backward", and "symmetric"')
 
     if sparse.isspmatrix_csr(A):
         for _iter in range(iterations):
@@ -566,9 +564,6 @@ def block_gauss_seidel(A, x, b, iterations=1, sweep='forward', blocksize=1,
     elif (Dinv.shape[1] != blocksize) or (Dinv.shape[2] != blocksize):
         raise ValueError('Dinv and blocksize are incompatible')
 
-    if sweep not in ('forward', 'backward', 'symmetric'):
-        raise ValueError('valid sweep directions: "forward", "backward", and "symmetric"')
-
     if sweep == 'forward':
         row_start, row_stop, row_step = 0, int(len(x)/blocksize), 1
     elif sweep == 'backward':
@@ -580,6 +575,8 @@ def block_gauss_seidel(A, x, b, iterations=1, sweep='forward', blocksize=1,
             block_gauss_seidel(A, x, b, iterations=1, sweep='backward',
                                blocksize=blocksize, Dinv=Dinv)
         return
+    else:
+        raise ValueError('valid sweep directions: "forward", "backward", and "symmetric"')
 
     for _iter in range(iterations):
         amg_core.block_gauss_seidel(A.indptr, A.indices, np.ravel(A.data),
@@ -716,9 +713,6 @@ def gauss_seidel_indexed(A, x, b, indices, iterations=1, sweep='forward'):
     # if indices.max() >= A.shape[0]
     #     raise ValueError('row index (%d) is invalid' % indices.max())
 
-    if sweep not in ('forward', 'backward', 'symmetric'):
-        raise ValueError('valid sweep directions: "forward", "backward", and "symmetric"')
-
     if sweep == 'forward':
         row_start, row_stop, row_step = 0, len(indices), 1
     elif sweep == 'backward':
@@ -730,6 +724,8 @@ def gauss_seidel_indexed(A, x, b, indices, iterations=1, sweep='forward'):
             gauss_seidel_indexed(A, x, b, indices, iterations=1,
                                  sweep='backward')
         return
+    else:
+        raise ValueError('valid sweep directions: "forward", "backward", and "symmetric"')
 
     for _iter in range(iterations):
         amg_core.gauss_seidel_indexed(A.indptr, A.indices, A.data,
@@ -887,9 +883,6 @@ def gauss_seidel_ne(A, x, b, iterations=1, sweep='forward', omega=1.0,
     if Dinv is None:
         Dinv = np.ravel(get_diagonal(A, norm_eq=2, inv=True))
 
-    if sweep not in ('forward', 'backward', 'symmetric'):
-        raise ValueError('valid sweep directions: "forward", "backward", and "symmetric"')
-
     if sweep == 'forward':
         row_start, row_stop, row_step = 0, len(x), 1
     elif sweep == 'backward':
@@ -901,6 +894,8 @@ def gauss_seidel_ne(A, x, b, iterations=1, sweep='forward', omega=1.0,
             gauss_seidel_ne(A, x, b, iterations=1, sweep='backward',
                             omega=omega, Dinv=Dinv)
         return
+    else:
+        raise ValueError('valid sweep directions: "forward", "backward", and "symmetric"')
 
     for _i in range(iterations):
         amg_core.gauss_seidel_ne(A.indptr, A.indices, A.data,
@@ -972,9 +967,6 @@ def gauss_seidel_nr(A, x, b, iterations=1, sweep='forward', omega=1.0,
     if Dinv is None:
         Dinv = np.ravel(get_diagonal(A, norm_eq=1, inv=True))
 
-    if sweep not in ('forward', 'backward', 'symmetric'):
-        raise ValueError('valid sweep directions: "forward", "backward", and "symmetric"')
-
     if sweep == 'forward':
         col_start, col_stop, col_step = 0, len(x), 1
     elif sweep == 'backward':
@@ -986,6 +978,8 @@ def gauss_seidel_nr(A, x, b, iterations=1, sweep='forward', omega=1.0,
             gauss_seidel_nr(A, x, b, iterations=1, sweep='backward',
                             omega=omega, Dinv=Dinv)
         return
+    else:
+        raise ValueError('valid sweep directions: "forward", "backward", and "symmetric"')
 
     # Calculate initial residual
     r = b - A*x

--- a/pyamg/relaxation/tests/test_relaxation.py
+++ b/pyamg/relaxation/tests/test_relaxation.py
@@ -203,9 +203,9 @@ class TestRelaxation(TestCase):
                                  [0, -1, 1], N, N).tocsr())
             cases.append(elasticity.linear_elasticity((N, N))[0].tocsr())
             C = csr_matrix(np.random.rand(N, N))
-            cases.append(C*C.H)
+            cases.append(C*C.T.conjugate())
             C = sprand(N*2, N*2, 0.3) + eye(N*2, N*2)
-            cases.append(C*C.H)
+            cases.append(C*C.T.conjugate())
 
         for A in cases:
             divisors =\
@@ -229,9 +229,9 @@ class TestRelaxation(TestCase):
                                  [0, -1, 1], N, N).tocsr())
             cases.append(elasticity.linear_elasticity((N, N))[0].tocsr())
             C = csr_matrix(np.random.rand(N, N))
-            cases.append(C*C.H)
+            cases.append(C*C.T.conjugate())
             C = sprand(N*2, N*2, 0.3) + eye(N*2, N*2)
-            cases.append(C*C.H)
+            cases.append(C*C.T.conjugate())
 
         for A in cases:
             for sweep in sweeps:
@@ -890,11 +890,11 @@ class TestComplexRelaxation(TestCase):
             cases.append(1.0j*elasticity.linear_elasticity((N, N))[0].tocsr())
             #
             C = csr_matrix(np.random.rand(N, N) + 1.0j*np.random.rand(N, N))
-            cases.append(C*C.H)
+            cases.append(C*C.T.conjugate())
             #
             C = sprand(N*2, N*2, 0.3) + 1.0j*sprand(N*2, N*2, 0.3) +\
                 eye(N*2, N*2)
-            cases.append(C*C.H)
+            cases.append(C*C.T.conjugate())
 
         for A in cases:
             n = A.shape[0]
@@ -924,11 +924,11 @@ class TestComplexRelaxation(TestCase):
             cases.append(1.0j*elasticity.linear_elasticity((N, N))[0].tocsr())
             #
             C = csr_matrix(np.random.rand(N, N) + 1.0j*np.random.rand(N, N))
-            cases.append(C*C.H)
+            cases.append(C*C.T.conjugate())
             #
             C = sprand(N*2, N*2, 0.3) + 1.0j*sprand(N*2, N*2, 0.3) +\
                 eye(N*2, N*2)
-            cases.append(C*C.H)
+            cases.append(C*C.T.conjugate())
 
         for A in cases:
             n = A.shape[0]

--- a/pyamg/strength.py
+++ b/pyamg/strength.py
@@ -308,9 +308,6 @@ def symmetric_strength_of_connection(A, theta=0):
     if theta < 0:
         raise ValueError('expected a positive theta')
 
-    if not sparse.isspmatrix_csr(A) and not sparse.isspmatrix_bsr(A):
-        raise TypeError('expected csr_matrix or bsr_matrix')
-
     if sparse.isspmatrix_csr(A):
         # if theta == 0:
         #     return A
@@ -343,6 +340,8 @@ def symmetric_strength_of_connection(A, theta=0):
             A = sparse.csr_matrix((data, A.indices, A.indptr),
                                   shape=(int(M / R), int(N / C)))
             return symmetric_strength_of_connection(A, theta)
+    else:
+        raise TypeError('expected csr_matrix or bsr_matrix')
 
     # Strength represents "distance", so take the magnitude
     S.data = np.abs(S.data)
@@ -427,6 +426,7 @@ def energy_based_strength_of_connection(A, theta=0.0, k=2):
             raise ValueError('expected square blocks in BSR matrix A')
     else:
         bsr_flag = False
+        numPDEs = 1
 
     # Convert A to csc and Atilde to csr
     if sparse.isspmatrix_csr(A):

--- a/pyamg/strength.py
+++ b/pyamg/strength.py
@@ -499,10 +499,11 @@ def energy_based_strength_of_connection(A, theta=0.0, k=2):
     return Atilde
 
 
-@np.deprecate
 def ode_strength_of_connection(A, B=None, epsilon=4.0, k=2, proj_type='l2',
                                block_flag=False, symmetrize_measure=True):
     """Use evolution_strength_of_connection instead (deprecated)."""
+    warn('ode_strength_of_connection method is deprecated. '
+         'Use evolution_strength_of_connection.', DeprecationWarning, stacklevel=2)
     return evolution_strength_of_connection(A, B, epsilon, k, proj_type,
                                             block_flag, symmetrize_measure)
 

--- a/pyamg/tests/test_multilevel.py
+++ b/pyamg/tests/test_multilevel.py
@@ -150,7 +150,7 @@ class TestComplexMultilevel(TestCase):
 
         # Make cases complex
         cases = [G+1e-5j*G for G in cases]
-        cases = [0.5*(G + G.H) for G in cases]
+        cases = [0.5*(G + G.T.conjugate()) for G in cases]
 
         # method should be almost exact for small matrices
         for A in cases:

--- a/pyamg/tests/test_multilevel.py
+++ b/pyamg/tests/test_multilevel.py
@@ -1,6 +1,4 @@
 """Test MultilevelSolver class."""
-import inspect
-
 import numpy as np
 from numpy.testing import TestCase, assert_almost_equal, assert_equal
 from scipy import sparse
@@ -56,12 +54,11 @@ class TestMultilevel(TestCase):
         ml = smoothed_aggregation_solver(A)
 
         kwargs = dict(tol=1e-8, maxiter=30, atol=0)
-        if 'rtol' in inspect.getfullargspec(cg).args:
-            kwargs['rtol'] = kwargs.pop('tol')
+        kwargscg = dict(rtol=1e-8, maxiter=30, atol=0)
 
         for cycle in ['V', 'W', 'F']:
             M = ml.aspreconditioner(cycle=cycle)
-            x, info = cg(A, b, M=M, **kwargs)
+            x, info = cg(A, b, M=M, **kwargscg)
             # cg satisfies convergence in the preconditioner norm
             assert precon_norm(b - A*x, ml) < 1e-8*precon_norm(b, ml)
 

--- a/pyamg/tests/test_multilevel.py
+++ b/pyamg/tests/test_multilevel.py
@@ -53,12 +53,9 @@ class TestMultilevel(TestCase):
 
         ml = smoothed_aggregation_solver(A)
 
-        kwargs = dict(tol=1e-8, maxiter=30, atol=0)
-        kwargscg = dict(rtol=1e-8, maxiter=30, atol=0)
-
         for cycle in ['V', 'W', 'F']:
             M = ml.aspreconditioner(cycle=cycle)
-            x, info = cg(A, b, M=M, **kwargscg)
+            x, info = cg(A, b, M=M, rtol=1e-8, maxiter=30, atol=0)
             # cg satisfies convergence in the preconditioner norm
             assert precon_norm(b - A*x, ml) < 1e-8*precon_norm(b, ml)
 

--- a/pyamg/util/linalg.py
+++ b/pyamg/util/linalg.py
@@ -42,7 +42,7 @@ def norm(x, pnorm='2'):
     x = np.ravel(x)
 
     if pnorm == '2':
-        return np.sqrt(np.inner(x.conj(), x).real) # pylint: disable=no-member
+        return np.sqrt(np.inner(x.conj(), x).real)  # pylint: disable=no-member
 
     if pnorm == 'inf':
         return np.max(np.abs(x))

--- a/pyamg/util/linalg.py
+++ b/pyamg/util/linalg.py
@@ -42,7 +42,7 @@ def norm(x, pnorm='2'):
     x = np.ravel(x)
 
     if pnorm == '2':
-        return np.sqrt(np.inner(x.conj(), x).real)
+        return np.sqrt(np.inner(x.conj(), x).real) # pylint: disable=no-member
 
     if pnorm == 'inf':
         return np.max(np.abs(x))

--- a/pyamg/util/tests/test_utils.py
+++ b/pyamg/util/tests/test_utils.py
@@ -1179,12 +1179,12 @@ class TestComplexUtils(TestCase):
             D = 1.0/D
             assert_almost_equal(D, D_A_inv)
 
-            D = np.diag((A.H*A).toarray())
+            D = np.diag((A.T.conjugate()*A).toarray())
             assert_almost_equal(D, D_AA)
             D = 1.0/D
             assert_almost_equal(D, D_AA_inv)
 
-            D = np.diag((A*A.H).toarray())
+            D = np.diag((A*A.T.conjugate()).toarray())
             assert_almost_equal(D, D_AA2)
             D = 1.0/D
             assert_almost_equal(D, D_AA_inv2)

--- a/pyamg/util/tests/test_utils.py
+++ b/pyamg/util/tests/test_utils.py
@@ -1,6 +1,4 @@
 """Test utils."""
-import inspect
-
 import numpy as np
 from scipy.sparse import (csr_matrix, csc_matrix, isspmatrix,
                           bsr_matrix, isspmatrix_bsr,
@@ -170,10 +168,7 @@ class TestUtils(TestCase):
         opts = []
         opts.append({})
 
-        # does cg have rtol?
-        nextopt = dict(accel=cg, tol=1e-10, atol=0)
-        if 'rtol' in inspect.getfullargspec(cg).args:
-            nextopt['rtol'] = nextopt.pop('tol')
+        nextopt = dict(accel=cg, rtol=1e-10, atol=0)
         opts.append(nextopt)
 
         for kwargs in opts:
@@ -1201,10 +1196,7 @@ class TestComplexUtils(TestCase):
         opts = []
         opts.append({})
 
-        # does cg have rtol?
-        nextopt = dict(accel=cg, tol=1e-10, atol=0)
-        if 'rtol' in inspect.getfullargspec(cg).args:
-            nextopt['rtol'] = nextopt.pop('tol')
+        nextopt = dict(accel=cg, rtol=1e-10, atol=0)
         opts.append(nextopt)
 
         for kwargs in opts:

--- a/pyamg/util/utils.py
+++ b/pyamg/util/utils.py
@@ -7,27 +7,12 @@ from scipy.sparse import isspmatrix, isspmatrix_csr, isspmatrix_csc, \
     isspmatrix_bsr, csr_matrix, csc_matrix, bsr_matrix, coo_matrix, eye
 from scipy.linalg import eigvals
 
-try:
-    from scipy.sparse._sparsetools import (csr_scale_rows, bsr_scale_rows,
-                                           csr_scale_columns, bsr_scale_columns)
-except ImportError:
-    from scipy.sparse.sparsetools import (csr_scale_rows, bsr_scale_rows,
-                                          csr_scale_columns, bsr_scale_columns)
+from scipy.sparse._sparsetools import (csr_scale_rows, bsr_scale_rows,
+                                       csr_scale_columns, bsr_scale_columns)
 
-try:
-    # scipy >=1.8
-    # pylint: disable=unused-import
-    from scipy.sparse.linalg._isolve.utils import make_system
-except ImportError:
-    # scipy <1.8
-    from scipy.sparse.linalg.isolve.utils import make_system  # noqa: F401
-
-try:
-    # scipy >=1.8
-    from scipy.sparse._sputils import upcast
-except ImportError:
-    # scipy <1.8
-    from scipy.sparse.sputils import upcast
+# pylint: disable=unused-import
+from scipy.sparse.linalg._isolve.utils import make_system
+from scipy.sparse._sputils import upcast
 
 from .. import amg_core
 from . import linalg

--- a/pyamg/util/utils.py
+++ b/pyamg/util/utils.py
@@ -11,7 +11,7 @@ from scipy.sparse._sparsetools import (csr_scale_rows, bsr_scale_rows,
                                        csr_scale_columns, bsr_scale_columns)
 
 # pylint: disable=unused-import
-from scipy.sparse.linalg._isolve.utils import make_system
+from scipy.sparse.linalg._isolve.utils import make_system  # noqa: F401
 from scipy.sparse._sputils import upcast
 
 from .. import amg_core

--- a/pyamg/util/utils.py
+++ b/pyamg/util/utils.py
@@ -7,6 +7,7 @@ from scipy.sparse import isspmatrix, isspmatrix_csr, isspmatrix_csc, \
     isspmatrix_bsr, csr_matrix, csc_matrix, bsr_matrix, coo_matrix, eye
 from scipy.linalg import eigvals
 
+# pylint: disable=no-name-in-module
 from scipy.sparse._sparsetools import (csr_scale_rows, bsr_scale_rows,
                                        csr_scale_columns, bsr_scale_columns)
 
@@ -1944,6 +1945,7 @@ def filter_matrix_columns(A, theta):
     """
     if not isspmatrix(A):
         raise ValueError('Sparse matrix input needed')
+    blocksize = 1
     if isspmatrix_bsr(A):
         blocksize = A.blocksize
     Aformat = A.format
@@ -2026,6 +2028,7 @@ def filter_matrix_rows(A, theta, diagonal=False, lump=False):
     """
     if not isspmatrix(A):
         raise ValueError('Sparse matrix input needed')
+    blocksize = 1
     if isspmatrix_bsr(A):
         blocksize = A.blocksize
     Aformat = A.format
@@ -2106,6 +2109,7 @@ def truncate_rows(A, nz_per_row):
     """
     if not isspmatrix(A):
         raise ValueError('Sparse matrix input needed')
+    blocksize = 1
     if isspmatrix_bsr(A):
         blocksize = A.blocksize
     if isspmatrix_csr(A):

--- a/pyamg/vis/vis_coarse.py
+++ b/pyamg/vis/vis_coarse.py
@@ -208,7 +208,7 @@ def vis_splitting(V, splitting, output='vtk', fname='output.vtu'):
     if len(a) < 2:
         fname1 = a[0]
         fname2 = '.vtu'
-    elif len(a) >= 2:
+    else:
         fname1 = ''.join(a[:-1])
         fname2 = a[-1]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 numpy
-scipy>=1.8.0
+scipy>=1.11.0
 pytest
 pep8-naming
 flake8-quotes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 numpy
-scipy>=1.8.0
+scipy>=1.11.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ platforms = any
 python_requires = >=3.8
 install_requires =
     numpy
-    scipy>=1.8.0
+    scipy>=1.11.0
 tests_require =
     pytest>=2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,6 @@ classifiers =
     Programming Language :: C++
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -39,7 +38,7 @@ zip_safe = False
 include_package_data = False
 packages = find:
 platforms = any
-python_requires = >=3.8
+python_requires = >=3.9
 install_requires =
     numpy
     scipy>=1.11.0


### PR DESCRIPTION
- [x] add numpy 2.0 deprecation
- [x] add `rtol` to scipy Krylov calls, bump minimum scipy to 1.11.0
- [x] drop Python 3.8 support (near end-of-life and 3.9 is required by scipy 1.11.0)
- [x] fix new unbound lint warnings