### PR TITLE
fix: resolve sor bug

### DIFF
--- a/pyamg/amg_core/__init__.py
+++ b/pyamg/amg_core/__init__.py
@@ -13,7 +13,7 @@ from .graph import (maximal_independent_set_serial, maximal_independent_set_para
 
 from .krylov import (apply_householders, householder_hornerscheme, apply_givens)
 from .linalg import (pinv_array, csc_scale_columns, csc_scale_rows, filter_matrix_rows)
-from .relaxation import (gauss_seidel, bsr_gauss_seidel, gauss_seidel_indexed,
+from .relaxation import (gauss_seidel, sor_gauss_seidel, bsr_gauss_seidel, gauss_seidel_indexed,
                          jacobi, bsr_jacobi,
                          jacobi_ne, gauss_seidel_ne, gauss_seidel_nr,
                          block_jacobi, block_gauss_seidel,
@@ -70,6 +70,7 @@ __all__ = [
     'filter_matrix_rows',
     # relaxation
     'gauss_seidel',
+    'sor_gauss_seidel',
     'bsr_gauss_seidel',
     'jacobi',
     'bsr_jacobi',

--- a/pyamg/amg_core/__init__.py
+++ b/pyamg/amg_core/__init__.py
@@ -13,7 +13,8 @@ from .graph import (maximal_independent_set_serial, maximal_independent_set_para
 
 from .krylov import (apply_householders, householder_hornerscheme, apply_givens)
 from .linalg import (pinv_array, csc_scale_columns, csc_scale_rows, filter_matrix_rows)
-from .relaxation import (gauss_seidel, sor_gauss_seidel, bsr_gauss_seidel, gauss_seidel_indexed,
+from .relaxation import (gauss_seidel, sor_gauss_seidel, bsr_gauss_seidel,
+                         gauss_seidel_indexed,
                          jacobi, bsr_jacobi,
                          jacobi_ne, gauss_seidel_ne, gauss_seidel_nr,
                          block_jacobi, block_gauss_seidel,

--- a/pyamg/amg_core/instantiate.yml
+++ b/pyamg/amg_core/instantiate.yml
@@ -9,6 +9,7 @@ instantiate:
     - householder_hornerscheme
     - apply_givens
     - gauss_seidel
+    - sor_gauss_seidel
     - bsr_gauss_seidel
     - jacobi
     - bsr_jacobi

--- a/pyamg/amg_core/relaxation.h
+++ b/pyamg/amg_core/relaxation.h
@@ -71,6 +71,36 @@ void gauss_seidel(const I Ap[], const int Ap_size,
     }
 }
 
+template<class I, class T, class F>
+void sor_gauss_seidel(const I Ap[], const int Ap_size,
+                  const I Aj[], const int Aj_size,
+                  const T Ax[], const int Ax_size,
+                        T  x[], const int  x_size,
+                  const T  b[], const int  b_size,
+                  const I row_start,
+                  const I row_stop,
+                  const I row_step,
+                  const F omega)
+{
+    for(I i = row_start; i != row_stop; i += row_step) {
+        I start = Ap[i];
+        I end   = Ap[i+1];
+        T rsum = 0;
+        T diag = 0;
+
+        for(I jj = start; jj < end; jj++){
+            I j = Aj[jj];
+            if (i == j)
+                diag  = Ax[jj];
+            else
+                rsum += Ax[jj]*x[j];
+        }
+
+        if (diag != (F) 0.0){
+            x[i] = omega*((b[i] - rsum)/diag) + (1-omega)*x[i];
+        }
+    }
+}
 
 /*
  * Perform one iteration of Gauss-Seidel relaxation on the linear

--- a/pyamg/amg_core/relaxation_bind.cpp
+++ b/pyamg/amg_core/relaxation_bind.cpp
@@ -44,6 +44,43 @@ void _gauss_seidel(
 }
 
 template<class I, class T, class F>
+void _sor_gauss_seidel(
+      py::array_t<I> & Ap,
+      py::array_t<I> & Aj,
+      py::array_t<T> & Ax,
+       py::array_t<T> & x,
+       py::array_t<T> & b,
+        const I row_start,
+         const I row_stop,
+         const I row_step,
+            const F omega
+                       )
+{
+    auto py_Ap = Ap.unchecked();
+    auto py_Aj = Aj.unchecked();
+    auto py_Ax = Ax.unchecked();
+    auto py_x = x.mutable_unchecked();
+    auto py_b = b.unchecked();
+    const I *_Ap = py_Ap.data();
+    const I *_Aj = py_Aj.data();
+    const T *_Ax = py_Ax.data();
+    T *_x = py_x.mutable_data();
+    const T *_b = py_b.data();
+
+    return sor_gauss_seidel<I, T, F>(
+                      _Ap, Ap.shape(0),
+                      _Aj, Aj.shape(0),
+                      _Ax, Ax.shape(0),
+                       _x, x.shape(0),
+                       _b, b.shape(0),
+                row_start,
+                 row_stop,
+                 row_step,
+                    omega
+                                     );
+}
+
+template<class I, class T, class F>
 void _bsr_gauss_seidel(
       py::array_t<I> & Ap,
       py::array_t<I> & Aj,
@@ -648,6 +685,7 @@ PYBIND11_MODULE(relaxation, m) {
     Methods
     -------
     gauss_seidel
+    sor_gauss_seidel
     bsr_gauss_seidel
     jacobi
     jacobi_indexed
@@ -712,6 +750,17 @@ only a subset of the unknowns.  A forward sweep is implemented
 with gauss_seidel(Ap, Aj, Ax, x, b, 0, N, 1) where N is the
 number of rows in matrix A.  Similarly, a backward sweep is
 implemented with gauss_seidel(Ap, Aj, Ax, x, b, N, -1, -1).)pbdoc");
+
+    m.def("sor_gauss_seidel", &_sor_gauss_seidel<int, float, float>,
+        py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("x").noconvert(), py::arg("b").noconvert(), py::arg("row_start"), py::arg("row_stop"), py::arg("row_step"), py::arg("omega"));
+    m.def("sor_gauss_seidel", &_sor_gauss_seidel<int, double, double>,
+        py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("x").noconvert(), py::arg("b").noconvert(), py::arg("row_start"), py::arg("row_stop"), py::arg("row_step"), py::arg("omega"));
+    m.def("sor_gauss_seidel", &_sor_gauss_seidel<int, std::complex<float>, float>,
+        py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("x").noconvert(), py::arg("b").noconvert(), py::arg("row_start"), py::arg("row_stop"), py::arg("row_step"), py::arg("omega"));
+    m.def("sor_gauss_seidel", &_sor_gauss_seidel<int, std::complex<double>, double>,
+        py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("x").noconvert(), py::arg("b").noconvert(), py::arg("row_start"), py::arg("row_stop"), py::arg("row_step"), py::arg("omega"),
+R"pbdoc(
+)pbdoc");
 
     m.def("bsr_gauss_seidel", &_bsr_gauss_seidel<int, float, float>,
         py::arg("Ap").noconvert(), py::arg("Aj").noconvert(), py::arg("Ax").noconvert(), py::arg("x").noconvert(), py::arg("b").noconvert(), py::arg("row_start"), py::arg("row_stop"), py::arg("row_step"), py::arg("blocksize"));

--- a/pyamg/relaxation/relaxation.py
+++ b/pyamg/relaxation/relaxation.py
@@ -150,10 +150,9 @@ def sor(A, x, b, omega, iterations=1, sweep='forward'):
     """
     A, x, b = make_system(A, x, b, formats=['csr', 'bsr'])
 
-    x_old = np.empty_like(x)
-
     for _i in range(iterations):
         gauss_seidel(A, x, b, iterations=1, sweep=sweep, omega=omega)
+
 
 def schwarz(A, x, b, iterations=1, subdomain=None, subdomain_ptr=None,
             inv_subblock=None, inv_subblock_ptr=None, sweep='forward'):
@@ -278,6 +277,8 @@ def gauss_seidel(A, x, b, iterations=1, sweep='forward', omega=1.0):
         Number of iterations to perform
     sweep : {'forward','backward','symmetric'}
         Direction of sweep
+    omega : scalar
+        Damping parameter. If omega != 1.0, then the method is SOR.
 
     Returns
     -------
@@ -335,7 +336,7 @@ def gauss_seidel(A, x, b, iterations=1, sweep='forward', omega=1.0):
             for _iter in range(iterations):
                 amg_core.sor_gauss_seidel(A.indptr, A.indices, A.data, x, b,
                                       row_start, row_stop, row_step, omega)
-        else:    
+        else:
             for _iter in range(iterations):
                 amg_core.gauss_seidel(A.indptr, A.indices, A.data, x, b,
                                       row_start, row_stop, row_step)

--- a/pyamg/relaxation/relaxation.py
+++ b/pyamg/relaxation/relaxation.py
@@ -131,11 +131,11 @@ def sor(A, x, b, omega, iterations=1, sweep='forward'):
     >>> from pyamg.util.linalg import norm
     >>> import numpy as np
     >>> A = poisson((10,10), format='csr')
-    >>> x0 = np.zeros((A.shape[0],1))
     >>> b = np.ones((A.shape[0],1))
+    >>> x0 = np.zeros((A.shape[0],1))
     >>> sor(A, x0, b, 1.33, iterations=10)
     >>> print(f'{norm(b-A@x0):2.4}')
-    3.039
+    2.013
     >>> #
     >>> # Use SOR as the multigrid smoother
     >>> from pyamg import smoothed_aggregation_solver

--- a/pyamg/relaxation/tests/test_relaxation.py
+++ b/pyamg/relaxation/tests/test_relaxation.py
@@ -1,7 +1,7 @@
 """Test relaxation."""
 import warnings
 import numpy as np
-from numpy.testing import TestCase, assert_almost_equal
+from numpy.testing import TestCase, assert_almost_equal, assert_allclose
 import scipy
 from scipy.sparse import csr_array, bsr_array, diags_array, eye_array
 from scipy.sparse import SparseEfficiencyWarning
@@ -819,19 +819,19 @@ class TestRelaxation(TestCase):
 
         x = np.array([0, 0, 0, 0.])
         sor(A, x, b, 0.5, iterations=1) 
-        assert_almost_equal(x, x1)
+        assert_allclose(x, x1, rtol=1e-6)
 
         x = np.array([0, 0, 0, 0.])
         sor(A, x, b, 0.5, iterations=2) 
-        assert_almost_equal(x, x2)
+        assert_allclose(x, x2, rtol=1e-6)
 
         x = np.array([0, 0, 0, 0.])
         sor(A, x, b, 0.5, iterations=3) 
-        assert_almost_equal(x, x3)
+        assert_allclose(x, x3, rtol=1e-6)
 
         x = np.array([0, 0, 0, 0.])
         sor(A, x, b, 0.5, iterations=38) 
-        assert_almost_equal(x, x38)
+        assert_allclose(x, x38, rtol=1e-6)
 
 
 # Test complex arithmetic

--- a/pyamg/relaxation/tests/test_relaxation.py
+++ b/pyamg/relaxation/tests/test_relaxation.py
@@ -804,12 +804,13 @@ class TestRelaxation(TestCase):
             schwarz(A, x, b, iterations=1, sweep='symmetric')
             assert_almost_equal(x, gold(A, x_copy, b, iterations=1,
                                         sweep='symmetric'))
+
     def test_sor(self):
         # https://en.wikipedia.org/wiki/Successive_over-relaxation#Example
-        A = np.array([[ 4, -1, -6,  0],
-                      [-5, -4, 10,  8],
-                      [ 0,  9,  4, -2],
-                      [ 1,  0, -7,  5.]])
+        A = np.array([[4, -1, -6, 0],
+                      [-5, -4, 10, 8],
+                      [0, 9,  4, -2],
+                      [1, 0, -7, 5.]])
         b = np.array([2, 21, -12, -6.])
 
         x1 = np.array([0.25, -2.78125, 1.6289062, 0.5152344])
@@ -818,19 +819,19 @@ class TestRelaxation(TestCase):
         x38 = np.array([3.0, -2.0, 2.0, 1.0])
 
         x = np.array([0, 0, 0, 0.])
-        sor(A, x, b, 0.5, iterations=1) 
+        sor(A, x, b, 0.5, iterations=1)
         assert_allclose(x, x1, rtol=1e-6)
 
         x = np.array([0, 0, 0, 0.])
-        sor(A, x, b, 0.5, iterations=2) 
+        sor(A, x, b, 0.5, iterations=2)
         assert_allclose(x, x2, rtol=1e-6)
 
         x = np.array([0, 0, 0, 0.])
-        sor(A, x, b, 0.5, iterations=3) 
+        sor(A, x, b, 0.5, iterations=3)
         assert_allclose(x, x3, rtol=1e-6)
 
         x = np.array([0, 0, 0, 0.])
-        sor(A, x, b, 0.5, iterations=38) 
+        sor(A, x, b, 0.5, iterations=38)
         assert_allclose(x, x38, rtol=1e-6)
 
 

--- a/pyamg/relaxation/tests/test_relaxation.py
+++ b/pyamg/relaxation/tests/test_relaxation.py
@@ -804,6 +804,34 @@ class TestRelaxation(TestCase):
             schwarz(A, x, b, iterations=1, sweep='symmetric')
             assert_almost_equal(x, gold(A, x_copy, b, iterations=1,
                                         sweep='symmetric'))
+    def test_sor(self):
+        # https://en.wikipedia.org/wiki/Successive_over-relaxation#Example
+        A = np.array([[ 4, -1, -6,  0],
+                      [-5, -4, 10,  8],
+                      [ 0,  9,  4, -2],
+                      [ 1,  0, -7,  5.]])
+        b = np.array([2, 21, -12, -6.])
+
+        x1 = np.array([0.25, -2.78125, 1.6289062, 0.5152344])
+        x2 = np.array([1.2490234, -2.2448974, 1.9687712, 0.9108547])
+        x3 = np.array([2.070478, -1.6696789, 1.5904881, 0.76172125])
+        x38 = np.array([3.0, -2.0, 2.0, 1.0])
+
+        x = np.array([0, 0, 0, 0.])
+        sor(A, x, b, 0.5, iterations=1) 
+        assert_almost_equal(x, x1)
+
+        x = np.array([0, 0, 0, 0.])
+        sor(A, x, b, 0.5, iterations=2) 
+        assert_almost_equal(x, x2)
+
+        x = np.array([0, 0, 0, 0.])
+        sor(A, x, b, 0.5, iterations=3) 
+        assert_almost_equal(x, x3)
+
+        x = np.array([0, 0, 0, 0.])
+        sor(A, x, b, 0.5, iterations=38) 
+        assert_almost_equal(x, x38)
 
 
 # Test complex arithmetic


### PR DESCRIPTION
fixes #410

Right now, when you run the SOR function, it internally uses a Gauss-Seidel iteration to calculate the next iteration and then incorporates the relaxation factor on the whole matrix. It doesn't include the relaxation factor while calculating the next x_i while in the Gauss-Seidel iteration. This results in incorrect values.

I've tried to resolve this by adding a new function in relaxation.h and adding an extra parameter, omega in the gauss_seidel function which has a default value of 1.0 and calls the sor variant of Gauss-Seidel only if omega is not 1.0

I hope I've followed all the necessary contribution guidelines. Please let me know if I haven't so I can fix it.