### PR TITLE
feat: support scipy sparse arrays while still supporting sparse matrices

### DIFF
--- a/docs/logo/pyamg_logo.py
+++ b/docs/logo/pyamg_logo.py
@@ -46,7 +46,7 @@ def plotaggs(AggOp, V, E, G,
             todraw.append(newobj)
 
         for i in aggids:                                   # for each point in the aggregate
-            nbrs = G.getrow(i).indices                     # get the neighbors in the graph
+            nbrs = G[i, :].indices                         # get the neighbors in the graph
 
             for j1 in nbrs:                                # for each neighbor
                 found = False                              # mark if triangle is found

--- a/pyamg/aggregation/adaptive.py
+++ b/pyamg/aggregation/adaptive.py
@@ -69,7 +69,7 @@ def eliminate_local_candidates(x, AggOp, A, T, thresh=1.0, **kwargs):
         z = np.ravel(z)*np.ravel(z)
         innerp = np.zeros((1, AggOp.shape[1]), dtype=z.dtype)
         for j in range(npde):
-            innerp += z[slice(j, ndof, npde)].reshape(1, -1) * AggOp
+            innerp += z[slice(j, ndof, npde)].reshape(1, -1) @ AggOp
 
         return innerp.reshape(-1, 1)
 
@@ -83,7 +83,7 @@ def eliminate_local_candidates(x, AggOp, A, T, thresh=1.0, **kwargs):
         """
         _ = ndof
         rho = approximate_spectral_radius(A)
-        zAz = np.dot(z.reshape(1, -1), A*z.reshape(-1, 1))
+        zAz = np.dot(z.reshape(1, -1), A@z.reshape(-1, 1))
         card = npde * (AggOp.indptr[1:]-AggOp.indptr[:-1])
         weights = (np.ravel(card)*zAz)/(A.shape[0]*rho)
         return weights.reshape(-1, 1)
@@ -94,7 +94,7 @@ def eliminate_local_candidates(x, AggOp, A, T, thresh=1.0, **kwargs):
 
     # Run test 2, which finds where x is already approximated
     # accurately by the existing T
-    projected_x = x - T*(T.T*x)
+    projected_x = x - T@(T.T@x)
     mask2 = aggregate_wise_inner_product(projected_x,
                                          AggOp, npde, ndof) <= weights
 

--- a/pyamg/aggregation/aggregate.py
+++ b/pyamg/aggregation/aggregate.py
@@ -234,7 +234,7 @@ def pairwise_aggregation(A, matchings=2, theta=0.25,
 
     """
     # Get SOC matrix
-    if A.format not in ('bsr', 'csr'):
+    if not sparse.issparse(A) or A.format not in ('bsr', 'csr'):
         try:
             A = A.tocsr()
             warn('Implicit conversion of A to csr', sparse.SparseEfficiencyWarning)
@@ -250,7 +250,7 @@ def pairwise_aggregation(A, matchings=2, theta=0.25,
     for i in range(0, matchings):
 
         # Compute SOC matrix for this matching
-        if A.format == 'bsr':
+        if sparse.issparse(A) and A.format == 'bsr':
             C = classical_strength_of_connection(A=Ac, theta=theta, block=True, norm=norm)
         else:
             C = classical_strength_of_connection(A=Ac, theta=theta, block=False, norm=norm)
@@ -276,7 +276,7 @@ def pairwise_aggregation(A, matchings=2, theta=0.25,
             shape = (num_rows, num_aggregates)
             Tp = np.arange(num_rows+1, dtype=index_type)
             # If A is not BSR
-            if A.format != 'bsr':
+            if not sparse.issparse(A) or A.format != 'bsr':
                 Tx = np.ones(len(Tj), dtype='int8')
                 T_temp = sparse.csr_matrix((Tx, Tj, Tp), shape=shape)
             else:
@@ -287,7 +287,7 @@ def pairwise_aggregation(A, matchings=2, theta=0.25,
         # Form aggregation matrix, need to make sure is CSR/BSR
         if i == 0:
             T = T_temp
-        elif A.format == 'bsr':
+        elif sparse.issparse(A) and A.format == 'bsr':
             T = sparse.bsr_matrix(T @ T_temp)
         else:
             T = sparse.csr_matrix(T @ T_temp)
@@ -298,7 +298,7 @@ def pairwise_aggregation(A, matchings=2, theta=0.25,
 
         # Form coarse grid operator for next matching
         if i < (matchings-1):
-            if T_temp.format == 'csr':
+            if sparse.issparse(T_temp) and T_temp.format == 'csr':
                 Ac = T_temp.T.tocsr() @ Ac @ T_temp
             else:
                 Ac = T_temp.T @ Ac @ T_temp

--- a/pyamg/aggregation/aggregation.py
+++ b/pyamg/aggregation/aggregation.py
@@ -7,7 +7,7 @@ from scipy.sparse import csr_matrix, issparse, SparseEfficiencyWarning
 
 from pyamg.multilevel import MultilevelSolver
 from pyamg.relaxation.smoothing import change_smoothers
-from pyamg.util.utils import eliminate_diag_dom_nodes, get_blocksize, \
+from pyamg.util.utils import eliminate_diag_dom_nodes, get_blocksize, asfptype, \
     levelize_strength_or_aggregation, levelize_smooth_or_improve_candidates
 from pyamg.strength import classical_strength_of_connection, \
     symmetric_strength_of_connection, evolution_strength_of_connection, \
@@ -218,12 +218,7 @@ def smoothed_aggregation_solver(A, B=None, BH=None,
             raise TypeError('Argument A must have type csr_matrix or bsr_matrix, '
                             'or be convertible to csr_matrix') from e
 
-    # convert to smallest compatible dtype if needed
-    if A.dtype.char not in 'fdFD':
-        for fp_type in 'fdFD':
-            if A.dtype <= np.dtype(fp_type):
-                A = A.astype(fp_type)
-                break
+    A = asfptype(A)
 
     if symmetry not in ('symmetric', 'hermitian', 'nonsymmetric'):
         raise ValueError('Expected "symmetric", "nonsymmetric" or "hermitian" '

--- a/pyamg/aggregation/rootnode.py
+++ b/pyamg/aggregation/rootnode.py
@@ -381,10 +381,10 @@ def _extend_hierarchy(levels, strength, aggregate, smooth, improve_candidates,
     fn, kwargs = unpack_arg(improve_candidates[len(levels)-1])
     if fn is not None:
         b = np.zeros((A.shape[0], 1), dtype=A.dtype)
-        B = relaxation_as_linear_operator((fn, kwargs), A, b) * B
+        B = relaxation_as_linear_operator((fn, kwargs), A, b) @ B
         levels[-1].B = B
         if A.symmetry == 'nonsymmetric':
-            BH = relaxation_as_linear_operator((fn, kwargs), AH, b) * BH
+            BH = relaxation_as_linear_operator((fn, kwargs), AH, b) @ BH
             levels[-1].BH = BH
 
     # Compute the tentative prolongator, T, which is a tentative interpolation

--- a/pyamg/aggregation/rootnode.py
+++ b/pyamg/aggregation/rootnode.py
@@ -10,7 +10,7 @@ from ..relaxation.smoothing import change_smoothers
 from ..relaxation.utils import relaxation_as_linear_operator
 from ..util.utils import scale_T, get_Cpt_params, \
     eliminate_diag_dom_nodes, get_blocksize, \
-    levelize_strength_or_aggregation, \
+    levelize_strength_or_aggregation, asfptype, \
     levelize_smooth_or_improve_candidates
 from ..strength import classical_strength_of_connection, \
     symmetric_strength_of_connection, evolution_strength_of_connection, \
@@ -239,12 +239,7 @@ def rootnode_solver(A, B=None, BH=None,
             raise TypeError('Argument A must have type csr_matrix, '
                             'bsr_matrix, or be convertible to csr_matrix') from e
 
-    # convert to smallest compatible dtype if needed
-    if A.dtype.char not in 'fdFD':
-        for fp_type in 'fdFD':
-            if A.dtype <= np.dtype(fp_type):
-                A = A.astype(fp_type)
-                break
+    A = asfptype(A)
 
     if symmetry not in ('symmetric', 'hermitian', 'nonsymmetric'):
         raise ValueError('Expected "symmetric", "nonsymmetric" '

--- a/pyamg/aggregation/smooth.py
+++ b/pyamg/aggregation/smooth.py
@@ -132,9 +132,9 @@ def jacobi_prolongation_smoother(S, T, C, B, omega=4.0/3.0, degree=1,
     """
     # preprocess weighting
     if weighting == 'block':
-        if S.format == 'csr':
+        if sparse.issparse(S) and S.format == 'csr':
             weighting = 'diagonal'
-        elif S.format == 'bsr':
+        elif sparse.issparse(S) and S.format == 'bsr':
             if S.blocksize[0] == 1:
                 weighting = 'diagonal'
         else:
@@ -144,7 +144,7 @@ def jacobi_prolongation_smoother(S, T, C, B, omega=4.0/3.0, degree=1,
         # Implement filtered prolongation smoothing for the general case by
         # utilizing satisfy constraints
 
-        if S.format == 'bsr':
+        if sparse.issparse(S) and S.format == 'bsr':
             numPDEs = S.blocksize[0]
         else:
             numPDEs = 1
@@ -1010,16 +1010,16 @@ def energy_prolongation_smoother(A, T, Atilde, B, Bf, Cpt_params,
     if tol > 1:
         raise ValueError('tol must be <= 1')
 
-    if A.format == 'csr':
+    if sparse.issparse(A) and A.format == 'csr':
         A = A.tobsr(blocksize=(1, 1), copy=False)
-    elif A.format == 'bsr':
+    elif sparse.issparse(A) and A.format == 'bsr':
         pass
     else:
         raise TypeError('A must be sparse BSR or CSR')
 
-    if T.format == 'csr':
+    if sparse.issparse(T) and T.format == 'csr':
         T = T.tobsr(blocksize=(1, 1), copy=False)
-    elif T.format == 'bsr':
+    elif sparse.issparse(T) and T.format == 'bsr':
         pass
     else:
         raise TypeError('T must be sparse BSR or CSR')

--- a/pyamg/aggregation/tentative.py
+++ b/pyamg/aggregation/tentative.py
@@ -2,7 +2,7 @@
 
 
 import numpy as np
-from scipy.sparse import isspmatrix_csr, bsr_matrix
+from scipy.sparse import issparse, bsr_matrix
 from pyamg import amg_core
 
 
@@ -114,7 +114,7 @@ def fit_candidates(AggOp, B, tol=1e-10):
            [1.        ]])
 
     """
-    if not isspmatrix_csr(AggOp):
+    if not issparse(AggOp) or AggOp.format != 'csr':
         raise TypeError('expected csr_matrix for argument AggOp')
 
     B = np.asarray(B)

--- a/pyamg/aggregation/tentative.py
+++ b/pyamg/aggregation/tentative.py
@@ -39,7 +39,7 @@ def fit_candidates(AggOp, B, tol=1e-10):
     -----
         Assuming that each row of AggOp contains exactly one non-zero entry,
         i.e. all unknowns belong to an aggregate, then Q and R satisfy the
-        relationship B = Q*R.  In other words, the near-nullspace candidates
+        relationship B = Q@R.  In other words, the near-nullspace candidates
         are represented exactly by the tentative prolongator.
 
         If AggOp contains rows with no non-zero entries, then the range of the

--- a/pyamg/aggregation/tests/test_adaptive.py
+++ b/pyamg/aggregation/tests/test_adaptive.py
@@ -189,7 +189,7 @@ class TestComplexAdaptiveSA(TestCase):
 #                assert_almost_equal(R_expected,R_result)
 #
 # each fine level candidate should be fit exactly
-#                assert_almost_equal(fine_candidates[:,:i+1],Q_result*R_result)
+#                assert_almost_equal(fine_candidates[:,:i+1],Q_result@R_result)
 #                assert_almost_equal(
-#                   Q_result*(Q_result.T*fine_candidates[:, :i+1]),
+#                   Q_result@(Q_result.T@fine_candidates[:, :i+1]),
 #                   fine_candidates[:, :i+1])

--- a/pyamg/aggregation/tests/test_aggregate.py
+++ b/pyamg/aggregation/tests/test_aggregate.py
@@ -43,7 +43,7 @@ class TestAggregate(TestCase):
             assert_equal(np.setdiff1d(Cpts, expected_Cpts).shape[0], 0)
 
         # S is diagonal - no dofs aggregated
-        S = sparse.spdiags([[1, 1, 1, 1]], [0], 4, 4, format='csr')
+        S = sparse.diags([[1, 1, 1, 1]], offsets=[0], shape=(4, 4), format='csr')
         (result, Cpts) = standard_aggregation(S)
         expected = np.array([[0], [0], [0], [0]])
         assert_equal(result.toarray(), expected)
@@ -61,7 +61,7 @@ class TestAggregate(TestCase):
             assert_equal(np.setdiff1d(Cpts, expected_Cpts).shape[0], 0)
 
         # S is diagonal - no dofs aggregated
-        S = sparse.spdiags([[1, 1, 1, 1]], [0], 4, 4, format='csr')
+        S = sparse.diags([[1, 1, 1, 1]], offsets=[0], shape=(4, 4), format='csr')
         (result, Cpts) = naive_aggregation(S)
         expected = np.eye(4)
         assert_equal(result.toarray(), expected)
@@ -78,7 +78,7 @@ class TestAggregate(TestCase):
             assert_equal(np.setdiff1d(Cpts, expected_Cpts).shape[0], 0)
 
         # S is diagonal - no dofs aggregated
-        S = sparse.spdiags([[1.0, 1.0, 1.0, 1.0]], [0], 4, 4, format='csr')
+        S = sparse.diags([[1, 1, 1, 1]], offsets=[0], shape=(4, 4), format='csr')
         (result, Cpts) = pairwise_aggregation(S, matchings=1, theta=0.25, norm='min')
         expected = np.eye(4)
         assert_equal(result.todense(), expected)

--- a/pyamg/aggregation/tests/test_aggregation.py
+++ b/pyamg/aggregation/tests/test_aggregation.py
@@ -27,7 +27,7 @@ class TestParameters(TestCase):
             np.random.seed(1883275855)  # make tests repeatable
 
             x = np.random.rand(A.shape[0])
-            b = A * np.random.rand(A.shape[0])
+            b = A @ np.random.rand(A.shape[0])
 
             residuals = []
             x_sol = ml.solve(b, x0=x, maxiter=30, tol=1e-10, residuals=residuals)
@@ -104,7 +104,7 @@ class TestComplexParameters(TestCase):
             np.random.seed(776825606)  # make tests repeatable
 
             x = np.random.rand(A.shape[0]) + 1.0j * np.random.rand(A.shape[0])
-            b = A * np.random.rand(A.shape[0])
+            b = A @ np.random.rand(A.shape[0])
             residuals = []
 
             x_sol = ml.solve(b, x0=x, maxiter=30, tol=1e-10, residuals=residuals)
@@ -200,7 +200,7 @@ class TestSolverPerformance(TestCase):
             np.random.seed(3009521727)  # make tests repeatable
 
             x = np.random.rand(A.shape[0])
-            b = A * np.random.rand(A.shape[0])
+            b = A @ np.random.rand(A.shape[0])
 
             residuals = []
             x_sol = ml.solve(b, x0=x, maxiter=20, tol=1e-10,
@@ -225,14 +225,14 @@ class TestSolverPerformance(TestCase):
         D = D.tocsr()
         D_inv = diag_sparse(1.0 / D.data)
 
-        # DAD = D * A * D
+        # DAD = D @ A @ D
 
         B = np.ones((A.shape[0], 1))
 
         # TODO force 2 level method and check that result is the same
         kwargs = {'max_coarse': 1, 'max_levels': 2, 'coarse_solver': 'splu'}
 
-        sa = smoothed_aggregation_solver(D * A * D, D_inv * B, **kwargs)
+        sa = smoothed_aggregation_solver(D @ A @ D, D_inv @ B, **kwargs)
 
         residuals = []
         x_sol = sa.solve(b, x0=x, maxiter=10, tol=1e-12, residuals=residuals)
@@ -312,7 +312,7 @@ class TestSolverPerformance(TestCase):
                 np.random.seed(3849986793)
                 x = np.random.rand(n,)
                 y = np.random.rand(n,)
-                out = (np.dot(P * x, y), np.dot(x, P * y))
+                out = (np.dot(P @ x, y), np.dot(x, P @ y))
                 # print("smoother = %s %g %g" % (smoother, out[0], out[1]))
                 assert_approx_equal(out[0], out[1])
 
@@ -323,7 +323,7 @@ class TestSolverPerformance(TestCase):
         B = data['B']
         np.random.seed(355704255)
         x0 = np.random.rand(A.shape[0])
-        b = A * np.random.rand(A.shape[0])
+        b = A @ np.random.rand(A.shape[0])
         # solver parameters
         smooth = ('energy', {'krylov': 'gmres'})
         SA_build_args = {'max_coarse': 25, 'coarse_solver': 'pinv',
@@ -490,7 +490,7 @@ class TestComplexSolverPerformance(TestCase):
             np.random.seed(2113979713)  # make tests repeatable
 
             x = np.random.rand(A.shape[0]) + 1.0j * np.random.rand(A.shape[0])
-            b = A * np.random.rand(A.shape[0])
+            b = A @ np.random.rand(A.shape[0])
             residuals = []
 
             x_sol = ml.solve(b, x0=x, maxiter=20, tol=1e-10,
@@ -512,7 +512,7 @@ class TestComplexSolverPerformance(TestCase):
         B = data['B']
         np.random.seed(28082572)
         x0 = np.random.rand(A.shape[0]) + 1.0j * np.random.rand(A.shape[0])
-        b = A * np.random.rand(A.shape[0]) + 1.0j * (A * np.random.rand(A.shape[0]))
+        b = A @ np.random.rand(A.shape[0]) + 1.0j * (A @ np.random.rand(A.shape[0]))
         # solver parameters
         smooth = ('energy', {'krylov': 'gmres'})
         SA_build_args = {'max_coarse': 25, 'coarse_solver': 'pinv',

--- a/pyamg/aggregation/tests/test_pairwise.py
+++ b/pyamg/aggregation/tests/test_pairwise.py
@@ -23,7 +23,7 @@ class TestPairwise(TestCase):
 
                 np.random.seed(0)  # make tests repeatable
                 x = np.random.rand(A.shape[0])
-                b = A*np.random.rand(A.shape[0])
+                b = A@np.random.rand(A.shape[0])
 
                 ml = pairwise_solver(A, aggregate=agg, max_coarse=10)
 

--- a/pyamg/aggregation/tests/test_rootnode.py
+++ b/pyamg/aggregation/tests/test_rootnode.py
@@ -29,7 +29,7 @@ class TestParameters(TestCase):
             np.random.seed(0)  # make tests repeatable
 
             x = np.random.rand(A.shape[0])
-            b = A * np.random.rand(A.shape[0])
+            b = A @ np.random.rand(A.shape[0])
 
             residuals = []
             x_sol = ml.solve(b, x0=x, maxiter=30, tol=1e-10,
@@ -107,7 +107,7 @@ class TestComplexParameters(TestCase):
             np.random.seed(0)  # make tests repeatable
 
             x = np.random.rand(A.shape[0]) + 1.0j * np.random.rand(A.shape[0])
-            b = A * np.random.rand(A.shape[0])
+            b = A @ np.random.rand(A.shape[0])
             residuals = []
 
             x_sol = ml.solve(b, x0=x, maxiter=30, tol=1e-10,
@@ -200,7 +200,7 @@ class TestSolverPerformance(TestCase):
             np.random.seed(0)  # make tests repeatable
 
             x = np.random.rand(A.shape[0])
-            b = A * np.random.rand(A.shape[0])
+            b = A @ np.random.rand(A.shape[0])
 
             residuals = []
             x_sol = ml.solve(b, x0=x, maxiter=20, tol=1e-10,
@@ -226,14 +226,14 @@ class TestSolverPerformance(TestCase):
         D = D.tocsr()
         D_inv = diag_sparse(1.0 / D.data)
 
-        # DAD = D * A * D
+        # DAD = D @ A @ D
 
         B = np.ones((A.shape[0], 1))
 
         # TODO force 2 level method and check that result is the same
         kwargs = {'max_coarse': 1, 'max_levels': 2, 'coarse_solver': 'splu'}
 
-        sa = rootnode_solver(D * A * D, D_inv * B, **kwargs)
+        sa = rootnode_solver(D @ A @ D, D_inv @ B, **kwargs)
 
         residuals = []
         x_sol = sa.solve(b, x0=x, maxiter=10, tol=1e-12, residuals=residuals)
@@ -309,7 +309,7 @@ class TestSolverPerformance(TestCase):
                 P = ml.aspreconditioner()
                 x = np.random.rand(n,)
                 y = np.random.rand(n,)
-                assert_approx_equal(np.dot(P * x, y), np.dot(x, P * y))
+                assert_approx_equal(np.dot(P @ x, y), np.dot(x, P @ y))
 
     def test_nonsymmetric(self):
         # problem data
@@ -318,7 +318,7 @@ class TestSolverPerformance(TestCase):
         B = data['B']
         np.random.seed(625)
         x0 = np.random.rand(A.shape[0])
-        b = A * np.random.rand(A.shape[0])
+        b = A @ np.random.rand(A.shape[0])
         # solver parameters
         smooth = ('energy', {'krylov': 'gmres'})
         SA_build_args = {'max_coarse': 25, 'coarse_solver': 'pinv',
@@ -471,7 +471,7 @@ class TestComplexSolverPerformance(TestCase):
             np.random.seed(0)  # make tests repeatable
 
             x = np.random.rand(A.shape[0]) + 1.0j * np.random.rand(A.shape[0])
-            b = A * np.random.rand(A.shape[0])
+            b = A @ np.random.rand(A.shape[0])
             residuals = []
 
             x_sol = ml.solve(b, x0=x, maxiter=20, tol=1e-10,

--- a/pyamg/aggregation/tests/test_smooth.py
+++ b/pyamg/aggregation/tests/test_smooth.py
@@ -461,7 +461,7 @@ class TestEnergyMin(TestCase):
 
         def _get_blocksize(A):
             # Helper Function: return the blocksize of a matrix
-            if A.format == 'bsr':
+            if sparse.issparse(A) and A.format == 'bsr':
                 return A.blocksize[0]
 
             return 1

--- a/pyamg/aggregation/tests/test_smooth.py
+++ b/pyamg/aggregation/tests/test_smooth.py
@@ -26,7 +26,7 @@ class TestEnergyMin(TestCase):
             S = S.copy()   # don't overwrite the original S
 
             S.data[:] = 1.0
-            SS = A * B
+            SS = A @ B
             SS = SS.multiply(S)
 
             # Union the sparsity patterns of SS and S, storing
@@ -457,11 +457,11 @@ class TestEnergyMin(TestCase):
             P = ml.levels[0].P
             B = ml.levels[0].B
             R = ml.levels[1].B
-            assert_almost_equal(P * R, B)
+            assert_almost_equal(P @ R, B)
 
         def _get_blocksize(A):
             # Helper Function: return the blocksize of a matrix
-            if sparse.isspmatrix_bsr(A):
+            if A.format == 'bsr':
                 return A.blocksize[0]
 
             return 1
@@ -496,8 +496,8 @@ class TestEnergyMin(TestCase):
                 # P should preserve B in its range, wherever P
                 # has enough nonzeros
                 mask = ((P.indptr[1:] - P.indptr[:-1]) >= B.shape[1])
-                assert_almost_equal((P*Bc)[mask, :], Bf[mask, :])
-                assert_almost_equal((P*Bc)[mask, :], Bf_H[mask, :])
+                assert_almost_equal((P@Bc)[mask, :], Bf[mask, :])
+                assert_almost_equal((P@Bc)[mask, :], Bf_H[mask, :])
 
                 # P should be the identity at Cpts
                 I1 = sparse.eye(T.shape[1], T.shape[1], format='csr', dtype=T.dtype)

--- a/pyamg/aggregation/tests/test_tentative.py
+++ b/pyamg/aggregation/tests/test_tentative.py
@@ -181,5 +181,5 @@ class TestFitCandidates(TestCase):
             Q, coarse_candidates = fit_candidates(AggOp, fine_candidates)
 
             # each fine level candidate should be fit (almost) exactly
-            assert_almost_equal(fine_candidates, Q * coarse_candidates)
-            assert_almost_equal(Q * (Q.T.conjugate() * fine_candidates), fine_candidates)
+            assert_almost_equal(fine_candidates, Q @ coarse_candidates)
+            assert_almost_equal(Q @ (Q.T.conjugate() @ fine_candidates), fine_candidates)

--- a/pyamg/blackbox.py
+++ b/pyamg/blackbox.py
@@ -263,7 +263,7 @@ def solve(A, b, x0=None, tol=1e-5, maxiter=400, return_solver=False,
     >>> A = poisson((40,40),format='csr')
     >>> b = np.array(np.arange(A.shape[0]), dtype=float)
     >>> x = solve(A,b,verb=False)
-    >>> print(f'{norm(b - A*x)/norm(b):1.2e}')
+    >>> print(f'{norm(b - A@x)/norm(b):1.2e}')
     6.28e-06
 
     """
@@ -311,11 +311,11 @@ def solve(A, b, x0=None, tol=1e-5, maxiter=400, return_solver=False,
                               callback=callback2, residuals=residuals)
 
     if verb:
-        r0 = b - A * x0
-        rk = b - A * x
+        r0 = b - A @ x0
+        rk = b - A @ x
         M = existing_solver.aspreconditioner()
-        nr0 = np.sqrt(np.inner(np.conjugate(M * r0), r0))
-        nrk = np.sqrt(np.inner(np.conjugate(M * rk), rk))
+        nr0 = np.sqrt(np.inner(np.conjugate(M @ r0), r0))
+        nrk = np.sqrt(np.inner(np.conjugate(M @ rk), rk))
         print(f'  Residuals ||r_k||_M, ||r_0||_M = {nrk:1.2e}, {nr0:1.2e}')
         if np.abs(nr0) > 1e-15:
             ratio = nrk / nr0

--- a/pyamg/blackbox.py
+++ b/pyamg/blackbox.py
@@ -6,6 +6,7 @@ from scipy.sparse import issparse, csr_matrix
 
 from .aggregation import smoothed_aggregation_solver
 from .util.linalg import ishermitian
+from .util.utils import asfptype
 
 
 def make_csr(A):
@@ -43,12 +44,7 @@ def make_csr(A):
     if A.shape[0] != A.shape[1]:
         raise TypeError('Argument A must be a square')
 
-    # convert to smallest compatible dtype if needed
-    if A.dtype.char not in 'fdFD':
-        for fp_type in 'fdFD':
-            if A.dtype <= np.dtype(fp_type):
-                A = A.astype(fp_type)
-                break
+    A = asfptype(A)
 
     return A
 
@@ -121,7 +117,7 @@ def solver_configuration(A, B=None, verb=True):
     # Determine near null-space modes B
     if B is None:
         # B is the constant for each variable in a node
-        if A.format == 'bsr' and A.blocksize[0] > 1:
+        if issparse(A) and A.format == 'bsr' and A.blocksize[0] > 1:
             bsize = A.blocksize[0]
             config['B'] = np.kron(np.ones((int(A.shape[0] / bsize), 1),
                                           dtype=A.dtype), np.eye(bsize))

--- a/pyamg/classical/classical.py
+++ b/pyamg/classical/classical.py
@@ -14,6 +14,7 @@ from pyamg.strength import classical_strength_of_connection, \
 from pyamg.classical.interpolate import direct_interpolation, classical_interpolation
 from . import split
 from .cr import CR
+from ..util.utils import asfptype
 
 
 def ruge_stuben_solver(A,
@@ -102,11 +103,7 @@ def ruge_stuben_solver(A,
             raise TypeError('Argument A must have type csr_matrix, '
                             'or be convertible to csr_matrix') from e
     # preprocess A
-    if A.dtype.char not in 'fdFD':
-        for fp_type in 'fdFD':
-            if A.dtype <= np.dtype(fp_type):
-                A = A.astype(fp_type)
-                break
+    A = asfptype(A)
     if A.shape[0] != A.shape[1]:
         raise ValueError('expected square matrix')
 

--- a/pyamg/classical/split.py
+++ b/pyamg/classical/split.py
@@ -89,7 +89,7 @@ References
 
 """
 import numpy as np
-from scipy.sparse import csr_matrix, isspmatrix_csr
+from scipy.sparse import csr_matrix, issparse
 
 from pyamg.graph import vertex_coloring
 from pyamg import amg_core
@@ -132,7 +132,7 @@ def RS(S, second_pass=False):
        SIAM: Philadelphia, PA, 1987; 73-130.
 
     """
-    if not isspmatrix_csr(S):
+    if not issparse(S) or S.format != 'csr':
         raise TypeError('expected csr_matrix')
     S = remove_diagonal(S)
 
@@ -270,7 +270,7 @@ def CLJP(S, color=False):
        Numerical Linear Algebra with Applications 2007; 14:611-643.
 
     """
-    if not isspmatrix_csr(S):
+    if not issparse(S) or S.format != 'csr':
         raise TypeError('expected csr_matrix')
     S = remove_diagonal(S)
 
@@ -360,7 +360,7 @@ def MIS(G, weights, maxiter=None):
     fn = amg_core.maximal_independent_set_parallel
 
     """
-    if not isspmatrix_csr(G):
+    if not issparse(G) or G.format != 'csr':
         raise TypeError('expected csr_matrix')
     G = remove_diagonal(G)
 
@@ -416,7 +416,7 @@ def _preprocess(S, coloring_method=None):
         - Augments weights with graph coloring (if use_color == True)
 
     """
-    if not isspmatrix_csr(S):
+    if not issparse(S) or S.format != 'csr':
         raise TypeError('expected csr_matrix')
 
     if S.shape[0] != S.shape[1]:

--- a/pyamg/classical/tests/test_air.py
+++ b/pyamg/classical/tests/test_air.py
@@ -17,14 +17,14 @@ class TestAIR(TestCase):
 
         for n in sizes:
             # CSR case
-            A = diags([np.ones((n,)), -1*np.ones((n-1,))], [0, -1]).tocsr()
+            A = diags([np.ones((n,)), -1*np.ones((n-1,))], offsets=[0, -1], format='csr')
             f_relax = ('fc_jacobi', {'iterations': 1, 'f_iterations': 1,
                        'c_iterations': 0})
             ml = air_solver(A, postsmoother=f_relax, max_levels=2)
 
             res = []
             x = np.random.rand(A.shape[0])
-            b = A*np.random.rand(A.shape[0])  # zeros_like(x)
+            b = A@np.random.rand(A.shape[0])  # zeros_like(x)
             x_sol = ml.solve(b, x0=x, maxiter=1, tol=1e-12, residuals=res)
             del x_sol
             assert (res[1] < 1e-12)
@@ -44,7 +44,7 @@ class TestAIR(TestCase):
 
             res = []
             xb = np.random.rand(Ab.shape[0])
-            bb = Ab*np.random.rand(Ab.shape[0])  # zeros_like(x)
+            bb = Ab@np.random.rand(Ab.shape[0])  # zeros_like(x)
             x_sol = ml.solve(bb, x0=xb, maxiter=1, tol=1e-12, residuals=res)
             del x_sol
             assert (res[1] < 1e-12)
@@ -65,7 +65,7 @@ class TestAIR(TestCase):
 
                     np.random.seed(0)  # make tests repeatable
                     x = np.random.rand(A.shape[0])
-                    b = A*np.random.rand(A.shape[0])  # zeros_like(x)
+                    b = A@np.random.rand(A.shape[0])  # zeros_like(x)
 
                     ml = air_solver(A, interpolation=interp, restrict=restr, max_coarse=50)
 

--- a/pyamg/classical/tests/test_classical.py
+++ b/pyamg/classical/tests/test_classical.py
@@ -48,7 +48,7 @@ class TestRugeStubenFunctions(TestCase):
             S.data[:] = 1
 
             # check that all F-nodes are strongly connected to a C-node
-            assert (splitting + S*splitting).min() > 0
+            assert (splitting + S @ splitting).min() > 0
 
             # THIS IS NOT STRICTLY ENFORCED!
             # check that all strong connections S[i, j] satisfy either:
@@ -72,9 +72,9 @@ class TestRugeStubenFunctions(TestCase):
 
             # X now consists of strong F->F edges only
             #
-            # (S * S.T)[i, j] is the # of C nodes on which both i and j
+            # (S @ S.T)[i, j] is the # of C nodes on which both i and j
             # strongly depend (i.e. the number of k's where (2) holds)
-            # Y = (S*S.T) - X
+            # Y = (S @ S.T) - X
             # assert(Y.nnz == 0 or Y.data.min() > 0)
 
     def test_cljp_splitting(self):
@@ -89,7 +89,7 @@ class TestRugeStubenFunctions(TestCase):
             S.data[:] = 1
 
             # check that all F-nodes are strongly connected to a C-node
-            assert (splitting + S*splitting).min() > 0
+            assert (splitting + S @ splitting).min() > 0
 
     def test_cljpc_splitting(self):
         for A in self.cases:
@@ -103,7 +103,7 @@ class TestRugeStubenFunctions(TestCase):
             S.data[:] = 1
 
             # check that all F-nodes are strongly connected to a C-node
-            assert (splitting + S*splitting).min() > 0
+            assert (splitting + S @ splitting).min() > 0
 
     def test_direct_interpolation(self):
         for A in self.cases:
@@ -177,7 +177,7 @@ class TestSolverPerformance(TestCase):
 
                 np.random.seed(0)  # make tests repeatable
                 x = np.random.rand(A.shape[0])
-                b = A*np.random.rand(A.shape[0])  # zeros_like(x)
+                b = A @ np.random.rand(A.shape[0])  # zeros_like(x)
 
                 ml = ruge_stuben_solver(A, interpolation=interp, max_coarse=50)
 

--- a/pyamg/gallery/advection.py
+++ b/pyamg/gallery/advection.py
@@ -92,7 +92,7 @@ def advection_2d(grid, theta=np.pi/4.0, l_bdry=1.0, b_bdry=1.0):
 
     # Eliminate boundary DOFs
     bdry = np.concatenate((l_bdry.flatten(), b_bdry.flatten()))
-    rhs = -A[int_dofs, :][:, all_bdofs]*bdry
+    rhs = -A[int_dofs, :][:, all_bdofs] @ bdry
     A = A[int_dofs, :][:, int_dofs]
 
     return A, rhs

--- a/pyamg/gallery/elasticity.py
+++ b/pyamg/gallery/elasticity.py
@@ -128,9 +128,9 @@ def q12d(grid, spacing=None, E=1e5, nu=0.3, dirichlet_boundary=True,
         P = sparse.bsr_matrix((data, indices, indptr),
                               shape=(2*(X+1)*(Y+1), 2*(X-1)*(Y-1)))
         Pt = P.T
-        A = P.T * A * P
+        A = P.T @ A @ P
 
-        B = Pt * B
+        B = Pt @ B
 
     return A.asformat(format), B
 

--- a/pyamg/gallery/fem.py
+++ b/pyamg/gallery/fem.py
@@ -79,7 +79,7 @@ def generate_quadratic(V, E, return_edges=False):
     # make a vertext-to-vertex graph
     ID = np.kron(np.arange(0, ne), np.ones((3,), dtype=int))
     G = sparse.coo_matrix((np.ones((ne*3,), dtype=int), (E.ravel(), ID,)))
-    V2V = G * G.T
+    V2V = G @ G.T
 
     # from the vertex graph, get the edges and create new midpoints
     V2Vmid = sparse.tril(V2V, -1)
@@ -199,7 +199,7 @@ def refine2dtri(V, E, marked_elements=None):
     row = np.kron(np.arange(0, Nel), [1, 1, 1])
     data = np.ones((Nel*3,))
     V2V = sparse.coo_matrix((data, (row, col)), shape=(Nel, Nv))
-    V2V = V2V.T * V2V
+    V2V = V2V.T @ V2V
 
     # compute interior edges list
     V2V.data = np.ones(V2V.data.shape)
@@ -931,7 +931,7 @@ def applybc(A, b, mesh, bc):
         u0[idx] = c['g'](X[idx], Y[idx])
 
     # lift (2 of 3)
-    b = b - A * u0
+    b = b - A @ u0
 
     # fix the values (3 of 3)
     for c in bc:

--- a/pyamg/gallery/tests/test_elasticity.py
+++ b/pyamg/gallery/tests/test_elasticity.py
@@ -33,7 +33,7 @@ class TestLinearElasticityP1(TestCase):
         """Check that rigid body modes lie in nullspace."""
         for V, E in self.cases:
             A, B = linear_elasticity_p1(V, E)
-            assert_almost_equal(A*B, 0*B)
+            assert_almost_equal(A @ B, 0*B)
 
 
 class TestLinearElasticityGrid(TestCase):

--- a/pyamg/graph.py
+++ b/pyamg/graph.py
@@ -9,7 +9,7 @@ from . import amg_core
 
 def asgraph(G):
     """Return (square) matrix as sparse."""
-    if not (sparse.isspmatrix_csr(G) or sparse.isspmatrix_csc(G)):
+    if not sparse.issparse(G) or G.format not in ('csc', 'csr'):
         G = sparse.csr_matrix(G)
 
     if G.shape[0] != G.shape[1]:

--- a/pyamg/krylov/_bicgstab.py
+++ b/pyamg/krylov/_bicgstab.py
@@ -67,7 +67,7 @@ def bicgstab(A, b, x0=None, tol=1e-5, criteria='rr',
     >>> A = poisson((10,10))
     >>> b = np.ones((A.shape[0],))
     >>> (x,flag) = bicgstab(A,b, maxiter=2, tol=1e-8)
-    >>> print(f'{norm(b - A*x):.6}')
+    >>> print(f'{norm(b - A@x):.6}')
     4.68163
 
     References

--- a/pyamg/krylov/_cg.py
+++ b/pyamg/krylov/_cg.py
@@ -70,7 +70,7 @@ def cg(A, b, x0=None, tol=1e-5, criteria='rr',
     >>> A = poisson((10,10))
     >>> b = np.ones((A.shape[0],))
     >>> (x,flag) = cg(A,b, maxiter=2, tol=1e-8)
-    >>> print(f'{norm(b - A*x):.6}')
+    >>> print(f'{norm(b - A@x):.6}')
     10.9371
 
     References

--- a/pyamg/krylov/_cgne.py
+++ b/pyamg/krylov/_cgne.py
@@ -73,7 +73,7 @@ def cgne(A, b, x0=None, tol=1e-5, criteria='rr',
     >>> A = poisson((10,10))
     >>> b = np.ones((A.shape[0],))
     >>> (x,flag) = cgne(A,b, maxiter=2, tol=1e-8)
-    >>> print(f'{norm(b - A*x):.6}')
+    >>> print(f'{norm(b - A@x):.6}')
     46.1547
 
     References

--- a/pyamg/krylov/_cgne.py
+++ b/pyamg/krylov/_cgne.py
@@ -84,7 +84,7 @@ def cgne(A, b, x0=None, tol=1e-5, criteria='rr',
 
     """
     # Store the conjugate transpose explicitly as it will be used much later on
-    if sparse.isspmatrix(A):
+    if sparse.issparse(A):
         AH = A.T.conjugate()
     else:
         # avoid doing this since A may be a different sparse type

--- a/pyamg/krylov/_cgnr.py
+++ b/pyamg/krylov/_cgnr.py
@@ -84,7 +84,7 @@ def cgnr(A, b, x0=None, tol=1e-5, criteria='rr',
 
     """
     # Store the conjugate transpose explicitly as it will be used much later on
-    if sparse.isspmatrix(A):
+    if sparse.issparse(A):
         AH = A.T.conjugate()
     else:
         # avoid doing this since A may be a different sparse type

--- a/pyamg/krylov/_cgnr.py
+++ b/pyamg/krylov/_cgnr.py
@@ -73,7 +73,7 @@ def cgnr(A, b, x0=None, tol=1e-5, criteria='rr',
     >>> A = poisson((10,10))
     >>> b = np.ones((A.shape[0],))
     >>> (x,flag) = cgnr(A,b, maxiter=2, tol=1e-8)
-    >>> print(f'{norm(b - A*x):.6}')
+    >>> print(f'{norm(b - A@x):.6}')
     9.39102
 
     References

--- a/pyamg/krylov/_cr.py
+++ b/pyamg/krylov/_cr.py
@@ -71,7 +71,7 @@ def cr(A, b, x0=None, tol=1e-5, criteria='rr',
     >>> A = poisson((10,10))
     >>> b = np.ones((A.shape[0],))
     >>> (x,flag) = cr(A,b, maxiter=2, tol=1e-8)
-    >>> print(f'{norm(b - A*x):.6}')
+    >>> print(f'{norm(b - A@x):.6}')
     6.54282
 
     References

--- a/pyamg/krylov/_fgmres.py
+++ b/pyamg/krylov/_fgmres.py
@@ -100,7 +100,7 @@ def fgmres(A, b, x0=None, tol=1e-5,
     >>> A = poisson((10,10))
     >>> b = np.ones((A.shape[0],))
     >>> (x,flag) = fgmres(A,b, maxiter=2, tol=1e-8)
-    >>> print(f'{norm(b - A*x):.6}')
+    >>> print(f'{norm(b - A@x):.6}')
     6.54282
 
     References

--- a/pyamg/krylov/_gmres.py
+++ b/pyamg/krylov/_gmres.py
@@ -91,7 +91,7 @@ def gmres(A, b, x0=None, tol=1e-5, restart=None, maxiter=None,
     >>> A = poisson((10,10))
     >>> b = np.ones((A.shape[0],))
     >>> (x,flag) = gmres(A,b, maxiter=2, tol=1e-8)
-    >>> print(f'{norm(b - A*x):.6}')
+    >>> print(f'{norm(b - A@x):.6}')
     6.54282
 
     References

--- a/pyamg/krylov/_gmres_householder.py
+++ b/pyamg/krylov/_gmres_householder.py
@@ -98,7 +98,7 @@ def gmres_householder(A, b, x0=None, tol=1e-5,
     >>> A = poisson((10, 10))
     >>> b = np.ones((A.shape[0],))
     >>> (x, flag) = gmres(A, b, maxiter=2, tol=1e-8, orthog='householder')
-    >>> print(f'{norm(b - A*x):.6}')
+    >>> print(f'{norm(b - A@x):.6}')
     6.54282
 
     References

--- a/pyamg/krylov/_gmres_mgs.py
+++ b/pyamg/krylov/_gmres_mgs.py
@@ -118,7 +118,7 @@ def gmres_mgs(A, b, x0=None, tol=1e-5,
     >>> A = poisson((10,10))
     >>> b = np.ones((A.shape[0],))
     >>> (x,flag) = gmres(A,b, maxiter=2, tol=1e-8, orthog='mgs')
-    >>> print(f'{norm(b - A*x):.6}')
+    >>> print(f'{norm(b - A@x):.6}')
     6.54282
 
     References

--- a/pyamg/krylov/_minimal_residual.py
+++ b/pyamg/krylov/_minimal_residual.py
@@ -78,7 +78,7 @@ def minimal_residual(A, b, x0=None, tol=1e-5,
     >>> A = poisson((10,10))
     >>> b = np.ones((A.shape[0],))
     >>> (x,flag) = minimal_residual(A,b, maxiter=2, tol=1e-8)
-    >>> print(f'{norm(b - A*x):.6}')
+    >>> print(f'{norm(b - A@x):.6}')
     7.26369
 
     References

--- a/pyamg/krylov/_steepest_descent.py
+++ b/pyamg/krylov/_steepest_descent.py
@@ -91,7 +91,7 @@ def steepest_descent(A, b, x0=None, tol=1e-5, criteria='rr',
 
     # determine maxiter
     if maxiter is None:
-        maxiter = int(len(b))
+        maxiter = len(b)
     elif maxiter < 1:
         raise ValueError('Number of iterations must be positive')
 

--- a/pyamg/krylov/_steepest_descent.py
+++ b/pyamg/krylov/_steepest_descent.py
@@ -74,7 +74,7 @@ def steepest_descent(A, b, x0=None, tol=1e-5, criteria='rr',
     >>> A = poisson((10,10))
     >>> b = np.ones((A.shape[0],))
     >>> (x,flag) = steepest_descent(A,b, maxiter=2, tol=1e-8)
-    >>> print(f'{norm(b - A*x):.6}')
+    >>> print(f'{norm(b - A@x):.6}')
     7.89436
 
     References

--- a/pyamg/multilevel.py
+++ b/pyamg/multilevel.py
@@ -416,7 +416,7 @@ class MultilevelSolver:
         >>> from pyamg import ruge_stuben_solver
         >>> from pyamg.gallery import poisson
         >>> A = poisson((100, 100), format='csr')
-        >>> b = A * ones(A.shape[0])
+        >>> b = A @ ones(A.shape[0])
         >>> ml = ruge_stuben_solver(A, max_coarse=10)
         >>> residuals = []
         >>> x = ml.solve(b, tol=1e-12, residuals=residuals) # standalone solver
@@ -592,7 +592,7 @@ class MultilevelSolver:
             p = np.zeros((nAMLI, coarse_b.shape[0]), dtype=coarse_b.dtype)
             beta = np.zeros((nAMLI, nAMLI), dtype=coarse_b.dtype)
             for k in range(nAMLI):
-                # New search direction --> M^{-1}*residual
+                # New search direction --> M^{-1}@residual
                 p[k, :] = 1
                 self.__solve(lvl + 1, p[k, :].reshape(coarse_b.shape),
                              coarse_b, cycle)
@@ -660,7 +660,7 @@ def coarse_grid_solver(solver):
     >>> from pyamg.gallery import poisson
     >>> from pyamg import coarse_grid_solver
     >>> A = poisson((10, 10), format='csr')
-    >>> b = A * np.ones(A.shape[0])
+    >>> b = A @ np.ones(A.shape[0])
     >>> cgs = coarse_grid_solver('lu')
     >>> x = cgs(A, b)
 

--- a/pyamg/multilevel.py
+++ b/pyamg/multilevel.py
@@ -599,12 +599,12 @@ class MultilevelSolver:
 
                 # Orthogonalize new search direction to old directions
                 for j in range(k):  # loops from j = 0...(k-1)
-                    beta[k, j] = np.inner(p[j, :].conj(), Ac * p[k, :]) /\
-                            np.inner(p[j, :].conj(), Ac * p[j, :])
+                    beta[k, j] = np.inner(p[j, :].conj(), Ac @ p[k, :]) /\
+                            np.inner(p[j, :].conj(), Ac @ p[j, :])
                     p[k, :] -= beta[k, j] * p[j, :]
 
                 # Compute step size
-                Ap = Ac * p[k, :]
+                Ap = Ac @ p[k, :]
                 alpha = np.inner(p[k, :].conj(), np.ravel(coarse_b)) /\
                         np.inner(p[k, :].conj(), Ap)
 
@@ -657,7 +657,6 @@ def coarse_grid_solver(solver):
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import spdiags
     >>> from pyamg.gallery import poisson
     >>> from pyamg import coarse_grid_solver
     >>> A = poisson((10, 10), format='csr')
@@ -703,11 +702,11 @@ def coarse_grid_solver(solver):
                 nonzero_cols = (diffptr != 0).nonzero()[0]
                 Map = sp.sparse.eye(Acsc.shape[0], Acsc.shape[1], format='csc')
                 Map = Map[:, nonzero_cols]
-                Acsc = Map.T.tocsc() * Acsc * Map
+                Acsc = Map.T.tocsc() @ Acsc @ Map
                 self.LU = sp.sparse.linalg.splu(Acsc, **kwargs)
                 self.LU_Map = Map
 
-            return self.LU_Map * self.LU.solve(np.ravel(self.LU_Map.T * b))
+            return self.LU_Map @ self.LU.solve(np.ravel(self.LU_Map.T @ b))
 
     elif solver in ['bicg', 'bicgstab', 'cg', 'cgs', 'gmres', 'qmr', 'minres']:
         if hasattr(krylov, solver):

--- a/pyamg/relaxation/relaxation.py
+++ b/pyamg/relaxation/relaxation.py
@@ -58,9 +58,9 @@ def make_system(A, x, b, formats=None):
     if formats is None:
         pass
     elif formats == ['csr']:
-        if A.format == 'csr':
+        if sparse.issparse(A) and A.format == 'csr':
             pass
-        elif A.format == 'bsr':
+        elif sparse.issparse(A) and A.format == 'bsr':
             A = A.tocsr()
         else:
             warn('implicit conversion to CSR', sparse.SparseEfficiencyWarning)
@@ -317,7 +317,7 @@ def gauss_seidel(A, x, b, iterations=1, sweep='forward'):
     """
     A, x, b = make_system(A, x, b, formats=['csr', 'bsr'])
 
-    if A.format == 'csr':
+    if sparse.issparse(A) and A.format == 'csr':
         blocksize = 1
     else:
         R, C = A.blocksize
@@ -337,7 +337,7 @@ def gauss_seidel(A, x, b, iterations=1, sweep='forward'):
     else:
         raise ValueError('valid sweep directions: "forward", "backward", and "symmetric"')
 
-    if A.format == 'csr':
+    if sparse.issparse(A) and A.format == 'csr':
         for _iter in range(iterations):
             amg_core.gauss_seidel(A.indptr, A.indices, A.data, x, b,
                                   row_start, row_stop, row_step)
@@ -1125,7 +1125,7 @@ def jacobi_indexed(A, x, b, indices, iterations=1, omega=1.0):
     # Create uniform type, convert possibly complex scalars to length 1 arrays
     [omega] = type_prep(A.dtype, [omega])
 
-    if A.format == 'csr':
+    if sparse.issparse(A) and A.format == 'csr':
         for _iter in range(iterations):
             amg_core.jacobi_indexed(A.indptr, A.indices, A.data, x, b, indices, omega)
     else:
@@ -1249,7 +1249,7 @@ def fc_jacobi(A, x, b, Cpts, Fpts, iterations=1, f_iterations=1,
     # Create uniform type, convert possibly complex scalars to length 1 arrays
     [omega] = type_prep(A.dtype, [omega])
 
-    if A.format == 'csr':
+    if sparse.issparse(A) and A.format == 'csr':
         for _iter in range(iterations):
             for _fiter in range(f_iterations):
                 amg_core.jacobi_indexed(A.indptr, A.indices, A.data, x, b, Fpts, omega)

--- a/pyamg/relaxation/smoothing.py
+++ b/pyamg/relaxation/smoothing.py
@@ -370,7 +370,7 @@ def change_smoothers(ml, presmoother, postsmoother):
 
 
 def rho_D_inv_A(A):
-    """Return the (approx.) spectral radius of D^-1 * A.
+    """Return the (approx.) spectral radius of D^-1 @ A.
 
     Parameters
     ----------
@@ -401,7 +401,7 @@ def rho_D_inv_A(A):
 
 
 def rho_block_D_inv_A(A, Dinv):
-    """Return the (approx.) spectral radius of block D^-1 * A.
+    """Return the (approx.) spectral radius of block D^-1 @ A.
 
     Parameters
     ----------
@@ -438,9 +438,9 @@ def rho_block_D_inv_A(A, Dinv):
                                   np.arange(Dinv.shape[0]+1)),
                                  shape=A.shape)
 
-        # Don't explicitly form Dinv*A
+        # Don't explicitly form Dinv @ A
         def matvec(x):
-            return Dinv*(A*x)
+            return Dinv @ (A @ x)
         D_inv_A = LinearOperator(A.shape, matvec, dtype=A.dtype)
 
         A.rho_block_D_inv = approximate_spectral_radius(D_inv_A)
@@ -554,9 +554,9 @@ def setup_block_jacobi(lvl, iterations=DEFAULT_NITER, omega=1.0, Dinv=None,
     """Set up block Jacobi."""
     # Determine Blocksize
     if blocksize is None and Dinv is None:
-        if sparse.isspmatrix_csr(lvl.A):
+        if lvl.A.format == 'csr':
             blocksize = 1
-        elif sparse.isspmatrix_bsr(lvl.A):
+        elif lvl.A.format == 'bsr':
             blocksize = lvl.A.blocksize[0]
     elif blocksize is None:
         blocksize = Dinv.shape[1]
@@ -585,9 +585,9 @@ def setup_block_gauss_seidel(lvl, iterations=DEFAULT_NITER,
     """Set up block Gauss-Seidel."""
     # Determine Blocksize
     if blocksize is None and Dinv is None:
-        if sparse.isspmatrix_csr(lvl.A):
+        if lvl.A.format == 'csr':
             blocksize = 1
-        elif sparse.isspmatrix_bsr(lvl.A):
+        elif lvl.A.format == 'bsr':
             blocksize = lvl.A.blocksize[0]
     elif blocksize is None:
         blocksize = Dinv.shape[1]
@@ -711,12 +711,12 @@ def setup_cf_block_jacobi(lvl, f_iterations=DEFAULT_NITER, c_iterations=DEFAULT_
     """Set up coarse-fine block Jacobi."""
     # Determine Blocksize
     if blocksize is None and Dinv is None:
-        if sparse.isspmatrix_csr(lvl.A):
+        if lvl.A.format == 'csr':
             blocksize = 1
-        elif sparse.isspmatrix_bsr(lvl.A):
+        elif lvl.A.format == 'bsr':
             blocksize = lvl.A.blocksize[0]
     elif blocksize is None:
-        if sparse.isspmatrix_bsr(Dinv):
+        if Dinv.format == 'bsr':
             blocksize = Dinv.blocksize[1]
         else:
             blocksize = 1
@@ -754,12 +754,12 @@ def setup_fc_block_jacobi(lvl, f_iterations=DEFAULT_NITER, c_iterations=DEFAULT_
     """Set up coarse-fine block Jacobi."""
     # Determine Blocksize
     if blocksize is None and Dinv is None:
-        if sparse.isspmatrix_csr(lvl.A):
+        if lvl.A.format == 'csr':
             blocksize = 1
-        elif sparse.isspmatrix_bsr(lvl.A):
+        elif lvl.A.format == 'bsr':
             blocksize = lvl.A.blocksize[0]
     elif blocksize is None:
-        if sparse.isspmatrix_bsr(Dinv):
+        if Dinv.format == 'bsr':
             blocksize = Dinv.blocksize[1]
         else:
             blocksize = 1

--- a/pyamg/relaxation/smoothing.py
+++ b/pyamg/relaxation/smoothing.py
@@ -554,9 +554,9 @@ def setup_block_jacobi(lvl, iterations=DEFAULT_NITER, omega=1.0, Dinv=None,
     """Set up block Jacobi."""
     # Determine Blocksize
     if blocksize is None and Dinv is None:
-        if lvl.A.format == 'csr':
+        if sparse.issparse(lvl.A) and lvl.A.format == 'csr':
             blocksize = 1
-        elif lvl.A.format == 'bsr':
+        elif sparse.issparse(lvl.A) and lvl.A.format == 'bsr':
             blocksize = lvl.A.blocksize[0]
     elif blocksize is None:
         blocksize = Dinv.shape[1]
@@ -585,9 +585,9 @@ def setup_block_gauss_seidel(lvl, iterations=DEFAULT_NITER,
     """Set up block Gauss-Seidel."""
     # Determine Blocksize
     if blocksize is None and Dinv is None:
-        if lvl.A.format == 'csr':
+        if sparse.issparse(lvl.A) and lvl.A.format == 'csr':
             blocksize = 1
-        elif lvl.A.format == 'bsr':
+        elif sparse.issparse(lvl.A) and lvl.A.format == 'bsr':
             blocksize = lvl.A.blocksize[0]
     elif blocksize is None:
         blocksize = Dinv.shape[1]
@@ -711,12 +711,12 @@ def setup_cf_block_jacobi(lvl, f_iterations=DEFAULT_NITER, c_iterations=DEFAULT_
     """Set up coarse-fine block Jacobi."""
     # Determine Blocksize
     if blocksize is None and Dinv is None:
-        if lvl.A.format == 'csr':
+        if sparse.issparse(lvl.A) and lvl.A.format == 'csr':
             blocksize = 1
-        elif lvl.A.format == 'bsr':
+        elif sparse.issparse(lvl.A) and lvl.A.format == 'bsr':
             blocksize = lvl.A.blocksize[0]
     elif blocksize is None:
-        if Dinv.format == 'bsr':
+        if sparse.issparse(Dinv) and Dinv.format == 'bsr':
             blocksize = Dinv.blocksize[1]
         else:
             blocksize = 1
@@ -754,12 +754,12 @@ def setup_fc_block_jacobi(lvl, f_iterations=DEFAULT_NITER, c_iterations=DEFAULT_
     """Set up coarse-fine block Jacobi."""
     # Determine Blocksize
     if blocksize is None and Dinv is None:
-        if lvl.A.format == 'csr':
+        if sparse.issparse(lvl.A) and lvl.A.format == 'csr':
             blocksize = 1
-        elif lvl.A.format == 'bsr':
+        elif sparse.issparse(lvl.A) and lvl.A.format == 'bsr':
             blocksize = lvl.A.blocksize[0]
     elif blocksize is None:
-        if Dinv.format == 'bsr':
+        if sparse.issparse(Dinv) and Dinv.format == 'bsr':
             blocksize = Dinv.blocksize[1]
         else:
             blocksize = 1

--- a/pyamg/strength.py
+++ b/pyamg/strength.py
@@ -712,12 +712,12 @@ def evolution_strength_of_connection(A, B=None, epsilon=4.0, k=2,
     del Dinv, Dinv_A, mask
 
     # Calculate strength based on constrained min problem of
-    # min( z - B*x ), such that
-    # (B*x)|_i = z|_i, i.e. they are equal at point i
+    # min( z - B@x ), such that
+    # (B@x)|_i = z|_i, i.e. they are equal at point i
     # z = (I - (t/k) Dinv A)^k delta_i
     #
     # Strength is defined as the relative point-wise approx. error between
-    # B*x and z.  We don't use the full z in this problem, only that part of
+    # B@x and z.  We don't use the full z in this problem, only that part of
     # z that is in the sparsity pattern of A.
     #
     # Can use either the D-norm, and inner product, or l2-norm and inner-prod
@@ -780,7 +780,7 @@ def evolution_strength_of_connection(A, B=None, epsilon=4.0, k=2,
         del data, weak_ratio, angle
 
     else:
-        # For use in computing local B_i^H*B, precompute the element-wise
+        # For use in computing local B_i^H@B, precompute the element-wise
         # multiply of each column of B with each other column.  We also scale
         # by 2.0 to account for BDB's eventual use in a constrained
         # minimization problem

--- a/pyamg/tests/test_blackbox.py
+++ b/pyamg/tests/test_blackbox.py
@@ -27,8 +27,8 @@ class TestBlackbox(TestCase):
         np.random.seed(3105563891)
         for A, b in self.cases:
             x = solve(A, b, verb=False, maxiter=A.shape[0])
-            norm1 = np.linalg.norm(b - A*x)
-            norm2 = np.linalg.norm(b - A*np.random.rand(b.shape[0],))
+            norm1 = np.linalg.norm(b - A@x)
+            norm2 = np.linalg.norm(b - A@np.random.rand(b.shape[0],))
             assert norm1 / norm2 < 1e-4
 
         # Special tests
@@ -40,8 +40,8 @@ class TestBlackbox(TestCase):
 
         # (2) Run with solver and make sure that solution is still good
         x = solve(A, b, existing_solver=ml, verb=False)
-        norm1 = np.linalg.norm(b - A*x)
-        norm2 = np.linalg.norm(b - A*np.random.rand(b.shape[0],))
+        norm1 = np.linalg.norm(b - A@x)
+        norm2 = np.linalg.norm(b - A@np.random.rand(b.shape[0],))
         assert norm1 / norm2 < 1e-4
 
         # (3) Convert to CSR, make sure B is a single vector
@@ -52,8 +52,8 @@ class TestBlackbox(TestCase):
         # (4) Run with x0, maxiter and tol
         x = solve(A, b, existing_solver=ml, x0=np.zeros_like(b), tol=1e-8,
                   maxiter=300, verb=False)
-        norm1 = np.linalg.norm(b - A*x)
-        norm2 = np.linalg.norm(b - A*np.random.rand(b.shape[0],))
+        norm1 = np.linalg.norm(b - A@x)
+        norm2 = np.linalg.norm(b - A@np.random.rand(b.shape[0],))
         assert norm1 / norm2 < 1e-7
 
         # (5) Run nonsymmetric example, make sure BH isn't None

--- a/pyamg/tests/test_graph.py
+++ b/pyamg/tests/test_graph.py
@@ -33,7 +33,7 @@ def assert_is_mis(G, mis):
     if G.nnz > 0:
         assert (mis[G.row] + mis[G.col]).max() <= 1
     # all non-set vertices have set neighbor
-    assert (mis + G*mis).min() == 1
+    assert (mis + G@mis).min() == 1
 
 
 def assert_is_vertex_coloring(G, c):

--- a/pyamg/tests/test_multilevel.py
+++ b/pyamg/tests/test_multilevel.py
@@ -36,11 +36,11 @@ class TestMultilevel(TestCase):
                 b = np.arange(A.shape[0], dtype=A.dtype)
 
                 x = s(A, b)
-                assert_almost_equal(A*x, b)
+                assert_almost_equal(A@x, b)
 
                 # subsequent calls use cached data
                 x = s(A, b)
-                assert_almost_equal(A*x, b)
+                assert_almost_equal(A@x, b)
 
     def test_aspreconditioner(self):
         from pyamg import smoothed_aggregation_solver
@@ -57,14 +57,14 @@ class TestMultilevel(TestCase):
             M = ml.aspreconditioner(cycle=cycle)
             x, _info = cg(A, b, M=M, rtol=1e-8, maxiter=30, atol=0)
             # cg satisfies convergence in the preconditioner norm
-            assert precon_norm(b - A*x, ml) < 1e-8*precon_norm(b, ml)
+            assert precon_norm(b - A@x, ml) < 1e-8*precon_norm(b, ml)
 
         for cycle in ['AMLI']:
             M = ml.aspreconditioner(cycle=cycle)
             res = []
             x, _info = fgmres(A, b, tol=1e-8, maxiter=30, M=M, residuals=res)
             # fgmres satisfies convergence in the 2-norm
-            assert np.linalg.norm(b - A*x) < 1e-8*np.linalg.norm(b)
+            assert np.linalg.norm(b - A@x) < 1e-8*np.linalg.norm(b)
 
     def test_accel(self):
         from pyamg import smoothed_aggregation_solver
@@ -80,15 +80,15 @@ class TestMultilevel(TestCase):
         for accel in ['cg', cg]:
             residuals = []
             x = ml.solve(b, maxiter=30, tol=1e-8, residuals=residuals, accel=accel)
-            assert precon_norm(b - A*x, ml) < 1e-8*precon_norm(b, ml)
-            assert_almost_equal(precon_norm(b - A*x, ml), residuals[-1])
+            assert precon_norm(b - A@x, ml) < 1e-8*precon_norm(b, ml)
+            assert_almost_equal(precon_norm(b - A@x, ml), residuals[-1])
 
         # cgs and bicgstab use the Euclidean norm
         for accel in ['bicgstab', 'cgs', bicgstab]:
             residuals = []
             x = ml.solve(b, maxiter=30, tol=1e-8, residuals=residuals, accel=accel)
-            assert np.linalg.norm(b - A*x) < 1e-8*np.linalg.norm(b)
-            assert_almost_equal(np.linalg.norm(b - A*x), residuals[-1])
+            assert np.linalg.norm(b - A@x) < 1e-8*np.linalg.norm(b)
+            assert_almost_equal(np.linalg.norm(b - A@x), residuals[-1])
 
     def test_cycle_complexity(self):
         # four levels
@@ -154,8 +154,8 @@ class TestComplexMultilevel(TestCase):
                 b = np.arange(A.shape[0], dtype=A.dtype)
 
                 x = s(A, b)
-                assert_almost_equal(A*x, b)
+                assert_almost_equal(A@x, b)
 
                 # subsequent calls use cached data
                 x = s(A, b)
-                assert_almost_equal(A*x, b)
+                assert_almost_equal(A@x, b)

--- a/pyamg/tests/test_strength.py
+++ b/pyamg/tests/test_strength.py
@@ -616,7 +616,7 @@ def reference_evolution_soc(A, B, epsilon=4.0, k=2, proj_type='l2'):
     --> This does the "unsymmetrized" version of the ode measure
     """
     # number of PDEs per point is defined implicitly by block size
-    csrflag = A.format == 'csr'
+    csrflag = sparse.issparse(A) and A.format == 'csr'
     if csrflag:
         numPDEs = 1
     else:
@@ -805,7 +805,7 @@ def reference_evolution_soc(A, B, epsilon=4.0, k=2, proj_type='l2'):
 def reference_distance_soc(A, V, theta=2.0, relative_drop=True):
     """Construct reference distance based strength of connection."""
     # deal with the supernode case
-    if A.format == 'bsr':
+    if sparse.issparse(A) and A.format == 'bsr':
         dimen = int(A.shape[0]/A.blocksize[0])
         C = sparse.csr_matrix((np.ones((A.data.shape[0],)), A.indices, A.indptr),
                               shape=(dimen, dimen))

--- a/pyamg/tests/test_strength.py
+++ b/pyamg/tests/test_strength.py
@@ -506,7 +506,7 @@ class TestComplexStrengthOfConnection(TestCase):
 
         # check if every neighbor is a strong connection
         for i in range(1, A.shape[0]-1):
-            idx = S.getrow(i)
+            idx = S[i, :]
             assert set(idx.indices) == {i-1, i+1}
 
 

--- a/pyamg/tests/test_strength.py
+++ b/pyamg/tests/test_strength.py
@@ -271,7 +271,7 @@ class TestStrengthOfConnection(TestCase):
                                     B.indices, B.data, result.indptr,
                                     result.indices, result.data, A.shape[0])
             result.eliminate_zeros()
-            exact = (A*B).multiply(mask)
+            exact = (A@B).multiply(mask)
             exact.sort_indices()
             exact.eliminate_zeros()
             assert_array_almost_equal(exact.data, result.data)
@@ -293,8 +293,8 @@ class TestStrengthOfConnection(TestCase):
         # strength stencil
         for N in [3, 6, 7]:
             u = np.ones(N*N)
-            A = sparse.spdiags([-u, -0.001*u, 2.002*u, -0.001*u, -u],
-                               [-N, -1, 0, 1, N], N*N, N*N, format='csr')
+            A = sparse.diags([-u, -0.001*u, 2.002*u, -0.001*u, -u],
+                             offsets=[-N, -1, 0, 1, N], shape=(N*N, N*N), format='csr')
             B = np.ones((A.shape[0], 1))
             cases.append({'A': A.copy(), 'B': B.copy(), 'epsilon': 4.0,
                           'k': 2, 'proj': 'l2'})
@@ -353,13 +353,13 @@ class TestStrengthOfConnection(TestCase):
                                         k=2, proj_type='D_A',
                                         symmetrize_measure=False)
         # create scaled A
-        D = sparse.spdiags([np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
-                           [0], A.shape[0], A.shape[0], format='csr')
-        Dinv = sparse.spdiags([1.0/np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
-                              [0], A.shape[0], A.shape[0], format='csr')
+        D = sparse.diags([np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
+                         offsets=[0], shape=(A.shape[0], A.shape[0]), format='csr')
+        Dinv = sparse.diags([1.0/np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
+                            offsets=[0], shape=(A.shape[0], A.shape[0]), format='csr')
         np.random.seed(3969802542)  # make results deterministic
-        result_scaled = evolution_soc((D*A*D).tobsr(blocksize=(2, 2)),
-                                      Dinv*B, epsilon=4.0, k=2,
+        result_scaled = evolution_soc((D@A@D).tobsr(blocksize=(2, 2)),
+                                      Dinv@B, epsilon=4.0, k=2,
                                       proj_type='D_A',
                                       symmetrize_measure=False)
         assert_array_almost_equal(result_scaled.toarray(),
@@ -455,12 +455,12 @@ class TestComplexStrengthOfConnection(TestCase):
                                         proj_type='D_A',
                                         symmetrize_measure=False)
         # create scaled A
-        D = sparse.spdiags([np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
-                           [0], A.shape[0], A.shape[0], format='csr')
-        Dinv = sparse.spdiags([1.0/np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
-                              [0], A.shape[0], A.shape[0], format='csr')
+        D = sparse.diags([np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
+                         offsets=[0], shape=(A.shape[0], A.shape[0]), format='csr')
+        Dinv = sparse.diags([1.0/np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
+                            offsets=[0], shape=(A.shape[0], A.shape[0]), format='csr')
         np.random.seed(743434914)  # make results deterministic
-        result_scaled = evolution_soc(D*A*D, Dinv*B, epsilon=4.0, k=2,
+        result_scaled = evolution_soc(D@A@D, Dinv@B, epsilon=4.0, k=2,
                                       proj_type='D_A',
                                       symmetrize_measure=False)
         assert_array_almost_equal(result_scaled.toarray(),
@@ -468,11 +468,11 @@ class TestComplexStrengthOfConnection(TestCase):
 
         # Test that the l2 and D_A are the same for the 1 candidate case
         np.random.seed(2417151167)  # make results deterministic
-        resultDA = evolution_soc(D*A*D, Dinv*B, epsilon=4.0,
+        resultDA = evolution_soc(D@A@D, Dinv@B, epsilon=4.0,
                                  k=2, proj_type='D_A',
                                  symmetrize_measure=False)
         np.random.seed(2866319482)  # make results deterministic
-        resultl2 = evolution_soc(D*A*D, Dinv*B, epsilon=4.0,
+        resultl2 = evolution_soc(D@A@D, Dinv@B, epsilon=4.0,
                                  k=2, proj_type='l2',
                                  symmetrize_measure=False)
         assert_array_almost_equal(resultDA.toarray(), resultl2.toarray())
@@ -486,12 +486,12 @@ class TestComplexStrengthOfConnection(TestCase):
                                         proj_type='D_A',
                                         symmetrize_measure=False)
         # create scaled A
-        D = sparse.spdiags([np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
-                           [0], A.shape[0], A.shape[0], format='csr')
-        Dinv = sparse.spdiags([1.0/np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
-                              [0], A.shape[0], A.shape[0], format='csr')
+        D = sparse.diags([np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
+                         offsets=[0], shape=(A.shape[0], A.shape[0]), format='csr')
+        Dinv = sparse.diags([1.0/np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
+                            offsets=[0], shape=(A.shape[0], A.shape[0]), format='csr')
         np.random.seed(1944403548)  # make results deterministic
-        result_scaled = evolution_soc((D*A*D).tobsr(blocksize=(2, 2)), Dinv*B,
+        result_scaled = evolution_soc((D@A@D).tobsr(blocksize=(2, 2)), Dinv@B,
                                       epsilon=4.0, k=2, proj_type='D_A',
                                       symmetrize_measure=False)
         assert_array_almost_equal(result_scaled.toarray(),
@@ -616,7 +616,7 @@ def reference_evolution_soc(A, B, epsilon=4.0, k=2, proj_type='l2'):
     --> This does the "unsymmetrized" version of the ode measure
     """
     # number of PDEs per point is defined implicitly by block size
-    csrflag = sparse.isspmatrix_csr(A)
+    csrflag = A.format == 'csr'
     if csrflag:
         numPDEs = 1
     else:
@@ -645,7 +645,7 @@ def reference_evolution_soc(A, B, epsilon=4.0, k=2, proj_type='l2'):
     S = (sparse.eye(dimen, dimen, format='csr') - (1.0/rho_DinvA)*Dinv_A)
     Atilde = sparse.eye(dimen, dimen, format='csr')
     for _i in range(k):
-        Atilde = S * Atilde
+        Atilde = S @ Atilde
 
     # Strength Info should be row-based, so transpose Atilde
     Atilde = Atilde.T.tocsr()
@@ -805,7 +805,7 @@ def reference_evolution_soc(A, B, epsilon=4.0, k=2, proj_type='l2'):
 def reference_distance_soc(A, V, theta=2.0, relative_drop=True):
     """Construct reference distance based strength of connection."""
     # deal with the supernode case
-    if sparse.isspmatrix_bsr(A):
+    if A.format == 'bsr':
         dimen = int(A.shape[0]/A.blocksize[0])
         C = sparse.csr_matrix((np.ones((A.data.shape[0],)), A.indices, A.indptr),
                               shape=(dimen, dimen))

--- a/pyamg/tests/test_strength.py
+++ b/pyamg/tests/test_strength.py
@@ -9,7 +9,7 @@ from pyamg.gallery import poisson, linear_elasticity, load_example, \
     stencil_grid
 from pyamg.strength import classical_strength_of_connection, \
     symmetric_strength_of_connection, evolution_strength_of_connection, \
-    distance_strength_of_connection
+    distance_strength_of_connection, energy_based_strength_of_connection
 from pyamg.amg_core import incomplete_mat_mult_csr
 from pyamg.util.linalg import approximate_spectral_radius
 from pyamg.util.utils import scale_rows
@@ -17,6 +17,7 @@ from pyamg.util.params import set_tol
 
 classical_soc = classical_strength_of_connection
 symmetric_soc = symmetric_strength_of_connection
+energy_soc = energy_based_strength_of_connection
 evolution_soc = evolution_strength_of_connection
 distance_soc = distance_strength_of_connection
 
@@ -496,6 +497,17 @@ class TestComplexStrengthOfConnection(TestCase):
                                       symmetrize_measure=False)
         assert_array_almost_equal(result_scaled.toarray(),
                                   result_unscaled.toarray(), decimal=2)
+
+    def test_energy_based_strength_of_connection(self):
+        A = poisson((10,), format='coo')
+        S = energy_based_strength_of_connection(A, k=100)
+        S.setdiag(0.0)
+        S.eliminate_zeros()
+
+        # check if every neighbor is a strong connection
+        for i in range(1, A.shape[0]-1):
+            idx = S.getrow(i)
+            assert set(idx.indices) == {i-1, i+1}
 
 
 # reference implementations for unittests  #

--- a/pyamg/util/linalg.py
+++ b/pyamg/util/linalg.py
@@ -193,7 +193,7 @@ def _approximate_eigenvalues(A, maxiter, symmetric=None, initial_guess=None):
 
     beta = 0.0
     for j in range(maxiter):
-        w = A * V[-1]
+        w = A @ V[-1]
 
         if symmetric:
             if j >= 1:

--- a/pyamg/util/tests/test_linalg.py
+++ b/pyamg/util/tests/test_linalg.py
@@ -171,7 +171,7 @@ class TestComplexLinalg(TestCase):
             rayleigh = abs(np.dot(Avec, vec) / np.dot(vec, vec))
             assert_almost_equal(rayleigh, expected_eig, decimal=4)
             vec = approximate_spectral_radius(Asp, return_vector=True)[1]
-            Aspvec = Asp * vec
+            Aspvec = Asp @ vec
             Aspvec = np.ravel(Aspvec)
             vec = np.ravel(vec)
             rayleigh = abs(np.dot(Aspvec, vec) / np.dot(vec, vec))
@@ -196,7 +196,7 @@ class TestComplexLinalg(TestCase):
             rayleigh = abs(np.dot(AAvec, vec) / np.dot(vec, vec))
             assert_almost_equal(rayleigh, expected_eig, decimal=4)
             vec = approximate_spectral_radius(AAsp, return_vector=True)[1]
-            AAspvec = AAsp * vec
+            AAspvec = AAsp @ vec
             AAspvec = np.ravel(AAspvec)
             vec = np.ravel(vec)
             rayleigh = abs(np.dot(AAspvec, vec) / np.dot(vec, vec))

--- a/pyamg/util/tests/test_utils.py
+++ b/pyamg/util/tests/test_utils.py
@@ -272,7 +272,7 @@ class TestUtils(TestCase):
                     blockflag = False
                     kwargs_gold = dict(kwargs)
                     # deal with block matrices
-                    if method.startswith('block') and A.format == 'bsr':
+                    if method.startswith('block') and issparse(A) and A.format == 'bsr':
                         blockflag = True
                         kwargs_gold['blocksize'] = A.blocksize[0]
                     # deal with omega and jacobi

--- a/pyamg/util/utils.py
+++ b/pyamg/util/utils.py
@@ -2186,7 +2186,22 @@ def scale_block_inverse(A, blocksize):
 
 
 def asfptype(A):
-    """Upcast array to a floating point format (if necessary)"""
+    """Upcast array to a floating point format (if necessary).
+
+    Parameters
+    ----------
+    A : array_like
+        Non-floating point or floating point array
+
+    Returns
+    -------
+    A : array_like
+        Floating point array
+
+    Notes
+    -----
+    see https://github.com/scipy/scipy/blob/4cc4d140efde4a33a77cd602c0d2f8698cf9b800/scipy/sparse/_base.py#L244
+    """
     # convert to smallest compatible dtype if needed
     if A.dtype.char in 'fdFD':
         return A
@@ -2195,4 +2210,4 @@ def asfptype(A):
         if A.dtype <= np.dtype(fp_type):
             return A.astype(fp_type)
 
-    raise TypeError(f'cannot upcast [{self.dtype}] to a floating point format')
+    raise TypeError(f'cannot upcast [{A.dtype}] to a floating point format')

--- a/pyamg/util/utils.py
+++ b/pyamg/util/utils.py
@@ -2201,6 +2201,7 @@ def asfptype(A):
     Notes
     -----
     see https://github.com/scipy/scipy/blob/4cc4d140efde4a33a77cd602c0d2f8698cf9b800/scipy/sparse/_base.py#L244
+
     """
     # convert to smallest compatible dtype if needed
     if A.dtype.char in 'fdFD':

--- a/pyamg/vis/vis_coarse.py
+++ b/pyamg/vis/vis_coarse.py
@@ -112,7 +112,7 @@ def vis_aggregate_groups(V, E2V, AggOp, mesh_type,
     if len(row) != len(col):
         raise ValueError('Problem constructing vertex-to-vertex map')
     V2V = coo_matrix((data, (row, col)), shape=(E2V.shape[0], E2V.max()+1))
-    V2V = V2V.T * V2V
+    V2V = V2V.T @ V2V
     V2V = triu(V2V, 1).tocoo()
 
     # get all the edges


### PR DESCRIPTION
Fixes #386     and prepares for SciPy changes to sparse.

This PR implements a set of 'pass 1' changes as described in the [migration guide from SciPy spmatrix to sparray](https://docs.scipy.org/doc/scipy-1.15.0/reference/sparse.migration_to_sparray.html). The spmatrix interface is not deprecated, but will eventually be. These changes allow the code to work for both spmatrix and sparray apis.

Basically, that means changing: 
- `* -> @` only for matmul involving scipy sparse. Scalar multiplication of sparse uses `*`.
- `spdiags` -> `diags`. This change still creates sparse matrix, but using the more modern array-api syntax for spmatrix. Changing to `diags_array` could occur in a 'pass 2' set of changes if/when we move to sparray.
- `asfptype` -> `astype`
- `isspmatrix_fmt(A)`-> `issparse and A.format == fmt`
- `isspmatrix` -> `issparse`

Sorry for the length of the diff here. Each change is hopefully straightforward.  If this should be split into parts, let me know.

Notes:
- Often `isspmatrix_csr(A)` is used as a check of `A.format == 'csr'` and the check for being sparse is assumed/not needed. Evidence of this can be e.g. an if-structure that checks if 'csr' or 'bsr' with no else-clause for other formats or non-sparse handling. I did not try to add code to handle other formats or non-sparse inputs. I just changed the code to check the format attribute directly. 
- `asfptype` finds the smallest floating point dtype that the input dytpe can convert to safely. This often is more than what is needed. I implemented the full treatment of `asfptype` to find the smallest floating point dtype rather than try to figure out if that is more than what is needed. So this should be the same as before, but it is possible it could be done faster/better. Actually in this project it seemed like most uses of `asfptype` needed the full treatment.
- I did not try to find or change the code handling of NumPy `matrix`.  That code should probably change `*` to `@` for readability and consistency, but I think that is a separate PR.