### PR TITLE
remove duplicate entries in air sparsity

### DIFF
--- a/pyamg/amg_core/air.h
+++ b/pyamg/amg_core/air.h
@@ -249,7 +249,7 @@ void approx_ideal_restriction_pass2(const I Rp[], const int Rp_size,
         }
 
         // Loop over unique distance two neighbors and add to column indices
-        for (const I &cc : colinds) {
+        for (const I cc : colinds) {
             Rj[ind] = cc;
             ind += 1;
         }
@@ -415,7 +415,7 @@ void block_approx_ideal_restriction_pass2(const I Rp[], const int Rp_size,
         }
 
         // Loop over unique distance two neighbors and add to column indices
-        for (const I &cc : colinds) {
+        for (const I cc : colinds) {
             Rj[ind] = cc;
             ind += 1;
         }

--- a/pyamg/amg_core/air.h
+++ b/pyamg/amg_core/air.h
@@ -152,7 +152,7 @@ void approx_ideal_restriction_pass1(      I Rp[], const int Rp_size,
         }
 
         // Set row-pointer for this row of R (including identity on C-points).
-        nnz += colinds.size();
+        nnz += colinds.size() + 1;
         Rp[row+1] = nnz; 
     }
     if ((distance != 1) && (distance != 2)) {
@@ -254,7 +254,7 @@ void approx_ideal_restriction_pass2(const I Rp[], const int Rp_size,
             ind += 1;
         }
 
-        if (ind != (Rp[row+1])) {
+        if (ind != (Rp[row+1]-1)) {
             std::cerr << "Error approx_ideal_restriction_pass2: Row pointer does not agree with neighborhood size.\n\t"
                          "ind = " << ind << ", Rp[row] = " << Rp[row] <<
                          ", Rp[row+1] = " << Rp[row+1] << "\n";
@@ -420,7 +420,7 @@ void block_approx_ideal_restriction_pass2(const I Rp[], const int Rp_size,
             ind += 1;
         }
 
-        if (ind != (Rp[row+1])) {
+        if (ind != (Rp[row+1]-1)) {
             std::cerr << "Error block_approx_ideal_restriction_pass2: Row pointer does not agree with neighborhood size.\n";
         }
 

--- a/pyamg/amg_core/air.h
+++ b/pyamg/amg_core/air.h
@@ -143,7 +143,7 @@ void approx_ideal_restriction_pass1(      I Rp[], const int Rp_size,
                 // Strong distance-two F-to-F connections
                 if (distance == 2) {
                     for (I kk = Cp[this_point]; kk < Cp[this_point+1]; kk++){
-                        if ((splitting[Cj[kk]] == F_NODE) && (this_point != cpoint)) {
+                        if (splitting[Cj[kk]] == F_NODE) {
                             colinds.insert(Cj[kk]);
                         }
                     } 
@@ -240,7 +240,7 @@ void approx_ideal_restriction_pass2(const I Rp[], const int Rp_size,
                 // Strong distance-two F-to-F connections
                 if (distance == 2) {
                     for (I kk = Cp[this_point]; kk < Cp[this_point+1]; kk++){
-                        if ((splitting[Cj[kk]] == F_NODE) && (this_point != cpoint)) {
+                        if (splitting[Cj[kk]] == F_NODE) {
                             colinds.insert(Cj[kk]);
                         }
                     } 
@@ -406,7 +406,7 @@ void block_approx_ideal_restriction_pass2(const I Rp[], const int Rp_size,
                 // Strong distance-two F-to-F connections
                 if (distance == 2) {
                     for (I kk = Cp[this_point]; kk < Cp[this_point+1]; kk++){
-                        if ((splitting[Cj[kk]] == F_NODE) && (this_point != cpoint)) {
+                        if (splitting[Cj[kk]] == F_NODE) {
                             colinds.insert(Cj[kk]);
                         }
                     } 


### PR DESCRIPTION
Previous implementation of AIR was finding all neighbors of distance one or two without checking for uniqueness. The result was extracting a submatrix with duplicate rows/columns, and then filling in R with duplicate entries. Used std::set to fix this. Note, in almost all cases, I expect least_squares could now be replaced with QR, but in general a principle submatrix of arbitrary nonsymmetric matrix need not be nonsingular, so we should probably keep this for robustness.