### PR TITLE
Test and add wheels for Python 3.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, macos-latest]
 
     steps:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build_wheels:
     name: Build wheel for ${{ matrix.os }}

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           # uncomment to force a wheel build
-          # ref: v5.2.1
+          ref: v5.2.1
           fetch-depth: 0
 
       - name: Build wheels
@@ -57,7 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           # uncomment to force a wheel build
-          # ref: v5.2.1
+          ref: v5.2.1
           fetch-depth: 0
 
       - name: Install pypa/build

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           # uncomment to force a wheel build
-          ref: v5.2.1
+          # ref: v5.2.1
           fetch-depth: 0
 
       - name: Build wheels
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           # uncomment to force a wheel build
-          ref: v5.2.1
+          # ref: v5.2.1
           fetch-depth: 0
 
       - name: Install pypa/build

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.19.1
         env:
-          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-*"
+          CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
           CIBW_SKIP: pp*
           CIBW_ARCHS_MACOS: "auto"
           CIBW_ARCHS_WINDOWS: "AMD64 x86"

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,6 +7,9 @@ on:
   release:
     types:
       - published
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build_wheels:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.19.1
+        uses: pypa/cibuildwheel@v2.21.3
         env:
           CIBW_BUILD: "cp39-* cp310-* cp311-* cp312-* cp313-*"
           CIBW_SKIP: pp*

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -68,24 +68,24 @@ jobs:
           name: artifact-sdist
           path: dist/*.tar.gz
 
-  upload_all:
-    name: upload to PyPI
-    needs: [build_wheels, build_sdist]
-    runs-on: ubuntu-latest
-    environment:
-      name: publish_pypi
-      url: https://pypi.org/p/pyamg
-    permissions:
-      id-token: write
-    steps:
-    - name: retrieve artifacts
-      uses: actions/download-artifact@v4
-      with:
-        pattern: artifact-*
-        merge-multiple: true
-        path: dist
-    - name: publish to pypi
-      uses: pypa/gh-action-pypi-publish@v1.9.0
-      with:
-        # uncomment to force a wheel build
-        skip-existing: true
+  # upload_all:
+  #   name: upload to PyPI
+  #   needs: [build_wheels, build_sdist]
+  #   runs-on: ubuntu-latest
+  #   environment:
+  #     name: publish_pypi
+  #     url: https://pypi.org/p/pyamg
+  #   permissions:
+  #     id-token: write
+  #   steps:
+  #   - name: retrieve artifacts
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       pattern: artifact-*
+  #       merge-multiple: true
+  #       path: dist
+  #   - name: publish to pypi
+  #     uses: pypa/gh-action-pypi-publish@v1.9.0
+  #     with:
+  #       # uncomment to force a wheel build
+  #       skip-existing: true

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -7,13 +7,6 @@ on:
   release:
     types:
       - published
-  pull_request:
-    branches:
-      - main
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
-  cancel-in-progress: true
 
 jobs:
   build_wheels:
@@ -72,24 +65,24 @@ jobs:
           name: artifact-sdist
           path: dist/*.tar.gz
 
-  # upload_all:
-  #   name: upload to PyPI
-  #   needs: [build_wheels, build_sdist]
-  #   runs-on: ubuntu-latest
-  #   environment:
-  #     name: publish_pypi
-  #     url: https://pypi.org/p/pyamg
-  #   permissions:
-  #     id-token: write
-  #   steps:
-  #   - name: retrieve artifacts
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       pattern: artifact-*
-  #       merge-multiple: true
-  #       path: dist
-  #   - name: publish to pypi
-  #     uses: pypa/gh-action-pypi-publish@v1.9.0
-  #     with:
-  #       # uncomment to force a wheel build
-  #       skip-existing: true
+  upload_all:
+    name: upload to PyPI
+    needs: [build_wheels, build_sdist]
+    runs-on: ubuntu-latest
+    environment:
+      name: publish_pypi
+      url: https://pypi.org/p/pyamg
+    permissions:
+      id-token: write
+    steps:
+    - name: retrieve artifacts
+      uses: actions/download-artifact@v4
+      with:
+        pattern: artifact-*
+        merge-multiple: true
+        path: dist
+    - name: publish to pypi
+      uses: pypa/gh-action-pypi-publish@v1.9.0
+      with:
+        # uncomment to force a wheel build
+        skip-existing: true


### PR DESCRIPTION
I noticed there weren't any Python 3.13 wheels because in one of the scikit-learn build, we have Python 3.13 and install pyamg with pip and it takes a bit of time because there is no Python 3.13 wheel yet and we have to build from source.

I created this PR mostly to investigate whether there were some complications with Python 3.13.