### PR TITLE
feat: switch to scipy sparse arrays internally

### DIFF
--- a/docs/dev/common_docstring.md
+++ b/docs/dev/common_docstring.md
@@ -1,6 +1,6 @@
     Parameters
     ----------
-    A : csr_matrix or bsr_matrix
+    A : csr_array or bsr_array
         Square, sparse matrix in CSR or BSR format
     B : array_like
         Right near-nullspace candidates stored in the columns of an NxK array.
@@ -16,13 +16,13 @@
         'nonsymmetric' i.e. nonsymmetric in a hermitian sense
         For the real case, symmetric and hermitian are the same.
     strength : {'symmetric', 'classical', 'distance', 'evolution',
-                ('predefined', {'C': csr_matrix}), None}
+                ('predefined', {'C': csr_array}), None}
         Method used to determine the strength of connection in the graph of A.
         Method-specific parameters are passed using a
         tuple, e.g. strength=('symmetric',{'theta': 0.25 }). If strength=None,
         all nonzero entries of the matrix are considered strong.
     aggregate : {'standard', 'naive', 'lloyd',
-                 ('predefined', {'AggOp': csr_matrix})}
+                 ('predefined', {'AggOp': csr_array})}
         Method used to aggregate nodes.
     smooth : {'jacobi', 'richardson', 'energy', None}
         Method used to improve the tentative prolongator.  Method-specific

--- a/pyamg/__init__.py
+++ b/pyamg/__init__.py
@@ -75,7 +75,7 @@ if spver[0] < spmin[0] or (spver[0] == spmin[0] and spver[1] < spmin[1]):
                   f'PyAMG (detected version {spver})', UserWarning, stacklevel=2)
 
 
-def test(verbose=False):
+def test(verbose=False):  # noqa: PT028
     """Test runner for pytest.
 
     Parameters

--- a/pyamg/aggregation/adaptive.py
+++ b/pyamg/aggregation/adaptive.py
@@ -2,7 +2,7 @@
 
 from warnings import warn
 import numpy as np
-from scipy.sparse import csr_matrix, bsr_matrix, issparse, \
+from scipy.sparse import csr_array, bsr_array, issparse, \
     eye_array, SparseEfficiencyWarning
 
 from ..multilevel import MultilevelSolver
@@ -127,7 +127,7 @@ def adaptive_sa_solver(A, initial_candidates=None, symmetry='hermitian',
 
     Parameters
     ----------
-    A : csr_matrix, bsr_matrix
+    A : csr_array, bsr_array
         Square matrix in CSR or BSR format
     initial_candidates : None, n x m dense matrix
         If a matrix, then this forms the basis for the first m candidates.
@@ -159,8 +159,8 @@ def adaptive_sa_solver(A, initial_candidates=None, symmetry='hermitian',
     strength : ['symmetric', 'classical', 'evolution', None]
         Method used to determine the strength of connection between unknowns of
         the linear system.  See smoothed_aggregation_solver(...) documentation.
-        Predefined strength may be used with ('predefined', {'C': csr_matrix}).
-    aggregate : ['standard', 'lloyd', 'naive', ('predefined', {'AggOp': csr_matrix})]
+        Predefined strength may be used with ('predefined', {'C': csr_array}).
+    aggregate : ['standard', 'lloyd', 'naive', ('predefined', {'AggOp': csr_array})]
         Method used to aggregate nodes.  See smoothed_aggregation_solver(...)
         documentation.
     smooth : ['jacobi', 'richardson', 'energy', None]
@@ -221,11 +221,11 @@ def adaptive_sa_solver(A, initial_candidates=None, symmetry='hermitian',
     """
     if not issparse(A) or A.format not in ('bsr', 'csr'):
         try:
-            A = csr_matrix(A)
+            A = csr_array(A)
             warn('Implicit conversion of A to CSR', SparseEfficiencyWarning)
         except Exception as e:
-            raise TypeError('Argument A must have type csr_matrix or '
-                            'bsr_matrix, or be convertible to csr_matrix') from e
+            raise TypeError('Argument A must have type csr_array or '
+                            'bsr_array, or be convertible to csr_array') from e
     A = asfptype(A)
     if A.shape[0] != A.shape[1]:
         raise ValueError('expected square matrix')
@@ -379,7 +379,7 @@ def initial_setup_stage(A, symmetry, pdef, candidate_iters, epsilon,
         Maximum number of levels to be used in the multilevel solver
     max_coarse : integer
         Maximum number of variables permitted on the coarse grid
-    aggregate : ['standard', 'lloyd', 'naive', ('predefined', {'AggOp': csr_matrix})]
+    aggregate : ['standard', 'lloyd', 'naive', ('predefined', {'AggOp': csr_array})]
         Method used to aggregate nodes.  See smoothed_aggregation_solver(...)
         documentation.
     prepostsmoother : string or dict
@@ -390,7 +390,7 @@ def initial_setup_stage(A, symmetry, pdef, candidate_iters, epsilon,
     strength : ['symmetric', 'classical', 'evolution', None]
         Method used to determine the strength of connection between unknowns of
         the linear system.  See smoothed_aggregation_solver(...) documentation.
-        Predefined strength may be used with ('predefined', {'C': csr_matrix}).
+        Predefined strength may be used with ('predefined', {'C': csr_array}).
     work : float
         A measure of the total complexity
     initial_candidate : array
@@ -651,7 +651,7 @@ def general_setup_stage(ml, symmetry, candidate_iters, prepostsmoother,
         # bridge 'T' ignores this new dof and just maps zeros there
         data = np.zeros((bnnz, K+1, K), dtype=T.dtype)
         data[:, :-1, :] = T.data
-        return bsr_matrix((data, T.indices, T.indptr),
+        return bsr_array((data, T.indices, T.indptr),
                           shape=((K + 1) * int(M / K), N))
 
     def expand_candidates(B_old, nodesize):  # pylint: disable=unused-variable

--- a/pyamg/aggregation/adaptive.py
+++ b/pyamg/aggregation/adaptive.py
@@ -3,7 +3,7 @@
 from warnings import warn
 import numpy as np
 from scipy.sparse import csr_matrix, bsr_matrix, issparse, \
-    eye, SparseEfficiencyWarning
+    eye_array, SparseEfficiencyWarning
 
 from ..multilevel import MultilevelSolver
 from ..strength import symmetric_strength_of_connection, \
@@ -475,11 +475,11 @@ def initial_setup_stage(A, symmetry, pdef, candidate_iters, epsilon,
         if fn == 'symmetric':
             C_l = symmetric_strength_of_connection(A_l, **kwargs)
             # Diagonal must be nonzero
-            C_l = C_l + eye(C_l.shape[0], C_l.shape[1], format='csr')
+            C_l = C_l + eye_array(C_l.shape[0], C_l.shape[1], format='csr')
         elif fn == 'classical':
             C_l = classical_strength_of_connection(A_l, **kwargs)
             # Diagonal must be nonzero
-            C_l = C_l + eye(C_l.shape[0], C_l.shape[1], format='csr')
+            C_l = C_l + eye_array(C_l.shape[0], C_l.shape[1], format='csr')
             if issparse(A_l) and A_l.format == 'bsr':
                 C_l = amalgamate(C_l, A_l.blocksize[0])
         elif fn in ('ode', 'evolution'):

--- a/pyamg/aggregation/aggregate.py
+++ b/pyamg/aggregation/aggregate.py
@@ -397,7 +397,7 @@ def lloyd_aggregation(C, ratio=0.03, distance='unit', maxiter=10):
 
     _, clusters, seeds = lloyd_cluster(G, num_seeds, maxiter=maxiter)
 
-    row = (clusters >= 0).nonzero()[0]
+    row = (clusters >= 0).nonzero()[0].astype(C.indices.dtype)
     col = clusters[row]
     data = np.ones(len(row), dtype='int8')
     AggOp = sparse.coo_array((data, (row, col)),
@@ -475,7 +475,7 @@ def balanced_lloyd_aggregation(C, num_clusters=None):
                                  d, cm, seeds)
 
     col = cm
-    row = np.arange(len(cm))
+    row = np.arange(len(cm), dtype=np.int32)
     data = np.ones(len(row), dtype=np.int32)
     AggOp = sparse.coo_array((data, (row, col)),
                               shape=(G.shape[0], num_clusters)).tocsr()

--- a/pyamg/aggregation/aggregate.py
+++ b/pyamg/aggregation/aggregate.py
@@ -14,12 +14,12 @@ def standard_aggregation(C):
 
     Parameters
     ----------
-    C : csr_matrix
+    C : csr_array
         strength of connection matrix
 
     Returns
     -------
-    AggOp : csr_matrix
+    AggOp : csr_array
         aggregation operator which determines the sparsity pattern
         of the tentative prolongator
     Cpts : array
@@ -27,7 +27,7 @@ def standard_aggregation(C):
 
     Examples
     --------
-    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse import csr_array
     >>> from pyamg.gallery import poisson
     >>> from pyamg.aggregation.aggregate import standard_aggregation
     >>> A = poisson((4,), format='csr')   # 1D mesh with 4 vertices
@@ -41,7 +41,7 @@ def standard_aggregation(C):
            [1, 0],
            [0, 1],
            [0, 1]], dtype=int8)
-    >>> A = csr_matrix([[1,0,0],[0,1,1],[0,1,1]])
+    >>> A = csr_array([[1,0,0],[0,1,1],[0,1,1]])
     >>> A.toarray()                      # first vertex is isolated
     array([[1, 0, 0],
            [0, 1, 1],
@@ -57,7 +57,7 @@ def standard_aggregation(C):
 
     """
     if not sparse.issparse(C) or C.format != 'csr':
-        raise TypeError('expected csr_matrix')
+        raise TypeError('expected csr_array')
 
     if C.shape[0] != C.shape[1]:
         raise ValueError('expected square matrix')
@@ -76,7 +76,7 @@ def standard_aggregation(C):
     # no nodes aggregated
     if num_aggregates == 0:
         # return all zero matrix and no Cpts
-        return sparse.csr_matrix((num_rows, 1), dtype='int8'), \
+        return sparse.csr_array((num_rows, 1), dtype='int8'), \
             np.array([], dtype=index_type)
 
     shape = (num_rows, num_aggregates)
@@ -87,12 +87,12 @@ def standard_aggregation(C):
         row = np.arange(num_rows, dtype=index_type)[mask]
         col = Tj[mask]
         data = np.ones(len(col), dtype='int8')
-        return sparse.coo_matrix((data, (row, col)), shape=shape).tocsr(), Cpts
+        return sparse.coo_array((data, (row, col)), shape=shape).tocsr(), Cpts
 
     # all nodes aggregated
     Tp = np.arange(num_rows+1, dtype=index_type)
     Tx = np.ones(len(Tj), dtype='int8')
-    return sparse.csr_matrix((Tx, Tj, Tp), shape=shape), Cpts
+    return sparse.csr_array((Tx, Tj, Tp), shape=shape), Cpts
 
 
 def naive_aggregation(C):
@@ -100,12 +100,12 @@ def naive_aggregation(C):
 
     Parameters
     ----------
-    C : csr_matrix
+    C : csr_array
         strength of connection matrix
 
     Returns
     -------
-    AggOp : csr_matrix
+    AggOp : csr_array
         aggregation operator which determines the sparsity pattern
         of the tentative prolongator
     Cpts : array
@@ -113,7 +113,7 @@ def naive_aggregation(C):
 
     Examples
     --------
-    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse import csr_array
     >>> from pyamg.gallery import poisson
     >>> from pyamg.aggregation.aggregate import naive_aggregation
     >>> A = poisson((4,), format='csr')   # 1D mesh with 4 vertices
@@ -127,7 +127,7 @@ def naive_aggregation(C):
            [1, 0],
            [0, 1],
            [0, 1]], dtype=int8)
-    >>> A = csr_matrix([[1,0,0],[0,1,1],[0,1,1]])
+    >>> A = csr_array([[1,0,0],[0,1,1],[0,1,1]])
     >>> A.toarray()                      # first vertex is isolated
     array([[1, 0, 0],
            [0, 1, 1],
@@ -150,7 +150,7 @@ def naive_aggregation(C):
 
     """
     if not sparse.issparse(C) or C.format != 'csr':
-        raise TypeError('expected csr_matrix')
+        raise TypeError('expected csr_array')
 
     if C.shape[0] != C.shape[1]:
         raise ValueError('expected square matrix')
@@ -169,13 +169,13 @@ def naive_aggregation(C):
 
     if num_aggregates == 0:
         # all zero matrix
-        return sparse.csr_matrix((num_rows, 1), dtype='int8'), Cpts
+        return sparse.csr_array((num_rows, 1), dtype='int8'), Cpts
 
     shape = (num_rows, num_aggregates)
     # all nodes aggregated
     Tp = np.arange(num_rows+1, dtype=index_type)
     Tx = np.ones(len(Tj), dtype='int8')
-    return sparse.csr_matrix((Tx, Tj, Tp), shape=shape), Cpts
+    return sparse.csr_array((Tx, Tj, Tp), shape=shape), Cpts
 
 
 def pairwise_aggregation(A, matchings=2, theta=0.25,
@@ -184,7 +184,7 @@ def pairwise_aggregation(A, matchings=2, theta=0.25,
 
     Parameters
     ----------
-    A : csr_matrix or bsr_matrix
+    A : csr_array or bsr_array
         level matrix
     matchings : int, default 2
         number of times to perform pairwise aggregation; each
@@ -202,7 +202,7 @@ def pairwise_aggregation(A, matchings=2, theta=0.25,
 
     Examples
     --------
-    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse import csr_array
     >>> from pyamg.gallery import poisson
     >>> from pyamg.aggregation.aggregate import pairwise_aggregation
     >>> A = poisson((4,), format='csr')   # 1D mesh with 4 vertices
@@ -270,7 +270,7 @@ def pairwise_aggregation(A, matchings=2, theta=0.25,
         # Construct sparse T
         if num_aggregates == 0:
             # all zero matrix
-            T_temp = sparse.csr_matrix((num_rows, 1), dtype='int8')
+            T_temp = sparse.csr_array((num_rows, 1), dtype='int8')
             warn('No pairwise aggregates found, T = 0.')
         else:
             shape = (num_rows, num_aggregates)
@@ -278,19 +278,19 @@ def pairwise_aggregation(A, matchings=2, theta=0.25,
             # If A is not BSR
             if not sparse.issparse(A) or A.format != 'bsr':
                 Tx = np.ones(len(Tj), dtype='int8')
-                T_temp = sparse.csr_matrix((Tx, Tj, Tp), shape=shape)
+                T_temp = sparse.csr_array((Tx, Tj, Tp), shape=shape)
             else:
                 shape = (shape[0]*A.blocksize[0], shape[1]*A.blocksize[1])
                 Tx = np.array(len(Tj)*[np.identity(A.blocksize[0])], dtype='int8')
-                T_temp = sparse.bsr_matrix((Tx, Tj, Tp), blocksize=A.blocksize, shape=shape)
+                T_temp = sparse.bsr_array((Tx, Tj, Tp), blocksize=A.blocksize, shape=shape)
 
         # Form aggregation matrix, need to make sure is CSR/BSR
         if i == 0:
             T = T_temp
         elif sparse.issparse(A) and A.format == 'bsr':
-            T = sparse.bsr_matrix(T @ T_temp)
+            T = sparse.bsr_array(T @ T_temp)
         else:
-            T = sparse.csr_matrix(T @ T_temp)
+            T = sparse.csr_array(T @ T_temp)
 
         # Break loop if zero aggregates were found
         if num_aggregates == 0:
@@ -315,7 +315,7 @@ def lloyd_aggregation(C, ratio=0.03, distance='unit', maxiter=10):
 
     Parameters
     ----------
-    C : csr_matrix
+    C : csr_array
         strength of connection matrix
     ratio : scalar
         Fraction of the nodes which will be seeds.
@@ -337,7 +337,7 @@ def lloyd_aggregation(C, ratio=0.03, distance='unit', maxiter=10):
 
     Returns
     -------
-    AggOp : csr_matrix
+    AggOp : csr_array
         aggregation operator which determines the sparsity pattern
         of the tentative prolongator
     seeds : array
@@ -349,7 +349,7 @@ def lloyd_aggregation(C, ratio=0.03, distance='unit', maxiter=10):
 
     Examples
     --------
-    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse import csr_array
     >>> from pyamg.gallery import poisson
     >>> from pyamg.aggregation.aggregate import lloyd_aggregation
     >>> A = poisson((4,), format='csr')   # 1D mesh with 4 vertices
@@ -371,7 +371,7 @@ def lloyd_aggregation(C, ratio=0.03, distance='unit', maxiter=10):
         raise ValueError('ratio must be > 0.0 and <= 1.0')
 
     if not sparse.issparse(C) or C.format not in ('csc', 'csr'):
-        raise TypeError('expected csr_matrix or csc_matrix')
+        raise TypeError('expected csr_array or csc_array')
 
     if distance == 'unit':
         data = np.ones_like(C.data).astype(float)
@@ -400,7 +400,7 @@ def lloyd_aggregation(C, ratio=0.03, distance='unit', maxiter=10):
     row = (clusters >= 0).nonzero()[0]
     col = clusters[row]
     data = np.ones(len(row), dtype='int8')
-    AggOp = sparse.coo_matrix((data, (row, col)),
+    AggOp = sparse.coo_array((data, (row, col)),
                               shape=(G.shape[0], num_seeds)).tocsr()
     return AggOp, seeds
 
@@ -410,14 +410,14 @@ def balanced_lloyd_aggregation(C, num_clusters=None):
 
     Parameters
     ----------
-    C : csr_matrix
+    C : csr_array
         strength of connection matrix with positive weights
     num_clusters : int
         Number of seeds or clusters expected (default: C.shape[0] / 10)
 
     Returns
     -------
-    AggOp : csr_matrix
+    AggOp : csr_array
         aggregation operator which determines the sparsity pattern
         of the tentative prolongator
     seeds : array
@@ -447,7 +447,7 @@ def balanced_lloyd_aggregation(C, num_clusters=None):
         raise ValueError('num_clusters must be between 1 and n')
 
     if not sparse.issparse(C) or C.format not in ('csc', 'csr'):
-        raise TypeError('expected csr_matrix or csc_matrix')
+        raise TypeError('expected csr_array or csc_array')
 
     if C.data.min() <= 0:
         raise ValueError('positive edge weights required')
@@ -477,6 +477,6 @@ def balanced_lloyd_aggregation(C, num_clusters=None):
     col = cm
     row = np.arange(len(cm))
     data = np.ones(len(row), dtype=np.int32)
-    AggOp = sparse.coo_matrix((data, (row, col)),
+    AggOp = sparse.coo_array((data, (row, col)),
                               shape=(G.shape[0], num_clusters)).tocsr()
     return AggOp, seeds

--- a/pyamg/aggregation/aggregation.py
+++ b/pyamg/aggregation/aggregation.py
@@ -3,7 +3,7 @@
 
 from warnings import warn
 import numpy as np
-from scipy.sparse import csr_matrix, issparse, SparseEfficiencyWarning
+from scipy.sparse import csr_array, issparse, SparseEfficiencyWarning
 
 from pyamg.multilevel import MultilevelSolver
 from pyamg.relaxation.smoothing import change_smoothers
@@ -41,7 +41,7 @@ def smoothed_aggregation_solver(A, B=None, BH=None,
 
     Parameters
     ----------
-    A : csr_matrix, bsr_matrix
+    A : csr_array, bsr_array
         Sparse NxN matrix in CSR or BSR format
 
     B : None, array_like
@@ -66,12 +66,12 @@ def smoothed_aggregation_solver(A, B=None, BH=None,
         tuple, e.g. strength=('symmetric',{'theta' : 0.25 }). If strength=None,
         all nonzero entries of the matrix are considered strong.
         Choose from 'symmetric', 'classical', 'evolution', 'algebraic_distance',
-        'affinity', ('predefined', {'C' : csr_matrix}), None
+        'affinity', ('predefined', {'C' : csr_array}), None
 
     aggregate : string or list
         Method used to aggregate nodes.
         Choose from 'standard', 'lloyd', 'naive', 'pairwise',
-        ('predefined', {'AggOp' : csr_matrix})
+        ('predefined', {'AggOp' : csr_array})
 
     smooth : list
         Method used to smooth the tentative prolongator.  Method-specific
@@ -178,7 +178,7 @@ def smoothed_aggregation_solver(A, B=None, BH=None,
 
           For predefined strength of connection, use a list consisting of
           tuples of the form ('predefined', {'C' : C0}), where C0 is a
-          csr_matrix and each degree-of-freedom in C0 represents a supernode.
+          csr_array and each degree-of-freedom in C0 represents a supernode.
           For instance to predefine a three-level hierarchy, use
           [('predefined', {'C' : C0}), ('predefined', {'C' : C1}) ].
 
@@ -187,7 +187,7 @@ def smoothed_aggregation_solver(A, B=None, BH=None,
           {'AggOp' : Agg0}), ('predefined', {'AggOp' : Agg1}) ], where the
           dimensions of A, Agg0 and Agg1 are compatible, i.e.  Agg0.shape[1] ==
           A.shape[0] and Agg1.shape[1] == Agg0.shape[0].  Each AggOp is a
-          csr_matrix.
+          csr_array.
 
     Examples
     --------
@@ -212,11 +212,11 @@ def smoothed_aggregation_solver(A, B=None, BH=None,
     """
     if not issparse(A) or A.format not in ('bsr', 'csr'):
         try:
-            A = csr_matrix(A)
+            A = csr_array(A)
             warn('Implicit conversion of A to CSR', SparseEfficiencyWarning)
         except Exception as e:
-            raise TypeError('Argument A must have type csr_matrix or bsr_matrix, '
-                            'or be convertible to csr_matrix') from e
+            raise TypeError('Argument A must have type csr_array or bsr_array, '
+                            'or be convertible to csr_array') from e
 
     A = asfptype(A)
 

--- a/pyamg/aggregation/pairwise.py
+++ b/pyamg/aggregation/pairwise.py
@@ -3,7 +3,7 @@
 
 from warnings import warn
 import numpy as np
-from scipy.sparse import csr_matrix, issparse, SparseEfficiencyWarning
+from scipy.sparse import csr_array, issparse, SparseEfficiencyWarning
 
 from pyamg.multilevel import MultilevelSolver
 from pyamg.relaxation.smoothing import change_smoothers
@@ -24,7 +24,7 @@ def pairwise_solver(A,
 
     Parameters
     ----------
-    A : {csr_matrix, bsr_matrix}
+    A : {csr_array, bsr_array}
         Sparse NxN matrix in CSR or BSR format
     aggregate : {tuple, string, list} : default ('pairwise',
             {'theta': 0.25, 'norm':'min', 'matchings': 2})
@@ -85,11 +85,11 @@ def pairwise_solver(A,
     """
     if not issparse(A) or A.format not in ('bsr', 'csr'):
         try:
-            A = csr_matrix(A)
+            A = csr_array(A)
             warn('Implicit conversion of A to CSR', SparseEfficiencyWarning)
         except Exception as e:
-            raise TypeError('Argument A must have type csr_matrix or bsr_matrix, '
-                            'or be convertible to csr_matrix') from e
+            raise TypeError('Argument A must have type csr_array or bsr_array, '
+                            'or be convertible to csr_array') from e
 
     A = asfptype(A)
 

--- a/pyamg/aggregation/rootnode.py
+++ b/pyamg/aggregation/rootnode.py
@@ -3,7 +3,7 @@
 
 from warnings import warn
 import numpy as np
-from scipy.sparse import csr_matrix, issparse, SparseEfficiencyWarning
+from scipy.sparse import csr_array, issparse, SparseEfficiencyWarning
 
 from ..multilevel import MultilevelSolver
 from ..relaxation.smoothing import change_smoothers
@@ -41,7 +41,7 @@ def rootnode_solver(A, B=None, BH=None,
 
     Parameters
     ----------
-    A : csr_matrix, bsr_matrix
+    A : csr_array, bsr_array
         Sparse NxN matrix in CSR or BSR format
 
     B : None, array_like
@@ -189,7 +189,7 @@ def rootnode_solver(A, B=None, BH=None,
 
            For predefined strength of connection, use a list consisting of
            tuples of the form ('predefined', {'C' : C0}), where C0 is a
-           csr_matrix and each degree-of-freedom in C0 represents a supernode.
+           csr_array and each degree-of-freedom in C0 represents a supernode.
            For instance to predefine a three-level hierarchy, use
            [('predefined', {'C' : C0}), ('predefined', {'C' : C1}) ].
 
@@ -198,7 +198,7 @@ def rootnode_solver(A, B=None, BH=None,
            {'AggOp' : Agg0}), ('predefined', {'AggOp' : Agg1}) ], where the
            dimensions of A, Agg0 and Agg1 are compatible, i.e.  Agg0.shape[1] ==
            A.shape[0] and Agg1.shape[1] == Agg0.shape[0].  Each AggOp is a
-           csr_matrix.
+           csr_array.
 
            Because this is a root-nodes solver, if a member of the predefined
            aggregation list is predefined, it must be of the form
@@ -232,12 +232,12 @@ def rootnode_solver(A, B=None, BH=None,
     """
     if not issparse(A) or A.format not in ('bsr', 'csr'):
         try:
-            A = csr_matrix(A)
+            A = csr_array(A)
             warn('Implicit conversion of A to CSR',
                  SparseEfficiencyWarning)
         except Exception as e:
-            raise TypeError('Argument A must have type csr_matrix, '
-                            'bsr_matrix, or be convertible to csr_matrix') from e
+            raise TypeError('Argument A must have type csr_array, '
+                            'bsr_array, or be convertible to csr_array') from e
 
     A = asfptype(A)
 

--- a/pyamg/aggregation/smooth.py
+++ b/pyamg/aggregation/smooth.py
@@ -19,7 +19,7 @@ def satisfy_constraints(U, B, BtBinv):
 
     Parameters
     ----------
-    U : bsr_matrix
+    U : bsr_array
         m x n sparse bsr matrix
         Update to the prolongator
     B : array
@@ -64,11 +64,11 @@ def jacobi_prolongation_smoother(S, T, C, B, omega=4.0/3.0, degree=1,
 
     Parameters
     ----------
-    S : csr_matrix, bsr_matrix
+    S : csr_array, bsr_array
         Sparse NxN matrix used for smoothing.  Typically, A.
-    T : csr_matrix, bsr_matrix
+    T : csr_array, bsr_array
         Tentative prolongator
-    C : csr_matrix, bsr_matrix
+    C : csr_array, bsr_array
         Strength-of-connection matrix
     B : array
         Near nullspace modes for the coarse grid such that T@B
@@ -90,7 +90,7 @@ def jacobi_prolongation_smoother(S, T, C, B, omega=4.0/3.0, degree=1,
 
     Returns
     -------
-    P : csr_matrix, bsr_matrix
+    P : csr_array, bsr_array
         Smoothed (final) prolongator defined by P = (I - omega/rho(K) K) @ T
         where K = diag(S)^-1 @ S and rho(K) is an approximation to the
         spectral radius of K.
@@ -106,12 +106,12 @@ def jacobi_prolongation_smoother(S, T, C, B, omega=4.0/3.0, degree=1,
     --------
     >>> from pyamg.aggregation import jacobi_prolongation_smoother
     >>> from pyamg.gallery import poisson
-    >>> from scipy.sparse import coo_matrix
+    >>> from scipy.sparse import coo_array
     >>> import numpy as np
     >>> data = np.ones((6,))
     >>> row = np.arange(0,6)
     >>> col = np.kron([0,1],np.ones((3,)))
-    >>> T = coo_matrix((data,(row,col)),shape=(6,2)).tocsr()
+    >>> T = coo_array((data,(row,col)),shape=(6,2)).tocsr()
     >>> T.toarray()
     array([[1., 0.],
            [1., 0.],
@@ -162,7 +162,7 @@ def jacobi_prolongation_smoother(S, T, C, B, omega=4.0/3.0, degree=1,
     elif weighting == 'block':
         # Use block diagonal of S
         D_inv = get_block_diag(S, blocksize=S.blocksize[0], inv_flag=True)
-        D_inv = sparse.bsr_matrix((D_inv, np.arange(D_inv.shape[0]),
+        D_inv = sparse.bsr_array((D_inv, np.arange(D_inv.shape[0]),
                                    np.arange(D_inv.shape[0]+1)),
                                   shape=S.shape)
         D_inv_S = D_inv@S
@@ -211,11 +211,11 @@ def richardson_prolongation_smoother(S, T, omega=4.0/3.0, degree=1):
 
     Parameters
     ----------
-    S : csr_matrix, bsr_matrix
+    S : csr_array, bsr_array
         Sparse NxN matrix used for smoothing.  Typically, A or the
         "filtered matrix" obtained from A by lumping weak connections
         onto the diagonal of A.
-    T : csr_matrix, bsr_matrix
+    T : csr_array, bsr_array
         Tentative prolongator
     omega : scalar
         Damping parameter
@@ -224,7 +224,7 @@ def richardson_prolongation_smoother(S, T, omega=4.0/3.0, degree=1):
 
     Returns
     -------
-    P : csr_matrix, bsr_matrix
+    P : csr_array, bsr_array
         Smoothed (final) prolongator defined by P = (I - omega/rho(S) S) @ T
         where rho(S) is an approximation to the spectral radius of S.
 
@@ -240,12 +240,12 @@ def richardson_prolongation_smoother(S, T, omega=4.0/3.0, degree=1):
     --------
     >>> from pyamg.aggregation import richardson_prolongation_smoother
     >>> from pyamg.gallery import poisson
-    >>> from scipy.sparse import coo_matrix
+    >>> from scipy.sparse import coo_array
     >>> import numpy as np
     >>> data = np.ones((6,))
     >>> row = np.arange(0,6)
     >>> col = np.kron([0,1],np.ones((3,)))
-    >>> T = coo_matrix((data,(row,col)),shape=(6,2)).tocsr()
+    >>> T = coo_array((data,(row,col)),shape=(6,2)).tocsr()
     >>> T.toarray()
     array([[1., 0.],
            [1., 0.],
@@ -279,9 +279,9 @@ def cg_prolongation_smoothing(A, T, B, BtBinv, pattern, maxiter, tol,
 
     Parameters
     ----------
-    A : csr_matrix, bsr_matrix
+    A : csr_array, bsr_array
         SPD sparse NxN matrix
-    T : bsr_matrix
+    T : bsr_array
         Tentative prolongator, a NxM sparse matrix (M < N).
         This is initial guess for the equation A T = 0.
         Assumed that T B_c = B_f
@@ -292,7 +292,7 @@ def cg_prolongation_smoothing(A, T, B, BtBinv, pattern, maxiter, tol,
         3 dimensional array such that,
         BtBinv[i] = pinv(B_i.H Bi), and B_i is B restricted
         to the neighborhood (in the matrix graph) of dof of i.
-    pattern : csr_matrix, bsr_matrix
+    pattern : csr_array, bsr_array
         Sparse NxM matrix
         This is the sparsity pattern constraint to enforce on the
         eventual prolongator
@@ -313,7 +313,7 @@ def cg_prolongation_smoothing(A, T, B, BtBinv, pattern, maxiter, tol,
 
     Returns
     -------
-    T : bsr_matrix
+    T : bsr_array
         Smoothed prolongator using conjugate gradients to solve A T = 0,
         subject to the constraints, T B_c = B_f, and T has no nonzero
         outside of the sparsity pattern in pattern.
@@ -325,7 +325,7 @@ def cg_prolongation_smoothing(A, T, B, BtBinv, pattern, maxiter, tol,
 
     """
     # Preallocate
-    AP = sparse.bsr_matrix((np.zeros(pattern.data.shape, dtype=T.dtype),
+    AP = sparse.bsr_array((np.zeros(pattern.data.shape, dtype=T.dtype),
                             pattern.indices, pattern.indptr),
                            shape=pattern.shape)
 
@@ -334,7 +334,7 @@ def cg_prolongation_smoothing(A, T, B, BtBinv, pattern, maxiter, tol,
         Dinv = get_diagonal(A, norm_eq=False, inv=True)
     elif weighting == 'block':
         Dinv = get_block_diag(A, blocksize=A.blocksize[0], inv_flag=True)
-        Dinv = sparse.bsr_matrix((Dinv, np.arange(Dinv.shape[0]),
+        Dinv = sparse.bsr_array((Dinv, np.arange(Dinv.shape[0]),
                                   np.arange(Dinv.shape[0]+1)),
                                  shape=A.shape)
     elif weighting == 'local':
@@ -350,7 +350,7 @@ def cg_prolongation_smoothing(A, T, B, BtBinv, pattern, maxiter, tol,
     #   with the added constraint that R has an explicit 0 wherever
     #   R is 0 and pattern is not
     uones = np.zeros(pattern.data.shape, dtype=T.dtype)
-    R = sparse.bsr_matrix((uones, pattern.indices,
+    R = sparse.bsr_array((uones, pattern.indices,
                            pattern.indptr),
                           shape=pattern.shape)
     amg_core.incomplete_mat_mult_bsr(A.indptr, A.indices,
@@ -449,10 +449,10 @@ def cgnr_prolongation_smoothing(A, T, B, BtBinv, pattern, maxiter,
 
     Parameters
     ----------
-    A : csr_matrix, bsr_matrix
+    A : csr_array, bsr_array
         SPD sparse NxN matrix
         Should be at least nonsymmetric or indefinite
-    T : bsr_matrix
+    T : bsr_array
         Tentative prolongator, a NxM sparse matrix (M < N).
         This is initial guess for the equation A T = 0.
         Assumed that T B_c = B_f
@@ -463,7 +463,7 @@ def cgnr_prolongation_smoothing(A, T, B, BtBinv, pattern, maxiter,
         3 dimensional array such that,
         BtBinv[i] = pinv(B_i.H Bi), and B_i is B restricted
         to the neighborhood (in the matrix graph) of dof of i.
-    pattern : csr_matrix, bsr_matrix
+    pattern : csr_array, bsr_array
         Sparse NxM matrix
         This is the sparsity pattern constraint to enforce on the
         eventual prolongator
@@ -485,7 +485,7 @@ def cgnr_prolongation_smoothing(A, T, B, BtBinv, pattern, maxiter,
 
     Returns
     -------
-    T : bsr_matrix
+    T : bsr_array
         Smoothed prolongator using CGNR to solve A T = 0,
         subject to the constraints, T B_c = B_f, and T has no nonzero
         outside of the sparsity pattern in pattern.
@@ -506,7 +506,7 @@ def cgnr_prolongation_smoothing(A, T, B, BtBinv, pattern, maxiter,
 
     # Preallocate
     uones = np.zeros(pattern.data.shape, dtype=T.dtype)
-    AP = sparse.bsr_matrix((uones, pattern.indices, pattern.indptr),
+    AP = sparse.bsr_array((uones, pattern.indices, pattern.indptr),
                            shape=pattern.shape)
 
     # D for A.H@A
@@ -517,7 +517,7 @@ def cgnr_prolongation_smoothing(A, T, B, BtBinv, pattern, maxiter,
     #   with the added constraint that R has an explicit 0 wherever
     #   R is 0 and pattern is not
     uones = np.zeros(pattern.data.shape, dtype=T.dtype)
-    R = sparse.bsr_matrix((uones, pattern.indices, pattern.indptr),
+    R = sparse.bsr_array((uones, pattern.indices, pattern.indptr),
                           shape=pattern.shape)
     AT = -1.0*A@T
     R.data[:] = 0.0
@@ -652,10 +652,10 @@ def gmres_prolongation_smoothing(A, T, B, BtBinv, pattern, maxiter,
 
     Parameters
     ----------
-    A : csr_matrix, bsr_matrix
+    A : csr_array, bsr_array
         SPD sparse NxN matrix
         Should be at least nonsymmetric or indefinite
-    T : bsr_matrix
+    T : bsr_array
         Tentative prolongator, a NxM sparse matrix (M < N).
         This is initial guess for the equation A T = 0.
         Assumed that T B_c = B_f
@@ -666,7 +666,7 @@ def gmres_prolongation_smoothing(A, T, B, BtBinv, pattern, maxiter,
         3 dimensional array such that,
         BtBinv[i] = pinv(B_i.H Bi), and B_i is B restricted
         to the neighborhood (in the matrix graph) of dof of i.
-    pattern : csr_matrix, bsr_matrix
+    pattern : csr_array, bsr_array
         Sparse NxM matrix
         This is the sparsity pattern constraint to enforce on the
         eventual prolongator
@@ -687,7 +687,7 @@ def gmres_prolongation_smoothing(A, T, B, BtBinv, pattern, maxiter,
 
     Returns
     -------
-    T : bsr_matrix
+    T : bsr_array
         Smoothed prolongator using GMRES to solve A T = 0,
         subject to the constraints, T B_c = B_f, and T has no nonzero
         outside of the sparsity pattern in pattern.
@@ -702,7 +702,7 @@ def gmres_prolongation_smoothing(A, T, B, BtBinv, pattern, maxiter,
 
     # Preallocate space for new search directions
     uones = np.zeros(pattern.data.shape, dtype=T.dtype)
-    AV = sparse.bsr_matrix((uones, pattern.indices, pattern.indptr),
+    AV = sparse.bsr_array((uones, pattern.indices, pattern.indptr),
                            shape=pattern.shape)
 
     # Preallocate for Givens Rotations, Hessenberg matrix and Krylov Space
@@ -719,7 +719,7 @@ def gmres_prolongation_smoothing(A, T, B, BtBinv, pattern, maxiter,
         Dinv = get_diagonal(A, norm_eq=False, inv=True)
     elif weighting == 'block':
         Dinv = get_block_diag(A, blocksize=A.blocksize[0], inv_flag=True)
-        Dinv = sparse.bsr_matrix((Dinv, np.arange(Dinv.shape[0]),
+        Dinv = sparse.bsr_array((Dinv, np.arange(Dinv.shape[0]),
                                   np.arange(Dinv.shape[0]+1)),
                                  shape=A.shape)
     elif weighting == 'local':
@@ -735,7 +735,7 @@ def gmres_prolongation_smoothing(A, T, B, BtBinv, pattern, maxiter,
     #   with the added constraint that R has an explicit 0 wherever
     #   R is 0 and pattern is not
     uones = np.zeros(pattern.data.shape, dtype=T.dtype)
-    R = sparse.bsr_matrix((uones, pattern.indices, pattern.indptr),
+    R = sparse.bsr_array((uones, pattern.indices, pattern.indptr),
                           shape=pattern.shape)
     amg_core.incomplete_mat_mult_bsr(A.indptr, A.indices,
                                      np.ravel(A.data),
@@ -884,11 +884,11 @@ def energy_prolongation_smoother(A, T, Atilde, B, Bf, Cpt_params,
 
     Parameters
     ----------
-    A : csr_matrix, bsr_matrix
+    A : csr_array, bsr_array
         Sparse NxN matrix
-    T : bsr_matrix
+    T : bsr_array
         Tentative prolongator, a NxM sparse matrix (M < N)
-    Atilde : csr_matrix
+    Atilde : csr_array
         Strength of connection matrix
     B : array
         Near-nullspace modes for coarse grid.  Has shape (M,k) where
@@ -943,7 +943,7 @@ def energy_prolongation_smoother(A, T, Atilde, B, Bf, Cpt_params,
 
     Returns
     -------
-    T : bsr_matrix
+    T : bsr_array
         Smoothed prolongator
 
     Notes
@@ -966,12 +966,12 @@ def energy_prolongation_smoother(A, T, Atilde, B, Bf, Cpt_params,
     --------
     >>> from pyamg.aggregation import energy_prolongation_smoother
     >>> from pyamg.gallery import poisson
-    >>> from scipy.sparse import coo_matrix
+    >>> from scipy.sparse import coo_array
     >>> import numpy as np
     >>> data = np.ones((6,))
     >>> row = np.arange(0,6)
     >>> col = np.kron([0,1],np.ones((3,)))
-    >>> T = coo_matrix((data,(row,col)),shape=(6,2)).tocsr()
+    >>> T = coo_array((data,(row,col)),shape=(6,2)).tocsr()
     >>> print(T.toarray())
     [[1. 0.]
      [1. 0.]
@@ -1035,7 +1035,7 @@ def energy_prolongation_smoother(A, T, Atilde, B, Bf, Cpt_params,
         return T
 
     if not sparse.issparse(Atilde) or Atilde.format != 'csr':
-        raise TypeError('Atilde must be csr_matrix')
+        raise TypeError('Atilde must be csr_array')
 
     if prefilter is None:
         prefilter = {}
@@ -1051,7 +1051,7 @@ def energy_prolongation_smoother(A, T, Atilde, B, Bf, Cpt_params,
 
     # Prepocess Atilde, the strength matrix
     if Atilde is None:
-        Atilde = sparse.csr_matrix((np.ones(len(A.indices)),
+        Atilde = sparse.csr_array((np.ones(len(A.indices)),
                                     A.indices.copy(), A.indptr.copy()),
                                    shape=(A.shape[0]/A.blocksize[0],
                                           A.shape[1]/A.blocksize[1]))
@@ -1067,7 +1067,7 @@ def energy_prolongation_smoother(A, T, Atilde, B, Bf, Cpt_params,
         T.sort_indices()
         shape = (int(T.shape[0]/T.blocksize[0]),
                  int(T.shape[1]/T.blocksize[1]))
-        pattern = sparse.csr_matrix((np.ones(T.indices.shape), T.indices, T.indptr),
+        pattern = sparse.csr_array((np.ones(T.indices.shape), T.indices, T.indptr),
                                     shape=shape)
 
         AtildeCopy = Atilde.copy()

--- a/pyamg/aggregation/smooth.py
+++ b/pyamg/aggregation/smooth.py
@@ -110,8 +110,8 @@ def jacobi_prolongation_smoother(S, T, C, B, omega=4.0/3.0, degree=1,
     >>> import numpy as np
     >>> data = np.ones((6,))
     >>> row = np.arange(0,6)
-    >>> col = np.kron([0,1],np.ones((3,)))
-    >>> T = coo_array((data,(row,col)),shape=(6,2)).tocsr()
+    >>> col = np.kron([0, 1], np.ones(3, dtype=int))
+    >>> T = coo_array((data,(row, col)),shape=(6, 2)).tocsr()
     >>> T.toarray()
     array([[1., 0.],
            [1., 0.],
@@ -162,8 +162,8 @@ def jacobi_prolongation_smoother(S, T, C, B, omega=4.0/3.0, degree=1,
     elif weighting == 'block':
         # Use block diagonal of S
         D_inv = get_block_diag(S, blocksize=S.blocksize[0], inv_flag=True)
-        D_inv = sparse.bsr_array((D_inv, np.arange(D_inv.shape[0]),
-                                   np.arange(D_inv.shape[0]+1)),
+        D_inv = sparse.bsr_array((D_inv, np.arange(D_inv.shape[0], dtype=np.int32),
+                                   np.arange(D_inv.shape[0] + 1, dtype=np.int32)),
                                   shape=S.shape)
         D_inv_S = D_inv@S
         D_inv_S = (omega/approximate_spectral_radius(D_inv_S))*D_inv_S
@@ -243,9 +243,9 @@ def richardson_prolongation_smoother(S, T, omega=4.0/3.0, degree=1):
     >>> from scipy.sparse import coo_array
     >>> import numpy as np
     >>> data = np.ones((6,))
-    >>> row = np.arange(0,6)
-    >>> col = np.kron([0,1],np.ones((3,)))
-    >>> T = coo_array((data,(row,col)),shape=(6,2)).tocsr()
+    >>> row = np.arange(0, 6, dtype=np.int32)
+    >>> col = np.kron([0, 1], np.ones(3, dtype=int))
+    >>> T = coo_array((data,(row, col)),shape=(6, 2)).tocsr()
     >>> T.toarray()
     array([[1., 0.],
            [1., 0.],
@@ -334,9 +334,9 @@ def cg_prolongation_smoothing(A, T, B, BtBinv, pattern, maxiter, tol,
         Dinv = get_diagonal(A, norm_eq=False, inv=True)
     elif weighting == 'block':
         Dinv = get_block_diag(A, blocksize=A.blocksize[0], inv_flag=True)
-        Dinv = sparse.bsr_array((Dinv, np.arange(Dinv.shape[0]),
-                                  np.arange(Dinv.shape[0]+1)),
-                                 shape=A.shape)
+        Dinv = sparse.bsr_array((Dinv, np.arange(Dinv.shape[0], dtype=np.int32),
+                                 np.arange(Dinv.shape[0] + 1, dtype=np.int32)),
+                                shape=A.shape)
     elif weighting == 'local':
         # Based on Gershgorin estimate
         D = np.abs(A)@np.ones((A.shape[0], 1), dtype=A.dtype)
@@ -719,8 +719,8 @@ def gmres_prolongation_smoothing(A, T, B, BtBinv, pattern, maxiter,
         Dinv = get_diagonal(A, norm_eq=False, inv=True)
     elif weighting == 'block':
         Dinv = get_block_diag(A, blocksize=A.blocksize[0], inv_flag=True)
-        Dinv = sparse.bsr_array((Dinv, np.arange(Dinv.shape[0]),
-                                  np.arange(Dinv.shape[0]+1)),
+        Dinv = sparse.bsr_array((Dinv, np.arange(Dinv.shape[0], dtype=np.int32),
+                                 np.arange(Dinv.shape[0] + 1, dtype=np.int32)),
                                  shape=A.shape)
     elif weighting == 'local':
         # Based on Gershgorin estimate
@@ -969,9 +969,9 @@ def energy_prolongation_smoother(A, T, Atilde, B, Bf, Cpt_params,
     >>> from scipy.sparse import coo_array
     >>> import numpy as np
     >>> data = np.ones((6,))
-    >>> row = np.arange(0,6)
-    >>> col = np.kron([0,1],np.ones((3,)))
-    >>> T = coo_array((data,(row,col)),shape=(6,2)).tocsr()
+    >>> row = np.arange(0, 6, dtype=np.int32)
+    >>> col = np.kron([0, 1], np.ones(3)).astype(np.int32)
+    >>> T = coo_array((data,(row, col)),shape=(6, 2)).tocsr()
     >>> print(T.toarray())
     [[1. 0.]
      [1. 0.]

--- a/pyamg/aggregation/tentative.py
+++ b/pyamg/aggregation/tentative.py
@@ -2,7 +2,7 @@
 
 
 import numpy as np
-from scipy.sparse import issparse, bsr_matrix
+from scipy.sparse import issparse, bsr_array
 from pyamg import amg_core
 
 
@@ -11,7 +11,7 @@ def fit_candidates(AggOp, B, tol=1e-10):
 
     Parameters
     ----------
-    AggOp : csr_matrix
+    AggOp : csr_array
         Describes the sparsity pattern of the tentative prolongator.
         Has dimension (#blocks, #aggregates)
     B : array
@@ -24,7 +24,7 @@ def fit_candidates(AggOp, B, tol=1e-10):
 
     Returns
     -------
-    (Q, R) : (bsr_matrix, array)
+    (Q, R) : (bsr_array, array)
         The tentative prolongator Q is a sparse block matrix with dimensions
         (#blocks * blocksize, #aggregates * #candidates) formed by dense blocks
         of size (blocksize, #candidates).  The coarse level candidates are
@@ -57,10 +57,10 @@ def fit_candidates(AggOp, B, tol=1e-10):
 
     Examples
     --------
-    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse import csr_array
     >>> from pyamg.aggregation.tentative import fit_candidates
     >>> # four nodes divided into two aggregates
-    ... AggOp = csr_matrix( [[1, 0],
+    ... AggOp = csr_array( [[1, 0],
     ...                      [1, 0],
     ...                      [0, 1],
     ...                      [0, 1]] )
@@ -95,7 +95,7 @@ def fit_candidates(AggOp, B, tol=1e-10):
            [1.41421356, 3.53553391],
            [0.        , 0.70710678]])
     >>> # aggregation excludes the third node
-    ... AggOp = csr_matrix( [[1, 0],
+    ... AggOp = csr_array( [[1, 0],
     ...                      [1, 0],
     ...                      [0, 0],
     ...                      [0, 1]] )
@@ -115,7 +115,7 @@ def fit_candidates(AggOp, B, tol=1e-10):
 
     """
     if not issparse(AggOp) or AggOp.format != 'csr':
-        raise TypeError('expected csr_matrix for argument AggOp')
+        raise TypeError('expected csr_array for argument AggOp')
 
     B = np.asarray(B)
     if B.dtype not in ['float32', 'float64', 'complex64', 'complex128']:
@@ -144,7 +144,7 @@ def fit_candidates(AggOp, B, tol=1e-10):
        AggOp_csc.indptr, AggOp_csc.indices, Qx.ravel(),
        B.ravel(), R.ravel(), tol)
 
-    Q = bsr_matrix((Qx.swapaxes(1, 2).copy(), AggOp_csc.indices,
+    Q = bsr_array((Qx.swapaxes(1, 2).copy(), AggOp_csc.indices,
                     AggOp_csc.indptr), shape=(K2*N_coarse, K1*N_fine))
     Q = Q.T.tobsr()
     R = R.reshape(-1, K2)

--- a/pyamg/aggregation/tests/test_adaptive.py
+++ b/pyamg/aggregation/tests/test_adaptive.py
@@ -103,7 +103,7 @@ class TestComplexAdaptiveSA(TestCase):
 
         # JBS:  Not sure if this is a valid test case
         # imaginary shift
-        # Ai = A + 1.1j*sparse.eye(A.shape[0], A.shape[1])
+        # Ai = A + 1.1j*sparse.eye_array(A.shape[0], A.shape[1])
         # cases.append((Ai,0.8))
 
         for A, rratio in cases:
@@ -133,7 +133,7 @@ class TestComplexAdaptiveSA(TestCase):
 # block candidates
 # self.cases.append((
 #   csr_matrix((np.ones(9),array([0,0,0,1,1,1,2,2,2]),arange(10)),
-#   shape=(9,3)), vstack((array([1]*9 + [0]*9),arange(2*9))).T ))
+#   shape=(9,3)), np.vstack((array([1]*9 + [0]*9),arange(2*9))).T ))
 #
 #    def test_first_level(self):
 #        cases = []
@@ -141,31 +141,31 @@ class TestComplexAdaptiveSA(TestCase):
 # tests where AggOp includes all DOFs
 #        cases.append((
 #           csr_matrix((np.ones(4),array([0,0,1,1]),arange(5)),
-#           shape=(4,2)), vstack((np.ones(4),arange(4))).T ))
+#           shape=(4,2)), np.vstack((np.ones(4),arange(4))).T ))
 #        cases.append((
 #           csr_matrix((np.ones(9),array([0,0,0,1,1,1,2,2,2]),arange(10)),
-#           shape=(9,3)), vstack((np.ones(9),arange(9))).T ))
+#           shape=(9,3)), np.vstack((np.ones(9),arange(9))).T ))
 #        cases.append((
 #           csr_matrix((np.ones(9),array([0,0,1,1,2,2,3,3,3]),arange(10)),
-#           shape=(9,4)), vstack((np.ones(9),arange(9))).T ))
+#           shape=(9,4)), np.vstack((np.ones(9),arange(9))).T ))
 #
 # tests where AggOp excludes some DOFs
 #        cases.append((
 #           csr_matrix((np.ones(4),array([0,0,1,1]),array([0,1,2,2,3,4])),
-#           shape=(5,2)), vstack((np.ones(5),arange(5))).T ))
+#           shape=(5,2)), np.vstack((np.ones(5),arange(5))).T ))
 #
 # overdetermined blocks
 #        cases.append((
 #           csr_matrix((np.ones(4),array([0,0,1,1]),array([0,1,2,2,3,4])),
-#           shape=(5,2)), vstack((np.ones(5),arange(5),arange(5)**2)).T  ))
+#           shape=(5,2)), np.vstack((np.ones(5),arange(5),arange(5)**2)).T  ))
 #        cases.append((
 #           csr_matrix(
 #               (np.ones(6),array([1,3,0,2,1,0]),array([0,0,1,2,2,3,4,5,5,6])),
-#           shape=(9,4)), vstack((np.ones(9),arange(9),arange(9)**2)).T ))
+#           shape=(9,4)), np.vstack((np.ones(9),arange(9),arange(9)**2)).T ))
 #        cases.append((
 #           csr_matrix(
 #               (np.ones(6),array([1,3,0,2,1,0]),array([0,0,1,2,2,3,4,5,5,6])),
-#           shape=(9,4)), vstack((np.ones(9),arange(9))).T ))
+#           shape=(9,4)), np.vstack((np.ones(9),arange(9))).T ))
 #
 #        def mask_candidate(AggOp,candidates):
 # mask out all DOFs that are not included in the aggregation

--- a/pyamg/aggregation/tests/test_adaptive.py
+++ b/pyamg/aggregation/tests/test_adaptive.py
@@ -132,7 +132,7 @@ class TestComplexAdaptiveSA(TestCase):
 #
 # block candidates
 # self.cases.append((
-#   csr_matrix((np.ones(9),array([0,0,0,1,1,1,2,2,2]),arange(10)),
+#   csr_array((np.ones(9),array([0,0,0,1,1,1,2,2,2]),arange(10)),
 #   shape=(9,3)), np.vstack((array([1]*9 + [0]*9),arange(2*9))).T ))
 #
 #    def test_first_level(self):
@@ -140,30 +140,30 @@ class TestComplexAdaptiveSA(TestCase):
 #
 # tests where AggOp includes all DOFs
 #        cases.append((
-#           csr_matrix((np.ones(4),array([0,0,1,1]),arange(5)),
+#           csr_array((np.ones(4),array([0,0,1,1]),arange(5)),
 #           shape=(4,2)), np.vstack((np.ones(4),arange(4))).T ))
 #        cases.append((
-#           csr_matrix((np.ones(9),array([0,0,0,1,1,1,2,2,2]),arange(10)),
+#           csr_array((np.ones(9),array([0,0,0,1,1,1,2,2,2]),arange(10)),
 #           shape=(9,3)), np.vstack((np.ones(9),arange(9))).T ))
 #        cases.append((
-#           csr_matrix((np.ones(9),array([0,0,1,1,2,2,3,3,3]),arange(10)),
+#           csr_array((np.ones(9),array([0,0,1,1,2,2,3,3,3]),arange(10)),
 #           shape=(9,4)), np.vstack((np.ones(9),arange(9))).T ))
 #
 # tests where AggOp excludes some DOFs
 #        cases.append((
-#           csr_matrix((np.ones(4),array([0,0,1,1]),array([0,1,2,2,3,4])),
+#           csr_array((np.ones(4),array([0,0,1,1]),array([0,1,2,2,3,4])),
 #           shape=(5,2)), np.vstack((np.ones(5),arange(5))).T ))
 #
 # overdetermined blocks
 #        cases.append((
-#           csr_matrix((np.ones(4),array([0,0,1,1]),array([0,1,2,2,3,4])),
+#           csr_array((np.ones(4),array([0,0,1,1]),array([0,1,2,2,3,4])),
 #           shape=(5,2)), np.vstack((np.ones(5),arange(5),arange(5)**2)).T  ))
 #        cases.append((
-#           csr_matrix(
+#           csr_array(
 #               (np.ones(6),array([1,3,0,2,1,0]),array([0,0,1,2,2,3,4,5,5,6])),
 #           shape=(9,4)), np.vstack((np.ones(9),arange(9),arange(9)**2)).T ))
 #        cases.append((
-#           csr_matrix(
+#           csr_array(
 #               (np.ones(6),array([1,3,0,2,1,0]),array([0,0,1,2,2,3,4,5,5,6])),
 #           shape=(9,4)), np.vstack((np.ones(9),arange(9))).T ))
 #

--- a/pyamg/aggregation/tests/test_aggregate.py
+++ b/pyamg/aggregation/tests/test_aggregate.py
@@ -198,8 +198,6 @@ def reference_naive_aggregation(C):
             R = np.union1d(R, unaggregated_neighbors)
             R = np.union1d(R, np.array([i]))
             Cpts.append(i)
-        else:
-            pass
 
     assert np.unique(R).shape[0] == n
 

--- a/pyamg/aggregation/tests/test_aggregate.py
+++ b/pyamg/aggregation/tests/test_aggregate.py
@@ -19,7 +19,7 @@ class TestAggregate(TestCase):
         # random matrices
         np.random.seed(2006482792)
         for N in [2, 3, 5]:
-            self.cases.append(sparse.csr_matrix(np.random.rand(N, N)))
+            self.cases.append(sparse.csr_array(np.random.rand(N, N)))
 
         # Poisson problems in 1D and 2D
         for N in [2, 3, 5, 7, 10, 11, 19]:
@@ -174,7 +174,7 @@ def reference_standard_aggregation(C):
     Pp = np.arange(n+1)
     Px = np.ones(n)
 
-    return sparse.csr_matrix((Px, Pj, Pp)), np.array(Cpts)
+    return sparse.csr_array((Px, Pj, Pp)), np.array(Cpts)
 
 
 def reference_naive_aggregation(C):
@@ -207,7 +207,7 @@ def reference_naive_aggregation(C):
     Pp = np.arange(n+1)
     Px = np.ones(n)
 
-    return sparse.csr_matrix((Px, Pj, Pp)), np.array(Cpts)
+    return sparse.csr_array((Px, Pj, Pp)), np.array(Cpts)
 
 
 def reference_pairwise_aggregation(C):
@@ -281,4 +281,4 @@ def reference_pairwise_aggregation(C):
     Pp = np.arange(n+1)
     Px = np.ones(n)
 
-    return sparse.csr_matrix((Px, Pj, Pp)), np.array(Cpts)
+    return sparse.csr_array((Px, Pj, Pp)), np.array(Cpts)

--- a/pyamg/aggregation/tests/test_aggregate.py
+++ b/pyamg/aggregation/tests/test_aggregate.py
@@ -43,7 +43,7 @@ class TestAggregate(TestCase):
             assert_equal(np.setdiff1d(Cpts, expected_Cpts).shape[0], 0)
 
         # S is diagonal - no dofs aggregated
-        S = sparse.diags([[1, 1, 1, 1]], offsets=[0], shape=(4, 4), format='csr')
+        S = sparse.diags_array([[1, 1, 1, 1]], offsets=[0], shape=(4, 4), format='csr')
         (result, Cpts) = standard_aggregation(S)
         expected = np.array([[0], [0], [0], [0]])
         assert_equal(result.toarray(), expected)
@@ -61,7 +61,7 @@ class TestAggregate(TestCase):
             assert_equal(np.setdiff1d(Cpts, expected_Cpts).shape[0], 0)
 
         # S is diagonal - no dofs aggregated
-        S = sparse.diags([[1, 1, 1, 1]], offsets=[0], shape=(4, 4), format='csr')
+        S = sparse.diags_array([[1, 1, 1, 1]], offsets=[0], shape=(4, 4), format='csr')
         (result, Cpts) = naive_aggregation(S)
         expected = np.eye(4)
         assert_equal(result.toarray(), expected)
@@ -78,7 +78,7 @@ class TestAggregate(TestCase):
             assert_equal(np.setdiff1d(Cpts, expected_Cpts).shape[0], 0)
 
         # S is diagonal - no dofs aggregated
-        S = sparse.diags([[1, 1, 1, 1]], offsets=[0], shape=(4, 4), format='csr')
+        S = sparse.diags_array([[1, 1, 1, 1]], offsets=[0], shape=(4, 4), format='csr')
         (result, Cpts) = pairwise_aggregation(S, matchings=1, theta=0.25, norm='min')
         expected = np.eye(4)
         assert_equal(result.todense(), expected)

--- a/pyamg/aggregation/tests/test_aggregate.py
+++ b/pyamg/aggregation/tests/test_aggregate.py
@@ -171,7 +171,7 @@ def reference_standard_aggregation(C):
     assert len(R) == 0
 
     Pj = aggregates
-    Pp = np.arange(n+1)
+    Pp = np.arange(n + 1, dtype=aggregates.dtype)
     Px = np.ones(n)
 
     return sparse.csr_array((Px, Pj, Pp)), np.array(Cpts)
@@ -204,7 +204,7 @@ def reference_naive_aggregation(C):
     assert np.unique(R).shape[0] == n
 
     Pj = aggregates
-    Pp = np.arange(n+1)
+    Pp = np.arange(n + 1, dtype=aggregates.dtype)
     Px = np.ones(n)
 
     return sparse.csr_array((Px, Pj, Pp)), np.array(Cpts)
@@ -278,7 +278,7 @@ def reference_pairwise_aggregation(C):
     assert (np.unique(R).shape[0] == n)
 
     Pj = aggregates
-    Pp = np.arange(n+1)
+    Pp = np.arange(n + 1, dtype=aggregates.dtype)
     Px = np.ones(n)
 
     return sparse.csr_array((Px, Pj, Pp)), np.array(Cpts)

--- a/pyamg/aggregation/tests/test_aggregation.py
+++ b/pyamg/aggregation/tests/test_aggregation.py
@@ -482,7 +482,7 @@ class TestComplexSolverPerformance(TestCase):
     def test_basic(self):
         """Check that method converges at a reasonable rate."""
         for A, B, c_factor, symmetry, smooth in self.cases:
-            A = sparse.csr_matrix(A)
+            A = sparse.csr_array(A)
 
             ml = smoothed_aggregation_solver(A, B, symmetry=symmetry,
                                              smooth=smooth, max_coarse=10)

--- a/pyamg/aggregation/tests/test_aggregation.py
+++ b/pyamg/aggregation/tests/test_aggregation.py
@@ -91,10 +91,10 @@ class TestComplexParameters(TestCase):
         # There are better near nullspace vectors than the default,
         #   but a constant should give a convergent solver, nonetheless.
         A = poisson((100,), format='csr')
-        A = A + 1.0j * sparse.eye(A.shape[0], A.shape[1])
+        A = A + 1.0j * sparse.eye_array(A.shape[0], A.shape[1])
         self.cases.append((A, None))
         A = poisson((10, 10), format='csr')
-        A = A + 1.0j * sparse.eye(A.shape[0], A.shape[1])
+        A = A + 1.0j * sparse.eye_array(A.shape[0], A.shape[1])
         self.cases.append((A, None))
 
     def run_cases(self, opts):
@@ -444,7 +444,7 @@ class TestComplexSolverPerformance(TestCase):
 
         # Test 1
         A = poisson((5000,), format='csr')
-        Ai = A + 1.0j * sparse.eye(A.shape[0], A.shape[1])
+        Ai = A + 1.0j * sparse.eye_array(A.shape[0], A.shape[1])
         self.cases.append((Ai, None, 0.12, 'symmetric',
                            ('jacobi', {'omega': 4.0 / 3.0})))
         self.cases.append((Ai, None, 0.12, 'symmetric',
@@ -452,7 +452,7 @@ class TestComplexSolverPerformance(TestCase):
 
         # Test 2
         A = poisson((71, 71), format='csr')
-        Ai = A + (0.625 / 0.01) * 1j * sparse.eye(A.shape[0], A.shape[1])
+        Ai = A + (0.625 / 0.01) * 1j * sparse.eye_array(A.shape[0], A.shape[1])
         self.cases.append((Ai, None, 1e-3, 'symmetric',
                            ('jacobi', {'omega': 4.0 / 3.0})))
         self.cases.append((Ai, None, 1e-3, 'symmetric',

--- a/pyamg/aggregation/tests/test_rootnode.py
+++ b/pyamg/aggregation/tests/test_rootnode.py
@@ -94,10 +94,10 @@ class TestComplexParameters(TestCase):
         # well.  There are better near nullspace vectors than the default, but
         # a constant should give a convergent solver, nonetheless.
         A = poisson((100,), format='csr')
-        A = A + 1.0j * sparse.eye(A.shape[0], A.shape[1])
+        A = A + 1.0j * sparse.eye_array(A.shape[0], A.shape[1])
         self.cases.append((A, None))
         A = poisson((10, 10), format='csr')
-        A = A + 1.0j * sparse.eye(A.shape[0], A.shape[1])
+        A = A + 1.0j * sparse.eye_array(A.shape[0], A.shape[1])
         self.cases.append((A, None))
 
     def run_cases(self, opts):
@@ -433,14 +433,14 @@ class TestComplexSolverPerformance(TestCase):
 
         # Test 1
         A = poisson((5000,), format='csr')
-        Ai = A + 1.0j * sparse.eye(A.shape[0], A.shape[1])
+        Ai = A + 1.0j * sparse.eye_array(A.shape[0], A.shape[1])
         self.cases.append((Ai, None, 0.12, 'symmetric',
                            ('energy', {'krylov': 'gmres'})))
 
         # Test 2
         A = poisson((71, 71), format='csr')
         Ai = A + (0.625 / 0.01) * 1.0j *\
-            sparse.eye(A.shape[0], A.shape[1])
+            sparse.eye_array(A.shape[0], A.shape[1])
         self.cases.append((Ai, None, 1e-3, 'symmetric',
                            ('energy', {'krylov': 'cgnr',
                                        'weighting': 'diagonal'})))

--- a/pyamg/aggregation/tests/test_rootnode.py
+++ b/pyamg/aggregation/tests/test_rootnode.py
@@ -463,7 +463,7 @@ class TestComplexSolverPerformance(TestCase):
     def test_basic(self):
         """Check that method converges at a reasonable rate."""
         for A, B, c_factor, symmetry, smooth in self.cases:
-            A = sparse.csr_matrix(A)
+            A = sparse.csr_array(A)
 
             ml = rootnode_solver(A, B, symmetry=symmetry, smooth=smooth,
                                  max_coarse=10)

--- a/pyamg/aggregation/tests/test_smooth.py
+++ b/pyamg/aggregation/tests/test_smooth.py
@@ -118,10 +118,12 @@ class TestEnergyMin(TestCase):
         A2 = sparse.csr_array(np.array([[1.3, 0.], [0., 4.]])).tobsr(blocksize=(2, 2))
         B2 = sparse.csr_array(np.array([[1.3, 0.], [2., 4.]])).tobsr(blocksize=(2, 1))
         mask = sparse.csr_array((np.array([1., 1., 1., 1.]),
-                                 (np.array([0, 0, 1, 1]), np.array([0, 1, 0, 1]))),
+                                 (np.array([0, 0, 1, 1], dtype=np.int32),
+                                  np.array([0, 1, 0, 1], dtype=np.int32))),
                                  shape=(2, 2)).tobsr(blocksize=(2, 2))
         mask2 = sparse.csr_array((np.array([1., 0., 1., 0.]),
-                                  (np.array([0, 0, 1, 1]), np.array([0, 1, 0, 1]))),
+                                  (np.array([0, 0, 1, 1], dtype=np.int32),
+                                   np.array([0, 1, 0, 1], dtype=np.int32))),
                                   shape=(2, 2)).tobsr(blocksize=(2, 1))
         mask2.eliminate_zeros()
         cases.append((A, A, mask))                                  # 2x2,  2x2
@@ -137,7 +139,8 @@ class TestEnergyMin(TestCase):
         mask = A.copy()
         mask2 = A2.copy()
         mask3 = sparse.csr_array((np.ones(2, dtype=float),
-                                  (np.array([0, 1]), np.array([0, 0]))),
+                                  (np.array([0, 1], dtype=np.int32),
+                                   np.array([0, 0], dtype=np.int32))),
                                   shape=(2, 2)).tobsr(blocksize=(1, 1))
         cases.append((A, B, mask))                                  # 2x2,  2x2
         cases.append((A2, B2, mask2))                               # 2x2,  2x2

--- a/pyamg/aggregation/tests/test_smooth.py
+++ b/pyamg/aggregation/tests/test_smooth.py
@@ -366,7 +366,7 @@ class TestEnergyMin(TestCase):
 
         # Simple, imaginary-valued problems
         name = 'random imaginary + I'
-        iA = A + 1.0j * sparse.eye(A.shape[0], A.shape[1])
+        iA = A + 1.0j * sparse.eye_array(A.shape[0], A.shape[1])
 
         cases.append((iA, B, ('jacobi',
                               {'filter_entries': True, 'weighting': 'local'}), name))
@@ -500,7 +500,7 @@ class TestEnergyMin(TestCase):
                 assert_almost_equal((P@Bc)[mask, :], Bf_H[mask, :])
 
                 # P should be the identity at Cpts
-                I1 = sparse.eye(T.shape[1], T.shape[1], format='csr', dtype=T.dtype)
+                I1 = sparse.eye_array(T.shape[1], format='csr', dtype=T.dtype)
                 I2 = P[Cpts, :]
                 assert_almost_equal(I1.data, I2.data)
                 assert_equal(I1.indptr, I2.indptr)

--- a/pyamg/aggregation/tests/test_smooth.py
+++ b/pyamg/aggregation/tests/test_smooth.py
@@ -34,7 +34,7 @@ class TestEnergyMin(TestCase):
             S = S.tocoo()
             SS = SS.tocoo()
             S.data[:] = 0.0
-            SS = sparse.coo_matrix((np.hstack((S.data, SS.data)),
+            SS = sparse.coo_array((np.hstack((S.data, SS.data)),
                                     (np.hstack((S.row, SS.row)),
                                      np.hstack((S.col, SS.col)))),
                                    shape=S.shape)
@@ -48,11 +48,11 @@ class TestEnergyMin(TestCase):
         cases = []
 
         # 1x1 tests
-        A = sparse.csr_matrix(np.array([[1.1]])).tobsr(blocksize=(1, 1))
-        B = sparse.csr_matrix(np.array([[1.0]])).tobsr(blocksize=(1, 1))
-        A2 = sparse.csr_matrix(np.array([[0.]])).tobsr(blocksize=(1, 1))
-        mask = sparse.csr_matrix(np.array([[1.]])).tobsr(blocksize=(1, 1))
-        mask2 = sparse.csr_matrix(np.array([[0.]])).tobsr(blocksize=(1, 1))
+        A = sparse.csr_array(np.array([[1.1]])).tobsr(blocksize=(1, 1))
+        B = sparse.csr_array(np.array([[1.0]])).tobsr(blocksize=(1, 1))
+        A2 = sparse.csr_array(np.array([[0.]])).tobsr(blocksize=(1, 1))
+        mask = sparse.csr_array(np.array([[1.]])).tobsr(blocksize=(1, 1))
+        mask2 = sparse.csr_array(np.array([[0.]])).tobsr(blocksize=(1, 1))
         cases.append((A, A, mask))                                  # 1x1,  1x1
         cases.append((A, A, mask2))                                 # 1x1,  1x1
         cases.append((A, B, mask))                                  # 1x1,  1x1
@@ -61,21 +61,21 @@ class TestEnergyMin(TestCase):
         cases.append((A2, A2, mask))                                # 1x1,  1x1
 
         # 1x2 and 2x1 tests
-        A = sparse.csr_matrix(np.array([[1.1]])).tobsr(blocksize=(1, 1))
-        B = sparse.csr_matrix(np.array([[1.0, 2.3]])).tobsr(blocksize=(1, 1))
-        A2 = sparse.csr_matrix(np.array([[0.]])).tobsr(blocksize=(1, 1))
-        mask = sparse.csr_matrix(np.array([[1., 1.]])).tobsr(blocksize=(1, 1))
-        mask2 = sparse.csr_matrix(np.array([[0., 1.]])).tobsr(blocksize=(1, 1))
+        A = sparse.csr_array(np.array([[1.1]])).tobsr(blocksize=(1, 1))
+        B = sparse.csr_array(np.array([[1.0, 2.3]])).tobsr(blocksize=(1, 1))
+        A2 = sparse.csr_array(np.array([[0.]])).tobsr(blocksize=(1, 1))
+        mask = sparse.csr_array(np.array([[1., 1.]])).tobsr(blocksize=(1, 1))
+        mask2 = sparse.csr_array(np.array([[0., 1.]])).tobsr(blocksize=(1, 1))
         cases.append((A, B, mask))                                  # 1x1,  1x2
         cases.append((A2, B, mask))                                 # 1x1,  1x2
         cases.append((A, B, mask2))                                 # 1x1,  1x2
         cases.append((A2, B, mask2))                                # 1x1,  1x2
 
-        B2 = sparse.csr_matrix(np.array([[0.0, 2.3]])).tobsr(blocksize=(1, 1))
-        B3 = sparse.csr_matrix(np.array([[3.0, 0.0]])).tobsr(blocksize=(1, 1))
-        mask = sparse.csr_matrix(np.array([[1., 1.],
+        B2 = sparse.csr_array(np.array([[0.0, 2.3]])).tobsr(blocksize=(1, 1))
+        B3 = sparse.csr_array(np.array([[3.0, 0.0]])).tobsr(blocksize=(1, 1))
+        mask = sparse.csr_array(np.array([[1., 1.],
                                            [1., 1.]])).tobsr(blocksize=(1, 1))
-        mask3 = sparse.csr_matrix(np.array([[0., 1.],
+        mask3 = sparse.csr_array(np.array([[0., 1.],
                                             [1., 0.]])).tobsr(blocksize=(1, 1))
         cases.append((B.T.copy(), B2, mask))                      # 2x1,  1x2
         cases.append((B.T.copy(), B2, mask3))                     # 2x1,  1x2
@@ -85,9 +85,9 @@ class TestEnergyMin(TestCase):
         B = B.tobsr(blocksize=(1, 2))
         B2 = B2.tobsr(blocksize=(1, 2))
         B3 = B3.tobsr(blocksize=(1, 2))
-        mask = sparse.csr_matrix(np.array([[1., 1.],
+        mask = sparse.csr_array(np.array([[1., 1.],
                                            [1., 1.]])).tobsr(blocksize=(2, 2))
-        mask2 = sparse.csr_matrix(np.array([[0., 0.],
+        mask2 = sparse.csr_array(np.array([[0., 0.],
                                             [0., 0.]])).tobsr(blocksize=(2, 2))
         cases.append((B.T.copy(), B2, mask))                      # 2x1,  1x2
         cases.append((B.T.copy(), B2, mask2))                     # 2x1,  1x2
@@ -97,8 +97,8 @@ class TestEnergyMin(TestCase):
         B = B.tobsr(blocksize=(1, 1))
         B2 = B2.tobsr(blocksize=(1, 1))
         B3 = B3.tobsr(blocksize=(1, 1))
-        mask = sparse.csr_matrix(np.array([[1.]])).tobsr(blocksize=(1, 1))
-        mask2 = sparse.csr_matrix(np.array([[0.]])).tobsr(blocksize=(1, 1))
+        mask = sparse.csr_array(np.array([[1.]])).tobsr(blocksize=(1, 1))
+        mask2 = sparse.csr_array(np.array([[0.]])).tobsr(blocksize=(1, 1))
         cases.append((B, B2.T.copy(), mask))                      # 1x2,  2x1
         cases.append((B, B2.T.copy(), mask2))                     # 1x2,  2x1
         cases.append((B, B3.T.copy(), mask))                      # 1x2,  2x1
@@ -113,14 +113,14 @@ class TestEnergyMin(TestCase):
         cases.append((B, B3.T.copy(), mask2))                     # 1x2,  2x1
 
         # 2x2 tests
-        A = sparse.csr_matrix(np.array([[1., 2.], [2., 4.]])).tobsr(blocksize=(2, 2))
-        B = sparse.csr_matrix(np.array([[1.3, 2.], [2.8, 4.]])).tobsr(blocksize=(2, 2))
-        A2 = sparse.csr_matrix(np.array([[1.3, 0.], [0., 4.]])).tobsr(blocksize=(2, 2))
-        B2 = sparse.csr_matrix(np.array([[1.3, 0.], [2., 4.]])).tobsr(blocksize=(2, 1))
-        mask = sparse.csr_matrix((np.array([1., 1., 1., 1.]),
+        A = sparse.csr_array(np.array([[1., 2.], [2., 4.]])).tobsr(blocksize=(2, 2))
+        B = sparse.csr_array(np.array([[1.3, 2.], [2.8, 4.]])).tobsr(blocksize=(2, 2))
+        A2 = sparse.csr_array(np.array([[1.3, 0.], [0., 4.]])).tobsr(blocksize=(2, 2))
+        B2 = sparse.csr_array(np.array([[1.3, 0.], [2., 4.]])).tobsr(blocksize=(2, 1))
+        mask = sparse.csr_array((np.array([1., 1., 1., 1.]),
                                  (np.array([0, 0, 1, 1]), np.array([0, 1, 0, 1]))),
                                  shape=(2, 2)).tobsr(blocksize=(2, 2))
-        mask2 = sparse.csr_matrix((np.array([1., 0., 1., 0.]),
+        mask2 = sparse.csr_array((np.array([1., 0., 1., 0.]),
                                   (np.array([0, 0, 1, 1]), np.array([0, 1, 0, 1]))),
                                   shape=(2, 2)).tobsr(blocksize=(2, 1))
         mask2.eliminate_zeros()
@@ -136,7 +136,7 @@ class TestEnergyMin(TestCase):
         B2 = B2.tobsr(blocksize=(1, 1))
         mask = A.copy()
         mask2 = A2.copy()
-        mask3 = sparse.csr_matrix((np.ones(2, dtype=float),
+        mask3 = sparse.csr_array((np.ones(2, dtype=float),
                                   (np.array([0, 1]), np.array([0, 0]))),
                                   shape=(2, 2)).tobsr(blocksize=(1, 1))
         cases.append((A, B, mask))                                  # 2x2,  2x2
@@ -144,10 +144,10 @@ class TestEnergyMin(TestCase):
         cases.append((A, B, mask3))                                 # 2x2,  2x2
         cases.append((A2, B2, mask3))                               # 2x2,  2x2
 
-        B = sparse.csr_matrix(np.array([[1.0], [2.3]])).tobsr(blocksize=(1, 1))
-        B2 = sparse.csr_matrix(np.array([[1.1], [0.0]])).tobsr(blocksize=(1, 1))
-        mask = sparse.csr_matrix(np.array([[1.], [1.1]])).tobsr(blocksize=(1, 1))
-        mask2 = sparse.csr_matrix(np.array([[0.], [1.1]])).tobsr(blocksize=(1, 1))
+        B = sparse.csr_array(np.array([[1.0], [2.3]])).tobsr(blocksize=(1, 1))
+        B2 = sparse.csr_array(np.array([[1.1], [0.0]])).tobsr(blocksize=(1, 1))
+        mask = sparse.csr_array(np.array([[1.], [1.1]])).tobsr(blocksize=(1, 1))
+        mask2 = sparse.csr_array(np.array([[0.], [1.1]])).tobsr(blocksize=(1, 1))
         cases.append((A, B, mask))                                 # 2x2,  2x1
         cases.append((A, B2, mask2))                                # 2x2,  2x1
         cases.append((A2, B, mask))                                 # 2x2,  2x1
@@ -162,14 +162,14 @@ class TestEnergyMin(TestCase):
         cases.append((A, B, mask))                                 # 2x2,  2x1
         cases.append((A2, B2, mask2))                              # 2x2,  2x1
 
-        B = sparse.csr_matrix(np.array([[1.3, 2., 1.0], [2.8, 4., 0.]]))
+        B = sparse.csr_array(np.array([[1.3, 2., 1.0], [2.8, 4., 0.]]))
         B = B.tobsr(blocksize=(1, 1))
-        B2 = sparse.csr_matrix(np.array([[1.3, 2., 1.0], [2.8, 4., 0.]]))
+        B2 = sparse.csr_array(np.array([[1.3, 2., 1.0], [2.8, 4., 0.]]))
         B2 = B2.tobsr(blocksize=(2, 3))
-        mask = sparse.csr_matrix(np.array([[1., 2., 1.], [1., 2., 0.]]))
+        mask = sparse.csr_array(np.array([[1., 2., 1.], [1., 2., 0.]]))
         mask = mask.tobsr(blocksize=(1, 1))
         mask2 = mask.tobsr((2, 3))
-        mask3 = sparse.csr_matrix(np.array([[0., 0., 0.], [0., 0., 0.]]))
+        mask3 = sparse.csr_array(np.array([[0., 0., 0.], [0., 0., 0.]]))
         mask3 = mask3.tobsr(blocksize=(2, 3))
         cases.append((A, B, mask))                                 # 2x2,  2x3
         cases.append((A2, B2, mask2))                              # 2x2,  2x3
@@ -191,11 +191,11 @@ class TestEnergyMin(TestCase):
         A2[1, :] = 0.0
         A3 = A2.copy()
         A3[:, 1] = 0.0
-        A = sparse.csr_matrix(A).tobsr(blocksize=(2, 2))
-        A2 = sparse.csr_matrix(A2).tobsr(blocksize=(2, 2))
-        A3 = sparse.csr_matrix(A3).tobsr(blocksize=(2, 2))
-        B = sparse.csr_matrix(B).tobsr(blocksize=(2, 2))
-        B2 = sparse.csr_matrix(B).tobsr(blocksize=(2, 1))
+        A = sparse.csr_array(A).tobsr(blocksize=(2, 2))
+        A2 = sparse.csr_array(A2).tobsr(blocksize=(2, 2))
+        A3 = sparse.csr_array(A3).tobsr(blocksize=(2, 2))
+        B = sparse.csr_array(B).tobsr(blocksize=(2, 2))
+        B2 = sparse.csr_array(B).tobsr(blocksize=(2, 1))
 
         mask = A.copy()
         mask2 = B.copy()
@@ -217,7 +217,7 @@ class TestEnergyMin(TestCase):
         A = A.tobsr(blocksize=(5, 5))
         Ai = 1.0j * A
         B = A.toarray()
-        B = sparse.csr_matrix(B[:, 0:8])
+        B = sparse.csr_array(B[:, 0:8])
         B = B.tobsr(blocksize=(5, 8))
         Bi = 1.0j * B
         B2 = B.tobsr(blocksize=(5, 2))
@@ -621,8 +621,8 @@ class TestEnergyMin(TestCase):
 # class TestSatisfyConstraints(TestCase):
 #    def test_scalar(self):
 #
-#        U = bsr_matrix([[1,2],[2,1]], blocksize=(1,1))
-#        pattern = bsr_matrix([[1,1],[1,1]],blocksize=(1,1))
+#        U = bsr_array([[1,2],[2,1]], blocksize=(1,1))
+#        pattern = bsr_array([[1,1],[1,1]],blocksize=(1,1))
 #        B = np.array(np.array([[1],[1]]))
 #        BtBinv = [ np.array([[0.5]]), np.array([[0.5]]) ]
 #        colindices = [ np.array([0,1]), np.array([0,1]) ]
@@ -645,8 +645,8 @@ class TestEnergyMin(TestCase):
 #                   [0,0,4,1],
 #                   [0,0,2,3]])
 #
-#        pattern = bsr_matrix(pattern, blocksize=(1,2))
-#        U = bsr_matrix(U, blocksize=(1,2))
+#        pattern = bsr_array(pattern, blocksize=(1,2))
+#        U = bsr_array(U, blocksize=(1,2))
 #        B = np.array([[1,1],
 #                   [1,2],
 #                   [1,3],

--- a/pyamg/aggregation/tests/test_tentative.py
+++ b/pyamg/aggregation/tests/test_tentative.py
@@ -1,6 +1,6 @@
 """Test tentative interpolation."""
 import numpy as np
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 
 from pyamg.aggregation.aggregation import fit_candidates
 
@@ -14,88 +14,88 @@ class TestFitCandidates(TestCase):
         # tests where AggOp includes all dofs
         # one candidate
         self.cases.append((
-            csr_matrix((np.ones(5), np.array([0, 0, 0, 1, 1]), np.arange(6)),
+            csr_array((np.ones(5), np.array([0, 0, 0, 1, 1]), np.arange(6)),
                        shape=(5, 2)), np.ones((5, 1))))
         self.cases.append((
-            csr_matrix((np.ones(5), np.array([1, 1, 0, 0, 0]), np.arange(6)),
+            csr_array((np.ones(5), np.array([1, 1, 0, 0, 0]), np.arange(6)),
                        shape=(5, 2)), np.ones((5, 1))))
         self.cases.append((
-            csr_matrix((np.ones(9), np.array([0, 0, 0, 1, 1, 1, 2, 2, 2]),
+            csr_array((np.ones(9), np.array([0, 0, 0, 1, 1, 1, 2, 2, 2]),
                         np.arange(10)),
                        shape=(9, 3)), np.ones((9, 1))))
         self.cases.append((
-            csr_matrix((np.ones(9), np.array([2, 1, 0, 0, 1, 2, 1, 0, 2]),
+            csr_array((np.ones(9), np.array([2, 1, 0, 0, 1, 2, 1, 0, 2]),
                         np.arange(10)),
                        shape=(9, 3)), np.arange(9).reshape(9, 1)))
         # two candidates
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 1, 1]), np.arange(5)),
+            csr_array((np.ones(4), np.array([0, 0, 1, 1]), np.arange(5)),
                        shape=(4, 2)), np.vstack((np.ones(4), np.arange(4))).T))
         self.cases.append((
-            csr_matrix((np.ones(9), np.array([0, 0, 0, 1, 1, 1, 2, 2, 2]),
+            csr_array((np.ones(9), np.array([0, 0, 0, 1, 1, 1, 2, 2, 2]),
                         np.arange(10)),
                        shape=(9, 3)), np.vstack((np.ones(9), np.arange(9))).T))
         self.cases.append((
-            csr_matrix((np.ones(9), np.array([0, 0, 1, 1, 2, 2, 3, 3, 3]),
+            csr_array((np.ones(9), np.array([0, 0, 1, 1, 2, 2, 3, 3, 3]),
                         np.arange(10)),
                        shape=(9, 4)), np.vstack((np.ones(9), np.arange(9))).T))
         # two candidates, small norms
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 1, 1]), np.arange(5)),
+            csr_array((np.ones(4), np.array([0, 0, 1, 1]), np.arange(5)),
                        shape=(4, 2)),
             np.vstack((np.ones(4), 1e-20 * np.arange(4))).T))
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 1, 1]), np.arange(5)),
+            csr_array((np.ones(4), np.array([0, 0, 1, 1]), np.arange(5)),
                        shape=(4, 2)),
             1e-20 * np.vstack((np.ones(4), np.arange(4))).T))
 
         # block aggregates, one candidate
         self.cases.append((
-            csr_matrix((np.ones(3), np.array([0, 1, 1]), np.arange(4)),
+            csr_array((np.ones(3), np.array([0, 1, 1]), np.arange(4)),
                        shape=(3, 2)), np.ones((6, 1))))
         self.cases.append((
-            csr_matrix((np.ones(3), np.array([0, 1, 1]), np.arange(4)),
+            csr_array((np.ones(3), np.array([0, 1, 1]), np.arange(4)),
                        shape=(3, 2)), np.ones((9, 1))))
         self.cases.append((
-            csr_matrix((np.ones(5), np.array([2, 0, 2, 1, 1]), np.arange(6)),
+            csr_array((np.ones(5), np.array([2, 0, 2, 1, 1]), np.arange(6)),
                        shape=(5, 3)), np.ones((10, 1))))
 
         # block aggregates, two candidates
         self.cases.append((
-            csr_matrix((np.ones(3), np.array([0, 1, 1]), np.arange(4)),
+            csr_array((np.ones(3), np.array([0, 1, 1]), np.arange(4)),
                        shape=(3, 2)), np.vstack((np.ones(6), np.arange(6))).T))
         self.cases.append((
-            csr_matrix((np.ones(3), np.array([0, 1, 1]), np.arange(4)),
+            csr_array((np.ones(3), np.array([0, 1, 1]), np.arange(4)),
                        shape=(3, 2)), np.vstack((np.ones(9), np.arange(9))).T))
         self.cases.append((
-            csr_matrix((np.ones(5), np.array([2, 0, 2, 1, 1]), np.arange(6)),
+            csr_array((np.ones(5), np.array([2, 0, 2, 1, 1]), np.arange(6)),
                        shape=(5, 3)),
             np.vstack((np.ones(10), np.arange(10))).T))
 
         # tests where AggOp excludes some dofs
         # one candidate
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 1, 1]),
+            csr_array((np.ones(4), np.array([0, 0, 1, 1]),
                         np.array([0, 1, 2, 2, 3, 4])),
                        shape=(5, 2)), np.ones((5, 1))))
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 1, 1]),
+            csr_array((np.ones(4), np.array([0, 0, 1, 1]),
                         np.array([0, 1, 2, 2, 3, 4])),
                        shape=(5, 2)), np.vstack((np.ones(5), np.arange(5))).T))
 
         # overdetermined blocks
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 1, 1]),
+            csr_array((np.ones(4), np.array([0, 0, 1, 1]),
                         np.array([0, 1, 2, 2, 3, 4])),
                        shape=(5, 2)),
             np.vstack((np.ones(5), np.arange(5), np.arange(5)**2)).T))
         self.cases.append((
-            csr_matrix((np.ones(6), np.array([1, 3, 0, 2, 1, 0]),
+            csr_array((np.ones(6), np.array([1, 3, 0, 2, 1, 0]),
                         np.array([0, 0, 1, 2, 2, 3, 4, 5, 5, 6])),
                        shape=(9, 4)),
             np.vstack((np.ones(9), np.arange(9), np.arange(9) ** 2)).T))
         self.cases.append((
-            csr_matrix((np.ones(6), np.array([1, 3, 0, 2, 1, 0]),
+            csr_array((np.ones(6), np.array([1, 3, 0, 2, 1, 0]),
                         np.array([0, 0, 1, 2, 2, 3, 4, 5, 5, 6])),
                        shape=(9, 4)),
             np.vstack((np.ones(9), np.arange(9))).T))
@@ -104,68 +104,68 @@ class TestFitCandidates(TestCase):
         # one aggregate one candidate
         # checks real part of complex
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 0, 0]), np.arange(5)),
+            csr_array((np.ones(4), np.array([0, 0, 0, 0]), np.arange(5)),
                        shape=(4, 1)), (1 + 0j) * np.ones((4, 1))))
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 0, 0]), np.arange(5)),
+            csr_array((np.ones(4), np.array([0, 0, 0, 0]), np.arange(5)),
                        shape=(4, 1)), (0 + 3j) * np.ones((4, 1))))
         # checks norm(), but not dot()
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 0, 0]), np.arange(5)),
+            csr_array((np.ones(4), np.array([0, 0, 0, 0]), np.arange(5)),
                        shape=(4, 1)), (1 + 3j) * np.ones((4, 1))))
         # checks norm(), but not dot()
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 0, 0]), np.arange(5)),
+            csr_array((np.ones(4), np.array([0, 0, 0, 0]), np.arange(5)),
                        shape=(4, 1)), (0 + 3j) * np.arange(4).reshape(4, 1)))
         # checks norm(), but not dot()
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 0, 0]), np.arange(5)),
+            csr_array((np.ones(4), np.array([0, 0, 0, 0]), np.arange(5)),
                        shape=(4, 1)), (1 + 3j) * np.arange(4).reshape(4, 1)))
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 0, 0]), np.arange(5)),
+            csr_array((np.ones(4), np.array([0, 0, 0, 0]), np.arange(5)),
                        shape=(4, 1)),
             np.array([[-1 + 4j], [0 + 5j], [5 - 2j], [9 - 8j]])))
         # one aggregate two candidates
         # checks real part of complex
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 0, 0]), np.arange(5)),
+            csr_array((np.ones(4), np.array([0, 0, 0, 0]), np.arange(5)),
                        shape=(4, 1)),
             (1 + 0j) * np.vstack((np.ones(4), np.arange(4))).T))
         # checks norm() and dot()
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 0, 0]), np.arange(5)),
+            csr_array((np.ones(4), np.array([0, 0, 0, 0]), np.arange(5)),
                        shape=(4, 1)),
             (1 + 3j) * np.vstack((np.ones(4), np.arange(4))).T))
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 0, 0]), np.arange(5)),
+            csr_array((np.ones(4), np.array([0, 0, 0, 0]), np.arange(5)),
                        shape=(4, 1)),
             np.array([[-1 + 4j, 1 + 3j], [0 + 5j, 6 + 0j],
                       [5 - 2j, 7 + 1j], [9 - 8j, 7 + 2j]])))
         # two aggregates one candidates
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 1, 1]), np.arange(5)),
+            csr_array((np.ones(4), np.array([0, 0, 1, 1]), np.arange(5)),
                        shape=(4, 2)), (1 + 3j) * np.arange(4).reshape(4, 1)))
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 1, 1]), np.arange(5)),
+            csr_array((np.ones(4), np.array([0, 0, 1, 1]), np.arange(5)),
                        shape=(4, 2)), (0 + 3j) * np.arange(4).reshape(4, 1)))
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 1, 1]), np.arange(5)),
+            csr_array((np.ones(4), np.array([0, 0, 1, 1]), np.arange(5)),
                        shape=(4, 2)), (1 + 3j) * np.arange(4).reshape(4, 1)))
         # two aggregates two candidates
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 1, 1]), np.arange(5)),
+            csr_array((np.ones(4), np.array([0, 0, 1, 1]), np.arange(5)),
                        shape=(4, 2)),
             (1 + 0j) * np.vstack((np.ones(4), np.arange(4))).T))
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 1, 1]), np.arange(5)),
+            csr_array((np.ones(4), np.array([0, 0, 1, 1]), np.arange(5)),
                        shape=(4, 2)),
             (0 + 3j) * np.vstack((np.ones(4), np.arange(4))).T))
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 1, 1]), np.arange(5)),
+            csr_array((np.ones(4), np.array([0, 0, 1, 1]), np.arange(5)),
                        shape=(4, 2)),
             (1 + 3j) * np.vstack((np.ones(4), np.arange(4))).T))
         self.cases.append((
-            csr_matrix((np.ones(4), np.array([0, 0, 1, 1]), np.arange(5)),
+            csr_array((np.ones(4), np.array([0, 0, 1, 1]), np.arange(5)),
                        shape=(4, 2)),
             np.array([[-1 + 4j, 1 + 3j], [0 + 5j, 6 + 0j],
                       [5 - 2j, 7 + 1j], [9 - 8j, 7 + 2j]])))

--- a/pyamg/aggregation/tests/test_tentative.py
+++ b/pyamg/aggregation/tests/test_tentative.py
@@ -176,6 +176,8 @@ class TestFitCandidates(TestCase):
             candidates[np.where(np.diff(AggOp.indptr) == 0)[0], :] = 0
 
         for AggOp, fine_candidates in self.cases:
+            AggOp.indptr = AggOp.indptr.astype(np.int32)
+            AggOp.indices = AggOp.indices.astype(np.int32)
             mask_candidate(AggOp, fine_candidates)
 
             Q, coarse_candidates = fit_candidates(AggOp, fine_candidates)

--- a/pyamg/amg_core/evolution_strength.h
+++ b/pyamg/amg_core/evolution_strength.h
@@ -46,14 +46,14 @@
  *
  * Examples
  * --------
- * >>> from scipy.sparse import csr_matrix
+ * >>> from scipy.sparse import csr_array
  * >>> from pyamg.amg_core import apply_absolute_distance_filter
  * >>> from scipy import array
  * >>> # Graph in CSR where entries in row i represent distances from dof i
  * >>> indptr = array([0,3,6,9])
  * >>> indices = array([0,1,2,0,1,2,0,1,2])
  * >>> data = array([1.,2.,3.,4.,1.,2.,3.,9.,1.])
- * >>> S = csr_matrix( (data,indices,indptr), shape=(3,3) )
+ * >>> S = csr_array( (data,indices,indptr), shape=(3,3) )
  * >>> print "Matrix Before Applying Filter\n" + str(S.todense())
  * >>> apply_absolute_distance_filter(3, 1.9, S.indptr, S.indices, S.data)
  * >>> print "Matrix After Applying Filter\n" + str(S.todense())
@@ -123,14 +123,14 @@ void apply_absolute_distance_filter(const I n_row,
  *
  * Examples
  * --------
- * >>> from scipy.sparse import csr_matrix
+ * >>> from scipy.sparse import csr_array
  * >>> from pyamg.amg_core import apply_distance_filter
  * >>> from scipy import array
  * >>> # Graph in CSR where entries in row i represent distances from dof i
  * >>> indptr = array([0,3,6,9])
  * >>> indices = array([0,1,2,0,1,2,0,1,2])
  * >>> data = array([1.,2.,3.,4.,1.,2.,3.,9.,1.])
- * >>> S = csr_matrix( (data,indices,indptr), shape=(3,3) )
+ * >>> S = csr_array( (data,indices,indptr), shape=(3,3) )
  * >>> print "Matrix before Applying Filter\n" + str(S.todense())
  * >>> apply_distance_filter(3, 1.9, S.indptr, S.indices, S.data)
  * >>> print "Matrix after Applying Filter\n" + str(S.todense())
@@ -198,18 +198,18 @@ void apply_distance_filter(const I n_row,
  *
  * Examples
  * --------
- * >>> from scipy.sparse import bsr_matrix, csr_matrix
+ * >>> from scipy.sparse import bsr_array, csr_array
  * >>> from pyamg.amg_core import min_blocks
  * >>> from numpy import zeros, array, ravel, round
  * >>> from numpy import rand
  * >>> row  = array([0,2,4,6])
  * >>> col  = array([0,2,2,0,1,2])
  * >>> data = round(10*rand(6,2,2), decimals=1)
- * >>> S = bsr_matrix( (data,col,row), shape=(6,6) )
+ * >>> S = bsr_array( (data,col,row), shape=(6,6) )
  * >>> T = zeros(data.shape[0])
  * >>> print "Matrix before\n" + str(S.todense())
  * >>> min_blocks(6, 4, ravel(S.data), T)
- * >>> S2 = csr_matrix((T, S.indices, S.indptr), shape=(3,3))
+ * >>> S2 = csr_array((T, S.indices, S.indptr), shape=(3,3))
  * >>> print "Matrix after\n" + str(S2.todense())
  */
 template<class I, class T>
@@ -664,11 +664,11 @@ T my_inner(const I Ap[], const I Aj[], const T Ax[],
  * --------
  * >>> from pyamg.amg_core import incomplete_mat_mult_csr
  * >>> from numpy import arange, eye, ones
- * >>> from scipy.sparse import csr_matrix, csc_matrix
+ * >>> from scipy.sparse import csr_array, csc_array
  * >>>
- * >>> A = csr_matrix(arange(1,10,dtype=float).reshape(3,3))
- * >>> B = csc_matrix(ones((3,3),dtype=float))
- * >>> AB = csr_matrix(eye(3,3,dtype=float))
+ * >>> A = csr_array(arange(1,10,dtype=float).reshape(3,3))
+ * >>> B = csc_array(ones((3,3),dtype=float))
+ * >>> AB = csr_array(eye(3,3,dtype=float))
  * >>> A.sort_indices()
  * >>> B.sort_indices()
  * >>> AB.sort_indices()

--- a/pyamg/amg_core/evolution_strength.h
+++ b/pyamg/amg_core/evolution_strength.h
@@ -201,7 +201,7 @@ void apply_distance_filter(const I n_row,
  * >>> from scipy.sparse import bsr_matrix, csr_matrix
  * >>> from pyamg.amg_core import min_blocks
  * >>> from numpy import zeros, array, ravel, round
- * >>> from scipy import rand
+ * >>> from numpy import rand
  * >>> row  = array([0,2,4,6])
  * >>> col  = array([0,2,2,0,1,2])
  * >>> data = round(10*rand(6,2,2), decimals=1)
@@ -663,7 +663,7 @@ T my_inner(const I Ap[], const I Aj[], const T Ax[],
  * Examples
  * --------
  * >>> from pyamg.amg_core import incomplete_mat_mult_csr
- * >>> from scipy import arange, eye, ones
+ * >>> from numpy import arange, eye, ones
  * >>> from scipy.sparse import csr_matrix, csc_matrix
  * >>>
  * >>> A = csr_matrix(arange(1,10,dtype=float).reshape(3,3))

--- a/pyamg/amg_core/evolution_strength_bind.cpp
+++ b/pyamg/amg_core/evolution_strength_bind.cpp
@@ -225,14 +225,14 @@ Principle calling routines are strength of connection routines, e.g.,
 
 Examples
 --------
->>> from scipy.sparse import csr_matrix
+>>> from scipy.sparse import csr_array
 >>> from pyamg.amg_core import apply_absolute_distance_filter
 >>> from scipy import array
 >>> # Graph in CSR where entries in row i represent distances from dof i
 >>> indptr = array([0,3,6,9])
 >>> indices = array([0,1,2,0,1,2,0,1,2])
 >>> data = array([1.,2.,3.,4.,1.,2.,3.,9.,1.])
->>> S = csr_matrix( (data,indices,indptr), shape=(3,3) )
+>>> S = csr_array( (data,indices,indptr), shape=(3,3) )
 >>> print "Matrix Before Applying Filter\n" + str(S.todense())
 >>> apply_absolute_distance_filter(3, 1.9, S.indptr, S.indices, S.data)
 >>> print "Matrix After Applying Filter\n" + str(S.todense()))pbdoc");
@@ -279,14 +279,14 @@ a drop tolerance.
 
 Examples
 --------
->>> from scipy.sparse import csr_matrix
+>>> from scipy.sparse import csr_array
 >>> from pyamg.amg_core import apply_distance_filter
 >>> from scipy import array
 >>> # Graph in CSR where entries in row i represent distances from dof i
 >>> indptr = array([0,3,6,9])
 >>> indices = array([0,1,2,0,1,2,0,1,2])
 >>> data = array([1.,2.,3.,4.,1.,2.,3.,9.,1.])
->>> S = csr_matrix( (data,indices,indptr), shape=(3,3) )
+>>> S = csr_array( (data,indices,indptr), shape=(3,3) )
 >>> print "Matrix before Applying Filter\n" + str(S.todense())
 >>> apply_distance_filter(3, 1.9, S.indptr, S.indices, S.data)
 >>> print "Matrix after Applying Filter\n" + str(S.todense()))pbdoc");
@@ -324,18 +324,18 @@ supernodes by setting the strength value to be the minimum nonzero in a block.
 
 Examples
 --------
->>> from scipy.sparse import bsr_matrix, csr_matrix
+>>> from scipy.sparse import bsr_array, csr_array
 >>> from pyamg.amg_core import min_blocks
 >>> from numpy import zeros, array, ravel, round
 >>> from numpy import rand
 >>> row  = array([0,2,4,6])
 >>> col  = array([0,2,2,0,1,2])
 >>> data = round(10*rand(6,2,2), decimals=1)
->>> S = bsr_matrix( (data,col,row), shape=(6,6) )
+>>> S = bsr_array( (data,col,row), shape=(6,6) )
 >>> T = zeros(data.shape[0])
 >>> print "Matrix before\n" + str(S.todense())
 >>> min_blocks(6, 4, ravel(S.data), T)
->>> S2 = csr_matrix((T, S.indices, S.indptr), shape=(3,3))
+>>> S2 = csr_array((T, S.indices, S.indptr), shape=(3,3))
 >>> print "Matrix after\n" + str(S2.todense()))pbdoc");
 
     m.def("evolution_strength_helper", &_evolution_strength_helper<int, float, float>,
@@ -485,11 +485,11 @@ Examples
 --------
 >>> from pyamg.amg_core import incomplete_mat_mult_csr
 >>> from numpy import arange, eye, ones
->>> from scipy.sparse import csr_matrix, csc_matrix
+>>> from scipy.sparse import csr_array, csc_array
 >>>
->>> A = csr_matrix(arange(1,10,dtype=float).reshape(3,3))
->>> B = csc_matrix(ones((3,3),dtype=float))
->>> AB = csr_matrix(eye(3,3,dtype=float))
+>>> A = csr_array(arange(1,10,dtype=float).reshape(3,3))
+>>> B = csc_array(ones((3,3),dtype=float))
+>>> AB = csr_array(eye(3,3,dtype=float))
 >>> A.sort_indices()
 >>> B.sort_indices()
 >>> AB.sort_indices()

--- a/pyamg/amg_core/evolution_strength_bind.cpp
+++ b/pyamg/amg_core/evolution_strength_bind.cpp
@@ -327,7 +327,7 @@ Examples
 >>> from scipy.sparse import bsr_matrix, csr_matrix
 >>> from pyamg.amg_core import min_blocks
 >>> from numpy import zeros, array, ravel, round
->>> from scipy import rand
+>>> from numpy import rand
 >>> row  = array([0,2,4,6])
 >>> col  = array([0,2,2,0,1,2])
 >>> data = round(10*rand(6,2,2), decimals=1)
@@ -484,7 +484,7 @@ BIG cost savings.
 Examples
 --------
 >>> from pyamg.amg_core import incomplete_mat_mult_csr
->>> from scipy import arange, eye, ones
+>>> from numpy import arange, eye, ones
 >>> from scipy.sparse import csr_matrix, csc_matrix
 >>>
 >>> A = csr_matrix(arange(1,10,dtype=float).reshape(3,3))

--- a/pyamg/amg_core/smoothed_aggregation.h
+++ b/pyamg/amg_core/smoothed_aggregation.h
@@ -701,7 +701,7 @@ void fit_candidates_complex(const I n_row,
  *        num_block_rows x cols_per_block x cols_per_block
  *   B  = asarray(B).reshape(-1,cols_per_block,B.shape[1])
  *   UB = asarray(UB).reshape(-1,rows_per_block,UB.shape[1])
- *   rows = csr_matrix((U.indices,U.indices,U.indptr), \
+ *   rows = csr_array((U.indices,U.indices,U.indptr), \
  *           shape=(U.shape[0]/rows_per_block,U.shape[1]/cols_per_block)).tocoo(copy=False).row
  *   for n,j in enumerate(U.indices):
  *      i = rows[n]

--- a/pyamg/amg_core/smoothed_aggregation_bind.cpp
+++ b/pyamg/amg_core/smoothed_aggregation_bind.cpp
@@ -591,7 +591,7 @@ This implements the python code:
        num_block_rows x cols_per_block x cols_per_block
   B  = asarray(B).reshape(-1,cols_per_block,B.shape[1])
   UB = asarray(UB).reshape(-1,rows_per_block,UB.shape[1])
-  rows = csr_matrix((U.indices,U.indices,U.indptr), \
+  rows = csr_array((U.indices,U.indices,U.indptr), \
           shape=(U.shape[0]/rows_per_block,U.shape[1]/cols_per_block)).tocoo(copy=False).row
   for n,j in enumerate(U.indices):
      i = rows[n]

--- a/pyamg/blackbox.py
+++ b/pyamg/blackbox.py
@@ -2,7 +2,7 @@
 
 
 import numpy as np
-from scipy.sparse import issparse, csr_matrix
+from scipy.sparse import issparse, csr_array
 
 from .aggregation import smoothed_aggregation_solver
 from .util.linalg import ishermitian
@@ -19,8 +19,8 @@ def make_csr(A):
 
     Returns
     -------
-    A : csr_matrix, bsr_matrix
-        If A is csr_matrix or bsr_matrix, then do nothing and return A.
+    A : csr_array, bsr_array
+        If A is csr_array or bsr_array, then do nothing and return A.
         Else, convert A to CSR if possible and return.
 
     Examples
@@ -35,11 +35,11 @@ def make_csr(A):
     # Convert to CSR or BSR if necessary
     if not issparse(A) or A.format not in ('bsr', 'csr'):
         try:
-            A = csr_matrix(A)
+            A = csr_array(A)
             print('Implicit conversion of A to CSR in pyamg.blackbox.make_csr')
         except Exception as e:
-            raise TypeError('Argument A must have type csr_matrix or '
-                            'bsr_matrix, or be convertible to csr_matrix') from e
+            raise TypeError('Argument A must have type csr_array or '
+                            'bsr_array, or be convertible to csr_array') from e
 
     if A.shape[0] != A.shape[1]:
         raise TypeError('Argument A must be a square')
@@ -54,7 +54,7 @@ def solver_configuration(A, B=None, verb=True):
 
     Parameters
     ----------
-    A : array, matrix, csr_matrix, bsr_matrix
+    A : array, matrix, csr_array, bsr_array
         (n x n) matrix to invert, CSR or BSR format preferred for efficiency
     B : None, array
         Near null-space modes used to construct the smoothed aggregation solver
@@ -156,7 +156,7 @@ def solver(A, config):
 
     Parameters
     ----------
-    A : array, matrix, csr_matrix, bsr_matrix
+    A : array, matrix, csr_array, bsr_array
         Matrix to invert, CSR or BSR format preferred for efficiency
     config : dict
         A dictionary of solver configuration parameters that is used to
@@ -217,7 +217,7 @@ def solve(A, b, x0=None, tol=1e-5, maxiter=400, return_solver=False,
 
     Parameters
     ----------
-    A : array, matrix, csr_matrix, bsr_matrix
+    A : array, matrix, csr_array, bsr_array
         Matrix to invert, CSR or BSR format preferred for efficiency
     b : array
         Right hand side.

--- a/pyamg/classical/air.py
+++ b/pyamg/classical/air.py
@@ -34,7 +34,7 @@ def air_solver(A,
 
     Parameters
     ----------
-    A : csr_matrix
+    A : csr_array
         Square (non)symmetric matrix in CSR format
     strength : ['symmetric', 'classical', 'evolution', 'distance',
                 'algebraic_distance','affinity', 'energy_based', None]

--- a/pyamg/classical/classical.py
+++ b/pyamg/classical/classical.py
@@ -2,7 +2,7 @@
 
 
 from warnings import warn
-from scipy.sparse import csr_matrix, issparse, SparseEfficiencyWarning
+from scipy.sparse import csr_array, issparse, SparseEfficiencyWarning
 import numpy as np
 
 from pyamg.multilevel import MultilevelSolver
@@ -28,7 +28,7 @@ def ruge_stuben_solver(A,
 
     Parameters
     ----------
-    A : csr_matrix
+    A : csr_array
         Square matrix in CSR format
     strength : str
         Valid strings are ['symmetric', 'classical', 'evolution', 'distance',
@@ -97,11 +97,11 @@ def ruge_stuben_solver(A,
     # convert A to csr
     if not issparse(A) or A.format != 'csr':
         try:
-            A = csr_matrix(A)
+            A = csr_array(A)
             warn('Implicit conversion of A to CSR', SparseEfficiencyWarning)
         except Exception as e:
-            raise TypeError('Argument A must have type csr_matrix, '
-                            'or be convertible to csr_matrix') from e
+            raise TypeError('Argument A must have type csr_array, '
+                            'or be convertible to csr_array') from e
     # preprocess A
     A = asfptype(A)
     if A.shape[0] != A.shape[1]:

--- a/pyamg/classical/cr.py
+++ b/pyamg/classical/cr.py
@@ -19,7 +19,7 @@ def _CRsweep(A, B, Findex, Cindex, nu, thetacr, method):
 
     Parameters
     ----------
-    A : csr_matrix
+    A : csr_array
         Target system matrix
     B : array like
         Target near null space mode
@@ -84,7 +84,7 @@ def CR(A, method='habituated', B=None, nu=3, thetacr=0.7,
 
     Parameters
     ----------
-    A : csr_matrix
+    A : csr_array
         sparse matrix (n x n) usually matrix A of Ax=b
     method : {'habituated','concurrent'}
         Method used during relaxation:
@@ -223,7 +223,7 @@ def binormalize(A, tol=1e-5, maxiter=10):
 
     Parameters
     ----------
-    A : csr_matrix
+    A : csr_array
         sparse matrix (n x n)
     tol : float
         tolerance
@@ -234,7 +234,7 @@ def binormalize(A, tol=1e-5, maxiter=10):
 
     Returns
     -------
-    C : csr_matrix
+    C : csr_array
         diagonally scaled A, C=DAD
 
     Notes

--- a/pyamg/classical/cr.py
+++ b/pyamg/classical/cr.py
@@ -3,7 +3,7 @@
 from copy import deepcopy
 import numpy as np
 from scipy.linalg import norm
-from scipy.sparse import issparse, diags
+from scipy.sparse import issparse, diags_array
 
 from pyamg import amg_core
 from ..relaxation.relaxation import gauss_seidel, gauss_seidel_indexed
@@ -311,7 +311,7 @@ def binormalize(A, tol=1e-5, maxiter=10):
 
     # rescale for unit 2-norm
     d = np.sqrt(x)
-    D = diags([d.ravel()], offsets=[0], shape=(n, n))
+    D = diags_array([d.ravel()], offsets=[0], shape=(n, n))
     C = D @ A @ D
     C = C.tocsr()
     beta = C.multiply(C).sum(axis=1)

--- a/pyamg/classical/interpolate.py
+++ b/pyamg/classical/interpolate.py
@@ -3,7 +3,7 @@
 from warnings import warn
 
 import numpy as np
-from scipy.sparse import csr_matrix, bsr_matrix, issparse, SparseEfficiencyWarning
+from scipy.sparse import csr_array, bsr_array, issparse, SparseEfficiencyWarning
 
 from .. import amg_core
 from ..strength import classical_strength_of_connection
@@ -14,9 +14,9 @@ def direct_interpolation(A, C, splitting, theta=None, norm='min'):
 
     Parameters
     ----------
-    A : csr_matrix
+    A : csr_array
         NxN matrix in CSR format
-    C : csr_matrix
+    C : csr_array
         Strength-of-Connection matrix
         Must have zero diagonal
     theta : float in [0, 1), default None
@@ -31,7 +31,7 @@ def direct_interpolation(A, C, splitting, theta=None, norm='min'):
 
     Returns
     -------
-    P : csr_matrix
+    P : csr_array
         Prolongator using direct interpolation
 
     Examples
@@ -51,10 +51,10 @@ def direct_interpolation(A, C, splitting, theta=None, norm='min'):
 
     """
     if not issparse(A) or A.format != 'csr':
-        raise TypeError('expected csr_matrix for A')
+        raise TypeError('expected csr_array for A')
 
     if not issparse(C) or C.format != 'csr':
-        raise TypeError('expected csr_matrix for C')
+        raise TypeError('expected csr_array for C')
 
     if theta is not None:
         C = classical_strength_of_connection(A, theta=theta, norm=norm)
@@ -80,7 +80,7 @@ def direct_interpolation(A, C, splitting, theta=None, norm='min'):
 
     nc = np.sum(splitting)
     n = A.shape[0]
-    return csr_matrix((P_data, P_indices, P_indptr), shape=[n, nc])
+    return csr_array((P_data, P_indices, P_indptr), shape=[n, nc])
 
 
 def classical_interpolation(A, C, splitting, theta=None, norm='min', modified=True):
@@ -88,9 +88,9 @@ def classical_interpolation(A, C, splitting, theta=None, norm='min', modified=Tr
 
     Parameters
     ----------
-    A : csr_matrix
+    A : csr_array
         NxN matrix in CSR format
-    C : csr_matrix
+    C : csr_array
         Strength-of-Connection matrix
         Must have zero diagonal
     splitting : array
@@ -109,7 +109,7 @@ def classical_interpolation(A, C, splitting, theta=None, norm='min', modified=Tr
 
     Returns
     -------
-    P : csr_matrix
+    P : csr_array
         Prolongator using classical interpolation; see Sec. 3 Eq. (8)
         of [0] for modified=False and Eq. (9) for modified=True.
 
@@ -130,10 +130,10 @@ def classical_interpolation(A, C, splitting, theta=None, norm='min', modified=Tr
 
     """
     if not issparse(A) or A.format != 'csr':
-        raise TypeError('expected csr_matrix for A')
+        raise TypeError('expected csr_array for A')
 
     if not issparse(C) or C.format != 'csr':
-        raise TypeError('Expected csr_matrix SOC matrix, C.')
+        raise TypeError('Expected csr_array SOC matrix, C.')
 
     nc = np.sum(splitting)
     n = A.shape[0]
@@ -168,7 +168,7 @@ def classical_interpolation(A, C, splitting, theta=None, norm='min', modified=Tr
                                               C.data, splitting, P_indptr,
                                               P_indices, P_data, modified)
 
-    return csr_matrix((P_data, P_indices, P_indptr), shape=[n, nc])
+    return csr_array((P_data, P_indices, P_indptr), shape=[n, nc])
 
 
 def injection_interpolation(A, splitting):
@@ -176,7 +176,7 @@ def injection_interpolation(A, splitting):
 
     Parameters
     ----------
-    A : {csr_matrix}
+    A : {csr_array}
         NxN matrix in CSR format or BSR format
     splitting : array
         C/F splitting stored in an array of length N
@@ -228,11 +228,11 @@ def injection_interpolation(A, splitting):
     P_colinds = np.arange(start=0, stop=nc, step=1, dtype=A.indptr.dtype)
 
     if blocksize == 1:
-        P = csr_matrix((np.ones((nc,), dtype=A.dtype),
+        P = csr_array((np.ones((nc,), dtype=A.dtype),
                        P_colinds, P_rowptr), shape=[n, nc])
     else:
         P_data = np.array(nc*[np.identity(blocksize, dtype=A.dtype)], dtype=A.dtype)
-        P = bsr_matrix((P_data, P_colinds, P_rowptr), blocksize=[blocksize, blocksize],
+        P = bsr_array((P_data, P_colinds, P_rowptr), blocksize=[blocksize, blocksize],
                        shape=[n*blocksize, nc*blocksize])
 
     return P
@@ -243,9 +243,9 @@ def one_point_interpolation(A, C, splitting, by_val=False):
 
     Parameters
     ----------
-    A : {csr_matrix}
+    A : {csr_array}
         NxN matrix in CSR format
-    C : {csr_matrix}
+    C : {csr_array}
         Strength-of-Connection matrix (does not need zero diagonal)
     splitting : array
         C/F splitting stored in an array of length N
@@ -305,17 +305,17 @@ def one_point_interpolation(A, C, splitting, by_val=False):
         if by_val:
             amg_core.one_point_interpolation(P_rowptr, P_colinds, P_data, A.indptr,
                                              A.indices, A.data, splitting)
-            P = csr_matrix((P_data, P_colinds, P_rowptr), shape=[n, nc])
+            P = csr_array((P_data, P_colinds, P_rowptr), shape=[n, nc])
         else:
             amg_core.one_point_interpolation(P_rowptr, P_colinds, P_data, C.indptr,
                                              C.indices, C.data, splitting)
             P_data = np.ones((n,), dtype=A.dtype)
-            P = csr_matrix((P_data, P_colinds, P_rowptr), shape=[n, nc])
+            P = csr_array((P_data, P_colinds, P_rowptr), shape=[n, nc])
     else:
         amg_core.one_point_interpolation(P_rowptr, P_colinds, P_data, C.indptr,
                                          C.indices, C.data, splitting)
         P_data = np.array(n*[np.identity(blocksize, dtype=A.dtype)], dtype=A.dtype)
-        P = bsr_matrix((P_data, P_colinds, P_rowptr), blocksize=[blocksize, blocksize],
+        P = bsr_array((P_data, P_colinds, P_rowptr), blocksize=[blocksize, blocksize],
                        shape=[blocksize*n, blocksize*nc])
 
     return P
@@ -327,7 +327,7 @@ def local_air(A, splitting, theta=0.1, norm='abs', degree=1,
 
     Parameters
     ----------
-    A : {csr_matrix, bsr_matrix}
+    A : {csr_array, bsr_array}
         NxN matrix in CSR or BSR format
     splitting : array
         C/F splitting stored in an array of length N
@@ -411,7 +411,7 @@ def local_air(A, splitting, theta=0.1, norm='abs', degree=1,
                                                       C.indices, C.data, Cpts, splitting,
                                                       blocksize, degree, use_gmres, maxiter,
                                                       precondition)
-        R = bsr_matrix((R_data.reshape((nnz, blocksize, blocksize)), R_colinds, R_rowptr),
+        R = bsr_array((R_data.reshape((nnz, blocksize, blocksize)), R_colinds, R_rowptr),
                        blocksize=[blocksize, blocksize], shape=[nc*blocksize, A.shape[0]])
     # Not block matrix
     else:
@@ -420,7 +420,7 @@ def local_air(A, splitting, theta=0.1, norm='abs', degree=1,
                                                 A.indices, A.data, C.indptr, C.indices,
                                                 C.data, Cpts, splitting, degree, use_gmres,
                                                 maxiter, precondition)
-        R = csr_matrix((R_data, R_colinds, R_rowptr), shape=[nc, A.shape[0]])
+        R = csr_array((R_data, R_colinds, R_rowptr), shape=[nc, A.shape[0]])
 
     R.eliminate_zeros()
     return R

--- a/pyamg/classical/split.py
+++ b/pyamg/classical/split.py
@@ -89,7 +89,7 @@ References
 
 """
 import numpy as np
-from scipy.sparse import csr_matrix, issparse
+from scipy.sparse import csr_array, issparse
 
 from pyamg.graph import vertex_coloring
 from pyamg import amg_core
@@ -101,7 +101,7 @@ def RS(S, second_pass=False):
 
     Parameters
     ----------
-    S : csr_matrix
+    S : csr_array
         Strength of connection matrix indicating the strength between nodes i
         and j (S_ij)
     second_pass : bool, default False
@@ -133,7 +133,7 @@ def RS(S, second_pass=False):
 
     """
     if not issparse(S) or S.format != 'csr':
-        raise TypeError('expected csr_matrix')
+        raise TypeError('expected csr_array')
     S = remove_diagonal(S)
 
     T = S.T.tocsr()  # transpose S for efficient column access
@@ -157,7 +157,7 @@ def PMIS(S):
 
     Parameters
     ----------
-    S : csr_matrix
+    S : csr_array
         Strength of connection matrix indicating the strength between nodes i
         and j (S_ij)
 
@@ -198,7 +198,7 @@ def PMISc(S, method='JP'):
 
     Parameters
     ----------
-    S : csr_matrix
+    S : csr_array
         Strength of connection matrix indicating the strength between nodes i
         and j (S_ij)
     method : string
@@ -241,7 +241,7 @@ def CLJP(S, color=False):
 
     Parameters
     ----------
-    S : csr_matrix
+    S : csr_array
         Strength of connection matrix indicating the strength between nodes i
         and j (S_ij)
     color : bool
@@ -271,7 +271,7 @@ def CLJP(S, color=False):
 
     """
     if not issparse(S) or S.format != 'csr':
-        raise TypeError('expected csr_matrix')
+        raise TypeError('expected csr_array')
     S = remove_diagonal(S)
 
     colorid = 0
@@ -298,7 +298,7 @@ def CLJPc(S):
 
     Parameters
     ----------
-    S : csr_matrix
+    S : csr_array
         Strength of connection matrix indicating the strength between nodes i
         and j (S_ij)
 
@@ -334,7 +334,7 @@ def MIS(G, weights, maxiter=None):
 
     Parameters
     ----------
-    G : csr_matrix
+    G : csr_array
         Matrix graph, G[i,j] != 0 indicates an edge
     weights : ndarray
         Array of weights for each vertex in the graph G
@@ -361,7 +361,7 @@ def MIS(G, weights, maxiter=None):
 
     """
     if not issparse(G) or G.format != 'csr':
-        raise TypeError('expected csr_matrix')
+        raise TypeError('expected csr_array')
     G = remove_diagonal(G)
 
     mis = np.empty(G.shape[0], dtype='intc')
@@ -386,7 +386,7 @@ def _preprocess(S, coloring_method=None):
 
     Parameters
     ----------
-    S : csr_matrix
+    S : csr_array
         Strength of connection matrix
     coloring_method : string
         Algorithm used to compute the vertex coloring:
@@ -398,11 +398,11 @@ def _preprocess(S, coloring_method=None):
     -------
     weights: ndarray
         Weights from a graph coloring of G
-    S : csr_matrix
+    S : csr_array
         Strength matrix with ones
-    T : csr_matrix
+    T : csr_array
         transpose of S
-    G : csr_matrix
+    G : csr_array
         union of S and T
 
     Notes
@@ -417,13 +417,13 @@ def _preprocess(S, coloring_method=None):
 
     """
     if not issparse(S) or S.format != 'csr':
-        raise TypeError('expected csr_matrix')
+        raise TypeError('expected csr_array')
 
     if S.shape[0] != S.shape[1]:
         raise ValueError(f'expected square matrix, shape={S.shape}')
 
     N = S.shape[0]
-    S = csr_matrix((np.ones(S.nnz, dtype='int8'), S.indices, S.indptr),
+    S = csr_array((np.ones(S.nnz, dtype='int8'), S.indices, S.indptr),
                    shape=(N, N))
     T = S.T.tocsr()  # transpose S for efficient column access
 

--- a/pyamg/classical/tests/test_air.py
+++ b/pyamg/classical/tests/test_air.py
@@ -2,7 +2,7 @@
 import numpy as np
 
 from numpy.testing import TestCase, assert_array_almost_equal
-from scipy.sparse import bsr_matrix, diags
+from scipy.sparse import bsr_matrix, diags_array
 from pyamg.classical.air import air_solver
 from pyamg.gallery import poisson
 
@@ -17,7 +17,8 @@ class TestAIR(TestCase):
 
         for n in sizes:
             # CSR case
-            A = diags([np.ones((n,)), -1*np.ones((n-1,))], offsets=[0, -1], format='csr')
+            A = diags_array([np.ones((n,)), -1*np.ones((n-1,))],
+                            offsets=[0, -1], format='csr')
             f_relax = ('fc_jacobi', {'iterations': 1, 'f_iterations': 1,
                        'c_iterations': 0})
             ml = air_solver(A, postsmoother=f_relax, max_levels=2)

--- a/pyamg/classical/tests/test_air.py
+++ b/pyamg/classical/tests/test_air.py
@@ -2,7 +2,7 @@
 import numpy as np
 
 from numpy.testing import TestCase, assert_array_almost_equal
-from scipy.sparse import bsr_matrix, diags_array
+from scipy.sparse import bsr_array, diags_array
 from pyamg.classical.air import air_solver
 from pyamg.gallery import poisson
 
@@ -38,7 +38,7 @@ class TestAIR(TestCase):
             data = np.concatenate((np.tile(bb, n-1), b1)).reshape((2*n-1, 2, 2))
             rowptr = A.indptr
             colinds = A.indices
-            Ab = bsr_matrix((data, colinds, rowptr), blocksize=[2, 2])
+            Ab = bsr_array((data, colinds, rowptr), blocksize=[2, 2])
             f_relax = ('fc_block_jacobi', {'iterations': 1, 'f_iterations': 1,
                        'c_iterations': 0})
             ml = air_solver(Ab, postsmoother=f_relax, max_levels=2)

--- a/pyamg/classical/tests/test_classical.py
+++ b/pyamg/classical/tests/test_classical.py
@@ -6,7 +6,7 @@ import numpy as np
 from numpy.testing import TestCase, assert_equal, assert_almost_equal, \
     assert_array_almost_equal
 
-from scipy.sparse import csr_matrix, coo_matrix, SparseEfficiencyWarning
+from scipy.sparse import csr_array, coo_array, SparseEfficiencyWarning
 
 from pyamg.gallery import poisson, load_example
 from pyamg.strength import classical_strength_of_connection
@@ -24,7 +24,7 @@ class TestRugeStubenFunctions(TestCase):
         # random matrices
         np.random.seed(0)
         for N in [2, 3, 5]:
-            self.cases.append(csr_matrix(np.random.rand(N, N)))
+            self.cases.append(csr_array(np.random.rand(N, N)))
 
         # Poisson problems in 1D and 2D
         for N in [2, 3, 5, 7, 10, 11, 19]:
@@ -141,7 +141,7 @@ class TestRugeStubenFunctions(TestCase):
         from pyamg import amg_core
         # test removing an F-F connection without any strong C in between (4--2),
         # while keeping the F-f connection (4--6) which does have a strong C in between
-        C = csr_matrix(np.array([[2., 1., 0., 0., 0., 0.],
+        C = csr_array(np.array([[2., 1., 0., 0., 0., 0.],
                                  [1., 2., 1., 1., 0., 0.],
                                  [0., 1., 2., 0., 0., 0.],
                                  [0., 1., 0., 2., 1., 1.],
@@ -217,8 +217,8 @@ def reference_direct_interpolation(A, S, splitting):
     S.data[:] = 1.0
     S = S.multiply(A)
 
-    A = coo_matrix(A)
-    S = coo_matrix(S)
+    A = coo_array(A)
+    S = coo_array(S)
 
     # remove diagonals
     mask = S.row != S.col
@@ -228,28 +228,28 @@ def reference_direct_interpolation(A, S, splitting):
 
     # strong C points
     c_mask = splitting[S.col] == 1
-    C_s = coo_matrix((S.data[c_mask], (S.row[c_mask], S.col[c_mask])),
+    C_s = coo_array((S.data[c_mask], (S.row[c_mask], S.col[c_mask])),
                      shape=S.shape)
 
     # strong F points
     # f_mask = ~c_mask
-    # F_s = coo_matrix((S.data[f_mask], (S.row[f_mask], S.col[f_mask])),
+    # F_s = coo_array((S.data[f_mask], (S.row[f_mask], S.col[f_mask])),
     #                shape=S.shape)
 
     # split A in to + and -
     mask = (A.data > 0) & (A.row != A.col)
-    A_pos = coo_matrix((A.data[mask], (A.row[mask], A.col[mask])),
+    A_pos = coo_array((A.data[mask], (A.row[mask], A.col[mask])),
                        shape=A.shape)
     mask = (A.data < 0) & (A.row != A.col)
-    A_neg = coo_matrix((A.data[mask], (A.row[mask], A.col[mask])),
+    A_neg = coo_array((A.data[mask], (A.row[mask], A.col[mask])),
                        shape=A.shape)
 
     # split C_S in to + and -
     mask = C_s.data > 0
-    C_s_pos = coo_matrix((C_s.data[mask], (C_s.row[mask], C_s.col[mask])),
+    C_s_pos = coo_array((C_s.data[mask], (C_s.row[mask], C_s.col[mask])),
                          shape=A.shape)
     mask = ~mask
-    C_s_neg = coo_matrix((C_s.data[mask], (C_s.row[mask], C_s.col[mask])),
+    C_s_neg = coo_array((C_s.data[mask], (C_s.row[mask], C_s.col[mask])),
                          shape=A.shape)
 
     sum_strong_pos = np.ravel(C_s_pos.sum(axis=1))
@@ -276,13 +276,13 @@ def reference_direct_interpolation(A, S, splitting):
     C_s_pos.data *= -beta[C_s_pos.row]/diag[C_s_pos.row]
 
     C_rows = splitting.nonzero()[0]
-    C_inject = coo_matrix((np.ones(sum(splitting)), (C_rows, C_rows)),
+    C_inject = coo_array((np.ones(sum(splitting)), (C_rows, C_rows)),
                           shape=A.shape)
 
     P = C_s_neg.tocsr() + C_s_pos.tocsr() + C_inject.tocsr()
 
     splitting_map = np.concatenate(([0], np.cumsum(splitting)))
-    P = csr_matrix((P.data, splitting_map[P.indices], P.indptr),
+    P = csr_array((P.data, splitting_map[P.indices], P.indptr),
                    shape=(P.shape[0], splitting_map[-1]))
 
     return P
@@ -363,4 +363,4 @@ def reference_classical_interpolation(A, S, splitting):
     for i in range(Pp[A.shape[0]]):
         Pj[i] = reorder[Pj[i]]
 
-    return csr_matrix((Px, Pj, Pp))
+    return csr_array((Px, Pj, Pp))

--- a/pyamg/classical/tests/test_cr.py
+++ b/pyamg/classical/tests/test_cr.py
@@ -1,7 +1,7 @@
 """Test compatible relaxation."""
 import numpy as np
 from numpy.testing import TestCase
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 from pyamg.gallery import poisson, load_example
 from pyamg.classical.cr import binormalize, CR
 
@@ -13,7 +13,7 @@ class TestCR(TestCase):
         # Random matrices, cases 0-2
         np.random.seed(0)
         for N in [2, 3, 5]:
-            self.cases.append(csr_matrix(np.random.rand(N, N)))
+            self.cases.append(csr_array(np.random.rand(N, N)))
 
         # Poisson problems in 1D, cases 3-9
         for N in [2, 3, 5, 7, 10, 11, 19]:

--- a/pyamg/gallery/__init__.py
+++ b/pyamg/gallery/__init__.py
@@ -21,7 +21,7 @@ from .mesh import regular_triangle_mesh
 from .diffusion import diffusion_stencil_2d
 from .advection import advection_2d
 
-from .random_sparse import sprand
+from .random_sparse import sprand  # note: could use scipy.sparse.random_array
 from .demo import demo
 
 __all__ = [

--- a/pyamg/gallery/advection.py
+++ b/pyamg/gallery/advection.py
@@ -30,7 +30,7 @@ def advection_2d(grid, theta=np.pi/4.0, l_bdry=1.0, b_bdry=1.0):
 
     Returns
     -------
-    A : csr_matrix
+    A : csr_array
         Defines 2D FD upwind discretization, with boundary
     rhs : array
         Defines right-hand-side with boundary contributions

--- a/pyamg/gallery/elasticity.py
+++ b/pyamg/gallery/elasticity.py
@@ -24,7 +24,7 @@ def linear_elasticity(grid, spacing=None, E=1e5, nu=0.3, format=None):
 
     Returns
     -------
-    A : csr_matrix
+    A : csr_array
         FE Q1 stiffness matrix
 
     B : array
@@ -105,7 +105,7 @@ def q12d(grid, spacing=None, E=1e5, nu=0.3, dirichlet_boundary=True,
     V = np.ravel(V)
 
     # sum duplicates
-    A = sparse.coo_matrix((V, (Id, J)), shape=(pts.size, pts.size)).tocsr()
+    A = sparse.coo_array((V, (Id, J)), shape=(pts.size, pts.size)).tocsr()
     A = A.tobsr(blocksize=(2, 2))
 
     del Id, J, V, LL, nodes
@@ -125,7 +125,7 @@ def q12d(grid, spacing=None, E=1e5, nu=0.3, dirichlet_boundary=True,
         data[:, 1, 1] = 1
         indices = np.arange((X-1)*(Y-1))
         indptr = np.concatenate((np.array([0]), np.cumsum(mask)))
-        P = sparse.bsr_matrix((data, indices, indptr),
+        P = sparse.bsr_array((data, indices, indptr),
                               shape=(2*(X+1)*(Y+1), 2*(X-1)*(Y-1)))
         Pt = P.T
         A = P.T @ A @ P
@@ -225,7 +225,7 @@ def linear_elasticity_p1(vertices, elements, E=1e5, nu=0.3, format=None):
 
     Returns
     -------
-    A : csr_matrix
+    A : csr_array
         FE Q1 stiffness matrix
 
     Notes
@@ -289,7 +289,7 @@ def linear_elasticity_p1(vertices, elements, E=1e5, nu=0.3, format=None):
     data = data.ravel()
 
     # sum duplicates
-    A = sparse.coo_matrix((data, (row, col)), shape=(DoF, DoF)).tocsr()
+    A = sparse.coo_array((data, (row, col)), shape=(DoF, DoF)).tocsr()
     A = A.tobsr(blocksize=(D, D))
 
     # compute rigid body modes

--- a/pyamg/gallery/elasticity.py
+++ b/pyamg/gallery/elasticity.py
@@ -92,7 +92,7 @@ def q12d(grid, spacing=None, E=1e5, nu=0.3, dirichlet_boundary=True,
     vertices = np.array([[0, 0], [DX, 0], [DX, DY], [0, DY]])
     K = q12d_local(vertices, lame, mu)
 
-    nodes = np.arange((X+1)*(Y+1)).reshape(X+1, Y+1)
+    nodes = np.arange((X+1)*(Y+1), dtype=np.int32).reshape(X+1, Y+1)
     LL = nodes[:-1, :-1]
     Id = (2*LL).repeat(K.size).reshape(-1, 8, 8)
     J = Id.copy()
@@ -123,8 +123,8 @@ def q12d(grid, spacing=None, E=1e5, nu=0.3, dirichlet_boundary=True,
         data = np.zeros(((X-1)*(Y-1), 2, 2))
         data[:, 0, 0] = 1
         data[:, 1, 1] = 1
-        indices = np.arange((X-1)*(Y-1))
-        indptr = np.concatenate((np.array([0]), np.cumsum(mask)))
+        indices = np.arange((X-1)*(Y-1), dtype=np.int32)
+        indptr = np.concatenate((np.array([0]), np.cumsum(mask)), dtype=np.int32)
         P = sparse.bsr_array((data, indices, indptr),
                               shape=(2*(X+1)*(Y+1), 2*(X-1)*(Y-1)))
         Pt = P.T
@@ -271,7 +271,7 @@ def linear_elasticity_p1(vertices, elements, E=1e5, nu=0.3, format=None):
 
     row = elements.repeat(D).reshape(-1, D)
     row *= D
-    row += np.arange(D)
+    row += np.arange(D, dtype=row.dtype)
     row = row.reshape(-1, D*(D+1)).repeat(D*(D+1), axis=0)
     row = row.reshape(-1, D*(D+1), D*(D+1))
     col = row.swapaxes(1, 2)

--- a/pyamg/gallery/fem.py
+++ b/pyamg/gallery/fem.py
@@ -962,9 +962,9 @@ def stokes(mesh, fu, fv):
     Av, bv = gradgradform(mesh, f=fv, degree=2)
     BX, BY = divform(mesh)
 
-    C = sparse.bmat([[Au, None, BX.T],
-                     [None, Av, BY.T],
-                     [BX, BY, None]])
+    C = sparse.block_array([[Au, None, BX.T],
+                            [None, Av, BY.T],
+                            [BX, BY, None]])
     b = np.hstack((bu, bv, np.zeros((BX.shape[0],))))
 
     return C, b

--- a/pyamg/gallery/fem.py
+++ b/pyamg/gallery/fem.py
@@ -78,7 +78,7 @@ def generate_quadratic(V, E, return_edges=False):
 
     # make a vertext-to-vertex graph
     ID = np.kron(np.arange(0, ne), np.ones((3,), dtype=int))
-    G = sparse.coo_matrix((np.ones((ne*3,), dtype=int), (E.ravel(), ID,)))
+    G = sparse.coo_array((np.ones((ne*3,), dtype=int), (E.ravel(), ID,)))
     V2V = G @ G.T
 
     # from the vertex graph, get the edges and create new midpoints
@@ -198,7 +198,7 @@ def refine2dtri(V, E, marked_elements=None):
     col = E.ravel()
     row = np.kron(np.arange(0, Nel), [1, 1, 1])
     data = np.ones((Nel*3,))
-    V2V = sparse.coo_matrix((data, (row, col)), shape=(Nel, Nv))
+    V2V = sparse.coo_array((data, (row, col)), shape=(Nel, Nv))
     V2V = V2V.T @ V2V
 
     # compute interior edges list
@@ -498,7 +498,7 @@ class Mesh:
         edge0 = self.E[:, [0, 0, 1, 1, 2, 2]].ravel()
         edge1 = self.E[:, [1, 2, 0, 2, 0, 1]].ravel()
         data = np.ones((edge0.shape[0],), dtype=int)
-        G = sparse.coo_matrix((data, (edge0, edge1)), shape=(nv, nv))
+        G = sparse.coo_array((data, (edge0, edge1)), shape=(nv, nv))
         G.sum_duplicates()
         G.eliminate_zeros()
 
@@ -762,9 +762,9 @@ def gradgradform(mesh, kappa=None, f=None, degree=1):
         jb[ei, :] = 0
 
     # convert matrices
-    A = sparse.coo_matrix((AA.ravel(), (IA.ravel(), JA.ravel())))
+    A = sparse.coo_array((AA.ravel(), (IA.ravel(), JA.ravel())))
     A.sum_duplicates()
-    b = sparse.coo_matrix((bb.ravel(), (ib.ravel(), jb.ravel()))).toarray().ravel()
+    b = sparse.coo_array((bb.ravel(), (ib.ravel(), jb.ravel()))).toarray().ravel()
 
     # A = A.tocsr()
     return A, b
@@ -857,10 +857,10 @@ def divform(mesh):
         DYJ[ei, :] = np.tile(K[np.arange(m1)], m2)
 
     # Convert representation to COO
-    BX = sparse.coo_matrix((DX.ravel(), (DXI.ravel(), DXJ.ravel())))
+    BX = sparse.coo_array((DX.ravel(), (DXI.ravel(), DXJ.ravel())))
     BX.sum_duplicates()
 
-    BY = sparse.coo_matrix((DY.ravel(), (DYI.ravel(), DYJ.ravel())))
+    BY = sparse.coo_array((DY.ravel(), (DYI.ravel(), DYJ.ravel())))
     BY.sum_duplicates()
 
     return BX, BY

--- a/pyamg/gallery/laplacian.py
+++ b/pyamg/gallery/laplacian.py
@@ -182,8 +182,8 @@ def gauge_laplacian(npts, spacing=1.0, beta=0.1):
 
     # Construct Final Matrix
     data = np.hstack((A.data, np.array(new_data)))
-    row = np.hstack((A.row, np.array(new_r)))
-    col = np.hstack((A.col, np.array(new_c)))
+    row = np.hstack((A.row, np.array(new_r, dtype=A.row.dtype)))
+    col = np.hstack((A.col, np.array(new_c, dtype=A.row.dtype)))
     A = sp.sparse.coo_array((data, (row, col)), shape=(N*N, N*N)).tocsr()
 
     return (1.0/spacing**2)*A

--- a/pyamg/gallery/laplacian.py
+++ b/pyamg/gallery/laplacian.py
@@ -184,6 +184,6 @@ def gauge_laplacian(npts, spacing=1.0, beta=0.1):
     data = np.hstack((A.data, np.array(new_data)))
     row = np.hstack((A.row, np.array(new_r)))
     col = np.hstack((A.col, np.array(new_c)))
-    A = sp.sparse.coo_matrix((data, (row, col)), shape=(N*N, N*N)).tocsr()
+    A = sp.sparse.coo_array((data, (row, col)), shape=(N*N, N*N)).tocsr()
 
     return (1.0/spacing**2)*A

--- a/pyamg/gallery/mesh.py
+++ b/pyamg/gallery/mesh.py
@@ -48,6 +48,6 @@ def regular_triangle_mesh(nx, ny):
 
     E2V1 = np.vstack((Vert1, Vert2, Vert3)).transpose()
     E2V2 = np.vstack((Vert1, Vert4, Vert2)).transpose()
-    E2V = np.vstack((E2V1, E2V2))
+    E2V = np.vstack((E2V1, E2V2)).astype(np.int32)
 
     return Vert, E2V

--- a/pyamg/gallery/random_sparse.py
+++ b/pyamg/gallery/random_sparse.py
@@ -14,7 +14,7 @@ def _rand_sparse(m, n, density):
     data = np.ones(nnz, dtype=float)
 
     # duplicate (i,j) entries will be summed together
-    return sp.sparse.csr_matrix((data, (row, col)), shape=(m, n))
+    return sp.sparse.csr_array((data, (row, col)), shape=(m, n))
 
 
 def sprand(m, n, density, format='csr'):

--- a/pyamg/gallery/random_sparse.py
+++ b/pyamg/gallery/random_sparse.py
@@ -9,8 +9,8 @@ def _rand_sparse(m, n, density):
     """Construct base function for sprand, sprandn."""
     nnz = max(min(int(m*n*density), m*n), 0)
 
-    row = np.random.randint(low=0, high=m-1, size=nnz)
-    col = np.random.randint(low=0, high=n-1, size=nnz)
+    row = np.random.randint(low=0, high=m-1, size=nnz, dtype=np.int32)
+    col = np.random.randint(low=0, high=n-1, size=nnz, dtype=np.int32)
     data = np.ones(nnz, dtype=float)
 
     # duplicate (i,j) entries will be summed together

--- a/pyamg/gallery/stencil.py
+++ b/pyamg/gallery/stencil.py
@@ -131,5 +131,5 @@ def stencil_grid(S, grid, dtype=None, format=None):
         diags = new_diags
         data = new_data
 
-    return sparse.dia_matrix((data, diags),
+    return sparse.dia_array((data, diags),
                              shape=(N_v, N_v)).asformat(format)

--- a/pyamg/gallery/stencil.py
+++ b/pyamg/gallery/stencil.py
@@ -84,7 +84,7 @@ def stencil_grid(S, grid, dtype=None, format=None):
 
     # compute index offset of each dof within the stencil
     strides = np.cumprod([1] + list(reversed(grid)))[:-1]  # noqa: RUF005
-    indices = tuple(i.copy() for i in S.nonzero())
+    indices = tuple(i.astype(np.int32) for i in S.nonzero())
     for i, s in zip(indices, S.shape):
         i -= s // 2
         # i = (i - s) // 2

--- a/pyamg/gallery/tests/test_elasticity.py
+++ b/pyamg/gallery/tests/test_elasticity.py
@@ -1,6 +1,6 @@
 """Test elasticity example."""
 import numpy as np
-from scipy.sparse import coo_matrix
+from scipy.sparse import coo_array
 from pyamg.gallery.elasticity import linear_elasticity, \
     linear_elasticity_p1, \
     q12d_local, p12d_local, p13d_local
@@ -73,7 +73,7 @@ class TestLinearElasticityGrid(TestCase):
                         3, 3, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 7,
                         7, 7, 7, 7])
 
-        A_expected = coo_matrix((data, (row, col)), shape=(8, 8)).toarray()
+        A_expected = coo_array((data, (row, col)), shape=(8, 8)).toarray()
         B_expected = np.array([[1., 0., 0.5],
                                [0., 1., -0.5],
                                [1., 0., 0.5],

--- a/pyamg/graph.py
+++ b/pyamg/graph.py
@@ -270,7 +270,7 @@ def breadth_first_search(G, seed):
     >>> import pyamg
     >>> import scipy.sparse as sparse
     >>> edges = np.array([[0,1],[0,2],[1,2],[1,3],[1,4],[3,4],[3,5],
-    ...                   [4,6], [4,7], [6,7], [7,8], [8,9]])
+    ...                   [4,6], [4,7], [6,7], [7,8], [8,9]], dtype=np.int32)
     >>> N = np.max(edges.ravel())+1
     >>> data = np.ones((edges.shape[0],))
     >>> A = sparse.coo_array((data, (edges[:,0], edges[:,1])), shape=(N,N))

--- a/pyamg/graph.py
+++ b/pyamg/graph.py
@@ -10,7 +10,7 @@ from . import amg_core
 def asgraph(G):
     """Return (square) matrix as sparse."""
     if not sparse.issparse(G) or G.format not in ('csc', 'csr'):
-        G = sparse.csr_matrix(G)
+        G = sparse.csr_array(G)
 
     if G.shape[0] != G.shape[1]:
         raise ValueError('expected square matrix')
@@ -172,7 +172,7 @@ def lloyd_cluster(G, seeds, maxiter=10):
 
     Parameters
     ----------
-    G : csr_matrix, csc_matrix
+    G : csr_array, csc_array
         A sparse NxN matrix where each nonzero entry G[i,j] is the distance
         between nodes i and j.
     seeds : int array
@@ -241,7 +241,7 @@ def breadth_first_search(G, seed):
 
     Parameters
     ----------
-    G : csr_matrix, csc_matrix
+    G : csr_array, csc_array
         A sparse NxN matrix where each nonzero entry G[i,j] is the distance
         between nodes i and j.
     seed : int
@@ -273,7 +273,7 @@ def breadth_first_search(G, seed):
     ...                   [4,6], [4,7], [6,7], [7,8], [8,9]])
     >>> N = np.max(edges.ravel())+1
     >>> data = np.ones((edges.shape[0],))
-    >>> A = sparse.coo_matrix((data, (edges[:,0], edges[:,1])), shape=(N,N))
+    >>> A = sparse.coo_array((data, (edges[:,0], edges[:,1])), shape=(N,N))
     >>> c, l = pyamg.graph.breadth_first_search(A, 0)
     >>> print(l)
     [0 1 1 2 2 3 3 3 4 5]

--- a/pyamg/krylov/tests/test_krylov.py
+++ b/pyamg/krylov/tests/test_krylov.py
@@ -25,7 +25,7 @@ class TestStoppingCriteria(TestCase):
         x0 = np.random.rand(n)
         A = 0.5 * (A + A.T) + n*np.eye(n, n)
         self.cases.append({'A': A, 'b': b, 'x0': x0, 'tol': 1e-8})
-        self.cases.append({'A': sparse.csr_matrix(A), 'b': b, 'x0': x0, 'tol': 1e-8})
+        self.cases.append({'A': sparse.csr_array(A), 'b': b, 'x0': x0, 'tol': 1e-8})
 
     def test_stoppingcriteria(self):
         for method, crits in [

--- a/pyamg/multilevel.py
+++ b/pyamg/multilevel.py
@@ -700,7 +700,7 @@ def coarse_grid_solver(solver):
                 Acsc.eliminate_zeros()
                 diffptr = Acsc.indptr[:-1] - Acsc.indptr[1:]
                 nonzero_cols = (diffptr != 0).nonzero()[0]
-                Map = sp.sparse.eye(Acsc.shape[0], Acsc.shape[1], format='csc')
+                Map = sp.sparse.eye_array(Acsc.shape[0], Acsc.shape[1], format='csc')
                 Map = Map[:, nonzero_cols]
                 Acsc = Map.T.tocsc() @ Acsc @ Map
                 self.LU = sp.sparse.linalg.splu(Acsc, **kwargs)

--- a/pyamg/multilevel.py
+++ b/pyamg/multilevel.py
@@ -63,11 +63,11 @@ class MultilevelSolver:
 
         Attributes
         ----------
-        A : csr_matrix
+        A : csr_array
             Problem matrix for Ax=b
-        R : csr_matrix
+        R : csr_array
             Restriction matrix between levels (often R = P.T)
-        P : csr_matrix
+        P : csr_array
             Prolongation or Interpolation matrix.
 
         Notes
@@ -296,7 +296,7 @@ class MultilevelSolver:
 
         Parameters
         ----------
-        A : csr_matrix
+        A : csr_array
             Target solution matrix
 
         Notes

--- a/pyamg/relaxation/relaxation.py
+++ b/pyamg/relaxation/relaxation.py
@@ -64,11 +64,11 @@ def make_system(A, x, b, formats=None):
             A = A.tocsr()
         else:
             warn('implicit conversion to CSR', sparse.SparseEfficiencyWarning)
-            A = sparse.csr_matrix(A)
+            A = sparse.csr_array(A)
     elif sparse.issparse(A) and A.format in formats:
         pass
     else:
-        A = sparse.csr_matrix(A).asformat(formats[0])
+        A = sparse.csr_array(A).asformat(formats[0])
 
     if not isinstance(x, np.ndarray):
         raise ValueError('expected numpy array for argument x')
@@ -102,7 +102,7 @@ def sor(A, x, b, omega, iterations=1, sweep='forward'):
 
     Parameters
     ----------
-    A : csr_matrix, bsr_matrix
+    A : csr_array, bsr_array
         Sparse NxN matrix
     x : ndarray
         Approximate solution (length N)
@@ -168,7 +168,7 @@ def schwarz(A, x, b, iterations=1, subdomain=None, subdomain_ptr=None,
 
     Parameters
     ----------
-    A : csr_matrix, bsr_matrix
+    A : csr_array, bsr_array
         Sparse NxN matrix
     x : ndarray
         Approximate solution (length N)
@@ -275,7 +275,7 @@ def gauss_seidel(A, x, b, iterations=1, sweep='forward'):
 
     Parameters
     ----------
-    A : csr_matrix, bsr_matrix
+    A : csr_array, bsr_array
         Sparse NxN matrix
     x : ndarray
         Approximate solution (length N)
@@ -352,7 +352,7 @@ def jacobi(A, x, b, iterations=1, omega=1.0):
 
     Parameters
     ----------
-    A : csr_matrix
+    A : csr_array
         Sparse NxN matrix
     x : ndarray
         Approximate solution (length N)
@@ -426,7 +426,7 @@ def block_jacobi(A, x, b, Dinv=None, blocksize=1, iterations=1, omega=1.0):
 
     Parameters
     ----------
-    A : csr_matrix or bsr_matrix
+    A : csr_array or bsr_array
         Sparse NxN matrix
     x : ndarray
         Approximate solution (length N)
@@ -506,7 +506,7 @@ def block_gauss_seidel(A, x, b, iterations=1, sweep='forward', blocksize=1,
 
     Parameters
     ----------
-    A : csr_matrix, bsr_matrix
+    A : csr_array, bsr_array
         Sparse NxN matrix
     x : ndarray
         Approximate solution (length N)
@@ -671,7 +671,7 @@ def gauss_seidel_indexed(A, x, b, indices, iterations=1, sweep='forward'):
 
     Parameters
     ----------
-    A : csr_matrix
+    A : csr_array
         Sparse NxN matrix
     x : ndarray
         Approximate solution (length N)
@@ -739,7 +739,7 @@ def jacobi_ne(A, x, b, iterations=1, omega=1.0):
 
     Parameters
     ----------
-    A : csr_matrix
+    A : csr_array
         Sparse NxN matrix
     x : ndarray
         Approximate solution (length N)
@@ -821,7 +821,7 @@ def gauss_seidel_ne(A, x, b, iterations=1, sweep='forward', omega=1.0,
 
     Parameters
     ----------
-    A : csr_matrix
+    A : csr_array
         Sparse NxN matrix
     x : ndarray
         Approximate solution (length N)
@@ -908,7 +908,7 @@ def gauss_seidel_nr(A, x, b, iterations=1, sweep='forward', omega=1.0,
 
     Parameters
     ----------
-    A : csr_matrix
+    A : csr_array
         Sparse NxN matrix
     x : ndarray
         Approximate solution (length N)
@@ -1011,7 +1011,7 @@ def schwarz_parameters(A, subdomain=None, subdomain_ptr=None,
 
     Parameters
     ----------
-    A : csr_matrix
+    A : csr_array
         System matrix for relaxation
     subdomain : array
         Indices of each subdomain must be sorted over each subdomain
@@ -1087,7 +1087,7 @@ def jacobi_indexed(A, x, b, indices, iterations=1, omega=1.0):
 
     Parameters
     ----------
-    A : csr_matrix
+    A : csr_array
         Sparse NxN matrix
     x : ndarray
         Approximate solution (length N)
@@ -1152,7 +1152,7 @@ def cf_jacobi(A, x, b, Cpts, Fpts, iterations=1, f_iterations=1,
 
     Parameters
     ----------
-    A : csr_matrix
+    A : csr_array
         Sparse NxN matrix
     x : ndarray
         Approximate solution (length N)
@@ -1217,7 +1217,7 @@ def fc_jacobi(A, x, b, Cpts, Fpts, iterations=1, f_iterations=1,
 
     Parameters
     ----------
-    A : csr_matrix
+    A : csr_array
         Sparse NxN matrix
     x : ndarray
         Approximate solution (length N)
@@ -1283,7 +1283,7 @@ def cf_block_jacobi(A, x, b, Cpts, Fpts, Dinv=None, blocksize=1, iterations=1,
 
     Parameters
     ----------
-    A : csr_matrix or bsr_matrix
+    A : csr_array or bsr_array
         Sparse NxN matrix
     x : ndarray
         Approximate solution (length N)
@@ -1354,7 +1354,7 @@ def fc_block_jacobi(A, x, b, Cpts, Fpts, Dinv=None, blocksize=1, iterations=1,
 
     Parameters
     ----------
-    A : csr_matrix or bsr_matrix
+    A : csr_array or bsr_array
         Sparse NxN matrix
     x : ndarray
         Approximate solution (length N)

--- a/pyamg/relaxation/smoothing.py
+++ b/pyamg/relaxation/smoothing.py
@@ -385,9 +385,9 @@ def rho_D_inv_A(A):
     --------
     >>> from pyamg.gallery import poisson
     >>> from pyamg.relaxation.smoothing import rho_D_inv_A
-    >>> from scipy.sparse import csr_matrix
+    >>> from scipy.sparse import csr_array
     >>> import numpy as np
-    >>> A = csr_matrix(np.array([[1.0,0,0],[0,2.0,0],[0,0,3.0]]))
+    >>> A = csr_array(np.array([[1.0,0,0],[0,2.0,0],[0,0,3.0]]))
     >>> print(f'{rho_D_inv_A(A):2.2}')
     1.0
 
@@ -433,7 +433,7 @@ def rho_block_D_inv_A(A, Dinv):
         if Dinv.shape[0] != int(A.shape[0]/blocksize):
             raise ValueError('Dinv and A have incompatible dimensions')
 
-        Dinv = sparse.bsr_matrix((Dinv,
+        Dinv = sparse.bsr_array((Dinv,
                                   np.arange(Dinv.shape[0]),
                                   np.arange(Dinv.shape[0]+1)),
                                  shape=A.shape)

--- a/pyamg/relaxation/smoothing.py
+++ b/pyamg/relaxation/smoothing.py
@@ -434,9 +434,9 @@ def rho_block_D_inv_A(A, Dinv):
             raise ValueError('Dinv and A have incompatible dimensions')
 
         Dinv = sparse.bsr_array((Dinv,
-                                  np.arange(Dinv.shape[0]),
-                                  np.arange(Dinv.shape[0]+1)),
-                                 shape=A.shape)
+                                 np.arange(Dinv.shape[0], dtype=np.int32),
+                                 np.arange(Dinv.shape[0] + 1, dtype=np.int32)),
+                                shape=A.shape)
 
         # Don't explicitly form Dinv @ A
         def matvec(x):

--- a/pyamg/relaxation/tests/test_relaxation.py
+++ b/pyamg/relaxation/tests/test_relaxation.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 from numpy.testing import TestCase, assert_almost_equal
 import scipy
-from scipy.sparse import csr_matrix, bsr_matrix, diags_array, eye_array
+from scipy.sparse import csr_array, bsr_array, diags_array, eye_array
 from scipy.sparse import SparseEfficiencyWarning
 from scipy.linalg import solve
 
@@ -202,7 +202,7 @@ class TestRelaxation(TestCase):
             cases.append(diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)],
                                offsets=[0, -1, 1], shape=(N, N), format='csr'))
             cases.append(elasticity.linear_elasticity((N, N))[0].tocsr())
-            C = csr_matrix(np.random.rand(N, N))
+            C = csr_array(np.random.rand(N, N))
             cases.append(C @ C.T.conjugate())
             C = sprand(N*2, N*2, 0.3) + eye_array(N*2, N*2)
             cases.append(C @ C.T.conjugate())
@@ -228,7 +228,7 @@ class TestRelaxation(TestCase):
             cases.append(diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)],
                                offsets=[0, -1, 1], shape=(N, N), format='csr'))
             cases.append(elasticity.linear_elasticity((N, N))[0].tocsr())
-            C = csr_matrix(np.random.rand(N, N))
+            C = csr_array(np.random.rand(N, N))
             cases.append(C @ C.T.conjugate())
             C = sprand(N*2, N*2, 0.3) + eye_array(N*2, N*2)
             cases.append(C @ C.T.conjugate())
@@ -256,7 +256,7 @@ class TestRelaxation(TestCase):
         cases.append(poisson((4, 4), format='csr'))
 
         temp = np.random.rand(4, 4)
-        cases.append(csr_matrix(temp.T.dot(temp)))
+        cases.append(csr_array(temp.T.dot(temp)))
 
         # reference implementation
         def gold(A, x, b, iterations, sweep):
@@ -527,7 +527,7 @@ class TestRelaxation(TestCase):
         cases.append(poisson((4, 4), format='csr'))
 
         temp = np.random.rand(4, 4)
-        cases.append(csr_matrix(temp.T.dot(temp)))
+        cases.append(csr_array(temp.T.dot(temp)))
 
         # reference implementation
         def gold(A, x, b, iterations, sweep):
@@ -666,13 +666,13 @@ class TestRelaxation(TestCase):
         cases.append(poisson((4, 4), format='csr'))
 
         temp = np.random.rand(1, 1)
-        cases.append(csr_matrix(temp))
+        cases.append(csr_array(temp))
 
         temp = np.random.rand(2, 2)
-        cases.append(csr_matrix(temp))
+        cases.append(csr_array(temp))
 
         temp = np.random.rand(4, 4)
-        cases.append(csr_matrix(temp))
+        cases.append(csr_array(temp))
 
         # reference implementation
         def gold(A, x, b, iterations, sweep):
@@ -742,17 +742,17 @@ class TestRelaxation(TestCase):
         cases.append(A)
 
         temp = np.random.rand(1, 1)
-        cases.append(csr_matrix(temp.T.dot(temp)))
+        cases.append(csr_array(temp.T.dot(temp)))
 
         temp = np.random.rand(2, 2)
-        cases.append(csr_matrix(temp.T.dot(temp)))
+        cases.append(csr_array(temp.T.dot(temp)))
 
         temp = np.random.rand(4, 4)
-        cases.append(csr_matrix(temp.T.dot(temp)))
+        cases.append(csr_array(temp.T.dot(temp)))
 
         # reference implementation
         def gold(A, x, b, iterations, sweep='forward'):
-            A = csr_matrix(A)
+            A = csr_array(A)
             n = A.shape[0]
 
             # Default is point-wise iteration with each subdomain a point's
@@ -887,7 +887,7 @@ class TestComplexRelaxation(TestCase):
             cases.append(C)
             cases.append(1.0j*elasticity.linear_elasticity((N, N))[0].tocsr())
 
-            C = csr_matrix(np.random.rand(N, N) + 1.0j*np.random.rand(N, N))
+            C = csr_array(np.random.rand(N, N) + 1.0j*np.random.rand(N, N))
             cases.append(C @ C.T.conjugate())
 
             C = sprand(N*2, N*2, 0.3) + 1.0j*sprand(N*2, N*2, 0.3) +\
@@ -919,7 +919,7 @@ class TestComplexRelaxation(TestCase):
             cases.append(C)
             cases.append(1.0j*elasticity.linear_elasticity((N, N))[0].tocsr())
 
-            C = csr_matrix(np.random.rand(N, N) + 1.0j*np.random.rand(N, N))
+            C = csr_array(np.random.rand(N, N) + 1.0j*np.random.rand(N, N))
             cases.append(C @ C.T.conjugate())
 
             C = sprand(N*2, N*2, 0.3) + 1.0j*sprand(N*2, N*2, 0.3) +\
@@ -954,17 +954,17 @@ class TestComplexRelaxation(TestCase):
         cases.append(A)
 
         temp = np.random.rand(1, 1) + 1.0j*np.random.rand(1, 1)
-        cases.append(csr_matrix(temp.conj().T.dot(temp)))
+        cases.append(csr_array(temp.conj().T.dot(temp)))
 
         temp = np.random.rand(2, 2) + 1.0j*np.random.rand(2, 2)
-        cases.append(csr_matrix(temp.conj().T.dot(temp)))
+        cases.append(csr_array(temp.conj().T.dot(temp)))
 
         temp = np.random.rand(4, 4) + 1.0j*np.random.rand(4, 4)
-        cases.append(csr_matrix(temp.conj().T.dot(temp)))
+        cases.append(csr_array(temp.conj().T.dot(temp)))
 
         # reference implementation
         def gold(A, x, b, iterations):
-            A = csr_matrix(A)
+            A = csr_array(A)
             n = A.shape[0]
 
             # Default is point-wise iteration with each subdomain a point's
@@ -1011,7 +1011,7 @@ class TestComplexRelaxation(TestCase):
         cases.append(A)
 
         temp = np.random.rand(4, 4) + 1.0j*np.random.rand(4, 4)
-        cases.append(csr_matrix(temp.conj().T.dot(temp)))
+        cases.append(csr_array(temp.conj().T.dot(temp)))
 
         # reference implementation
         def gold(A, x, b, iterations, sweep):
@@ -1256,7 +1256,7 @@ class TestComplexRelaxation(TestCase):
         cases.append(A.tobsr(blocksize=(2, 2)))
 
         temp = np.random.rand(4, 4) + 1.0j*np.random.rand(4, 4)
-        cases.append(csr_matrix(temp.T.dot(temp)))
+        cases.append(csr_array(temp.T.dot(temp)))
 
         # reference implementation
         def gold(A, x, b, iterations, sweep):
@@ -1415,11 +1415,11 @@ class TestComplexRelaxation(TestCase):
         cases.append(A.tobsr(blocksize=(2, 2)))
 
         temp = np.random.rand(1, 1) + 1.0j*np.random.rand(1, 1)
-        cases.append(csr_matrix(temp))
+        cases.append(csr_array(temp))
         temp = np.random.rand(2, 2) + 1.0j*np.random.rand(2, 2)
-        cases.append(csr_matrix(temp))
+        cases.append(csr_array(temp))
         temp = np.random.rand(4, 4) + 1.0j*np.random.rand(4, 4)
-        cases.append(csr_matrix(temp))
+        cases.append(csr_array(temp))
 
         # reference implementation
         def gold(A, x, b, iterations, sweep):
@@ -1490,20 +1490,20 @@ class TestBlockRelaxation(TestCase):
 
         # All real valued tests
         cases = []
-        A = csr_matrix(np.zeros((1, 1)))
+        A = csr_array(np.zeros((1, 1)))
         cases.append((A, 1))
-        A = csr_matrix(np.random.rand(1, 1))
+        A = csr_array(np.random.rand(1, 1))
         cases.append((A, 1))
-        A = csr_matrix(np.zeros((2, 2)))
-        cases.append((A, 1))
-        cases.append((A, 2))
-        A = csr_matrix(np.random.rand(2, 2))
+        A = csr_array(np.zeros((2, 2)))
         cases.append((A, 1))
         cases.append((A, 2))
-        A = csr_matrix(np.zeros((3, 3)))
+        A = csr_array(np.random.rand(2, 2))
+        cases.append((A, 1))
+        cases.append((A, 2))
+        A = csr_array(np.zeros((3, 3)))
         cases.append((A, 1))
         cases.append((A, 3))
-        A = csr_matrix(np.random.rand(3, 3))
+        A = csr_array(np.random.rand(3, 3))
         cases.append((A, 1))
         cases.append((A, 3))
         A = poisson((4, 4), format='csr')
@@ -1516,7 +1516,7 @@ class TestBlockRelaxation(TestCase):
                       [0., 0., 0., 0., 0., 0.],
                       [0., 0., 0., 4.2, 1., 1.1],
                       [0., 0., 9.1, 0., 0., 9.3]])
-        A = csr_matrix(A)
+        A = csr_array(A)
         cases.append((A, 1))
         cases.append((A, 2))
         cases.append((A, 3))
@@ -1524,14 +1524,14 @@ class TestBlockRelaxation(TestCase):
         # reference implementation of 1 iteration
         def gold(A, x, b, blocksize, omega):
 
-            A = csr_matrix(A)
+            A = csr_array(A)
             temp = x.copy()
             Dinv = get_block_diag(A, blocksize=blocksize, inv_flag=True)
             D = get_block_diag(A, blocksize=blocksize, inv_flag=False)
             I0 = np.arange(Dinv.shape[0])
             I1 = np.arange(Dinv.shape[0] + 1)
-            A_no_D = A - bsr_matrix((D, I0, I1), shape=A.shape)
-            A_no_D = csr_matrix(A_no_D)
+            A_no_D = A - bsr_array((D, I0, I1), shape=A.shape)
+            A_no_D = csr_array(A_no_D)
 
             for i in range(0, A.shape[0], blocksize):
                 r = A_no_D[i:(i+blocksize), :] @ temp
@@ -1560,7 +1560,7 @@ class TestBlockRelaxation(TestCase):
 
         # complex valued tests
         cases = []
-        A = csr_matrix(np.random.rand(3, 3) + 1.0j*np.random.rand(3, 3))
+        A = csr_array(np.random.rand(3, 3) + 1.0j*np.random.rand(3, 3))
         cases.append((A, 1))
         cases.append((A, 3))
         A = poisson((4, 4), format='csr')
@@ -1574,7 +1574,7 @@ class TestBlockRelaxation(TestCase):
                       [0., 0., 0., 0., 0., 0.],
                       [0., 0., 0., 4.2, 1.0j, 1.1],
                       [0., 0., 9.1, 0., 0., 9.3]])
-        A = csr_matrix(A)
+        A = csr_array(A)
         cases.append((A, 1))
         cases.append((A, 2))
         cases.append((A, 3))
@@ -1592,20 +1592,20 @@ class TestBlockRelaxation(TestCase):
 
         # All real valued tests
         cases = []
-        A = csr_matrix(np.zeros((1, 1)))
+        A = csr_array(np.zeros((1, 1)))
         cases.append((A, 1))
-        A = csr_matrix(np.random.rand(1, 1))
+        A = csr_array(np.random.rand(1, 1))
         cases.append((A, 1))
-        A = csr_matrix(np.zeros((2, 2)))
-        cases.append((A, 1))
-        cases.append((A, 2))
-        A = csr_matrix(np.random.rand(2, 2))
+        A = csr_array(np.zeros((2, 2)))
         cases.append((A, 1))
         cases.append((A, 2))
-        A = csr_matrix(np.zeros((3, 3)))
+        A = csr_array(np.random.rand(2, 2))
+        cases.append((A, 1))
+        cases.append((A, 2))
+        A = csr_array(np.zeros((3, 3)))
         cases.append((A, 1))
         cases.append((A, 3))
-        A = csr_matrix(np.random.rand(3, 3))
+        A = csr_array(np.random.rand(3, 3))
         cases.append((A, 1))
         cases.append((A, 3))
         A = poisson((4, 4), format='csr')
@@ -1618,7 +1618,7 @@ class TestBlockRelaxation(TestCase):
                       [0., 0., 0., 0., 0., 0.],
                       [0., 0., 0., 4.2, 1., 1.1],
                       [0., 0., 9.1, 0., 0., 9.3]])
-        A = csr_matrix(A)
+        A = csr_array(A)
         cases.append((A, 1))
         cases.append((A, 2))
         cases.append((A, 3))
@@ -1626,13 +1626,13 @@ class TestBlockRelaxation(TestCase):
         # reference implementation of 1 iteration
         def gold(A, x, b, blocksize, sweep):
 
-            A = csr_matrix(A)
+            A = csr_array(A)
             Dinv = get_block_diag(A, blocksize=blocksize, inv_flag=True)
             D = get_block_diag(A, blocksize=blocksize, inv_flag=False)
             I0 = np.arange(Dinv.shape[0])
             I1 = np.arange(Dinv.shape[0] + 1)
-            A_no_D = A - bsr_matrix((D, I0, I1), shape=A.shape)
-            A_no_D = csr_matrix(A_no_D)
+            A_no_D = A - bsr_array((D, I0, I1), shape=A.shape)
+            A_no_D = csr_array(A_no_D)
 
             if sweep == 'symmetric':
                 x = gold(A, x, b, blocksize, 'forward')
@@ -1704,7 +1704,7 @@ class TestBlockRelaxation(TestCase):
 
         # complex valued tests
         cases = []
-        A = csr_matrix(np.random.rand(3, 3) + 1.0j*np.random.rand(3, 3))
+        A = csr_array(np.random.rand(3, 3) + 1.0j*np.random.rand(3, 3))
         cases.append((A, 1))
         cases.append((A, 3))
         A = poisson((4, 4), format='csr')
@@ -1718,7 +1718,7 @@ class TestBlockRelaxation(TestCase):
                       [0., 0., 0., 0., 0., 0.],
                       [0., 0., 0., 4.2, 1.0j, 1.1],
                       [0., 0., 9.1, 0., 0., 9.3]])
-        A = csr_matrix(A)
+        A = csr_array(A)
         cases.append((A, 1))
         cases.append((A, 2))
         cases.append((A, 3))

--- a/pyamg/relaxation/tests/test_relaxation.py
+++ b/pyamg/relaxation/tests/test_relaxation.py
@@ -3,7 +3,7 @@ import warnings
 import numpy as np
 from numpy.testing import TestCase, assert_almost_equal
 import scipy
-from scipy.sparse import csr_matrix, bsr_matrix, diags, eye
+from scipy.sparse import csr_matrix, bsr_matrix, diags_array, eye_array
 from scipy.sparse import SparseEfficiencyWarning
 from scipy.linalg import solve
 
@@ -114,8 +114,8 @@ class TestCommonRelaxation(TestCase):
 class TestRelaxation(TestCase):
     def test_polynomial(self):
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                         shape=(N, N), format='csr')
         x0 = np.arange(N, dtype=A.dtype)
         x = x0.copy()
         b = np.zeros(N, dtype=A.dtype)
@@ -147,48 +147,48 @@ class TestRelaxation(TestCase):
 
     def test_jacobi(self):
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N).astype(np.float64)
         b = np.zeros(N)
         jacobi(A, x, b)
         assert_almost_equal(x, np.array([0]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.zeros(N)
         b = np.arange(N).astype(np.float64)
         jacobi(A, x, b)
         assert_almost_equal(x, np.array([0.0, 0.5, 1.0]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N).astype(np.float64)
         b = np.zeros(N)
         jacobi(A, x, b)
         assert_almost_equal(x, np.array([0.5, 1.0, 0.5]))
 
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N, dtype=A.dtype)
         b = np.array([10], dtype=A.dtype)
         jacobi(A, x, b)
         assert_almost_equal(x, np.array([5]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N, dtype=A.dtype)
         b = np.array([10, 20, 30], dtype=A.dtype)
         jacobi(A, x, b)
         assert_almost_equal(x, np.array([5.5, 11.0, 15.5]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N, dtype=A.dtype)
         x_copy = x.copy()
         b = np.array([10, 20, 30], dtype=A.dtype)
@@ -199,12 +199,12 @@ class TestRelaxation(TestCase):
     def test_jacobi_bsr(self):
         cases = []
         for N in [1, 2, 3, 4, 5, 6, 10]:
-            cases.append(diags([2 * np.ones(N), -np.ones(N), -np.ones(N)],
+            cases.append(diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)],
                                offsets=[0, -1, 1], shape=(N, N), format='csr'))
             cases.append(elasticity.linear_elasticity((N, N))[0].tocsr())
             C = csr_matrix(np.random.rand(N, N))
             cases.append(C @ C.T.conjugate())
-            C = sprand(N*2, N*2, 0.3) + eye(N*2, N*2)
+            C = sprand(N*2, N*2, 0.3) + eye_array(N*2, N*2)
             cases.append(C @ C.T.conjugate())
 
         for A in cases:
@@ -225,12 +225,12 @@ class TestRelaxation(TestCase):
         sweeps = ['forward', 'backward', 'symmetric']
         cases = []
         for N in [1, 2, 3, 4, 5, 6, 10]:
-            cases.append(diags([2 * np.ones(N), -np.ones(N), -np.ones(N)],
+            cases.append(diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)],
                                offsets=[0, -1, 1], shape=(N, N), format='csr'))
             cases.append(elasticity.linear_elasticity((N, N))[0].tocsr())
             C = csr_matrix(np.random.rand(N, N))
             cases.append(C @ C.T.conjugate())
-            C = sprand(N*2, N*2, 0.3) + eye(N*2, N*2)
+            C = sprand(N*2, N*2, 0.3) + eye_array(N*2, N*2)
             cases.append(C @ C.T.conjugate())
 
         for A in cases:
@@ -298,48 +298,48 @@ class TestRelaxation(TestCase):
 
     def test_gauss_seidel_csr(self):
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N).astype(np.float64)
         b = np.zeros(N)
         gauss_seidel(A, x, b)
         assert_almost_equal(x, np.array([0]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N).astype(np.float64)
         b = np.zeros(N)
         gauss_seidel(A, x, b)
         assert_almost_equal(x, np.array([1.0/2.0, 5.0/4.0, 5.0/8.0]))
 
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N).astype(np.float64)
         b = np.zeros(N)
         gauss_seidel(A, x, b, sweep='backward')
         assert_almost_equal(x, np.array([0]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N).astype(np.float64)
         b = np.zeros(N)
         gauss_seidel(A, x, b, sweep='backward')
         assert_almost_equal(x, np.array([1.0/8.0, 1.0/4.0, 1.0/2.0]))
 
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N, dtype=A.dtype)
         b = np.array([10], dtype=A.dtype)
         gauss_seidel(A, x, b)
         assert_almost_equal(x, np.array([5]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N, dtype=A.dtype)
         b = np.array([10, 20, 30], dtype=A.dtype)
         gauss_seidel(A, x, b)
@@ -348,8 +348,8 @@ class TestRelaxation(TestCase):
         # forward and backward passes should give same result with
         # x=np.ones(N),b=np.zeros(N)
         N = 100
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.ones(N)
         b = np.zeros(N)
         gauss_seidel(A, x, b, iterations=200, sweep='forward')
@@ -363,48 +363,48 @@ class TestRelaxation(TestCase):
 
     def test_gauss_seidel_indexed(self):
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N).astype(np.float64)
         b = np.zeros(N)
         gauss_seidel_indexed(A, x, b, [0])
         assert_almost_equal(x, np.array([0]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N).astype(np.float64)
         b = np.zeros(N)
         gauss_seidel_indexed(A, x, b, [0, 1, 2])
         assert_almost_equal(x, np.array([1.0/2.0, 5.0/4.0, 5.0/8.0]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N).astype(np.float64)
         b = np.zeros(N)
         gauss_seidel_indexed(A, x, b, [2, 1, 0], sweep='backward')
         assert_almost_equal(x, np.array([1.0/2.0, 5.0/4.0, 5.0/8.0]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N).astype(np.float64)
         b = np.zeros(N)
         gauss_seidel_indexed(A, x, b, [0, 1, 2], sweep='backward')
         assert_almost_equal(x, np.array([1.0/8.0, 1.0/4.0, 1.0/2.0]))
 
         N = 4
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.ones(N)
         b = np.zeros(N)
         gauss_seidel_indexed(A, x, b, [0, 3])
         assert_almost_equal(x, np.array([1.0/2.0, 1.0, 1.0, 1.0/2.0]))
 
         N = 4
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.ones(N)
         b = np.zeros(N)
         gauss_seidel_indexed(A, x, b, [0, 0])
@@ -412,40 +412,40 @@ class TestRelaxation(TestCase):
 
     def test_jacobi_indexed(self):
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N).astype(np.float64)
         b = np.zeros(N)
         jacobi_indexed(A, x, b, [0])
         assert_almost_equal(x, np.array([0]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N).astype(np.float64)
         b = np.zeros(N)
         jacobi_indexed(A, x, b, [0, 1, 2])
         assert_almost_equal(x, np.array([0.5, 1.0, 0.5]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N).astype(np.float64)
         b = np.zeros(N)
         jacobi_indexed(A, x, b, [2, 1, 0])
         assert_almost_equal(x, np.array([0.5, 1.0, 0.5]))
 
         N = 4
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.ones(N)
         b = np.zeros(N)
         jacobi_indexed(A, x, b, [0, 3])
         assert_almost_equal(x, np.array([0.5, 1.0, 1.0, 0.5]))
 
         N = 4
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.ones(N)
         b = np.zeros(N)
         jacobi_indexed(A, x, b, [0, 0])
@@ -453,48 +453,48 @@ class TestRelaxation(TestCase):
 
     def test_jacobi_ne(self):
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N).astype(np.float64)
         b = np.zeros(N)
         jacobi_ne(A, x, b)
         assert_almost_equal(x, np.array([0]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.zeros(N)
         b = np.arange(N).astype(np.float64)
         jacobi_ne(A, x, b)
         assert_almost_equal(x, np.array([-1./6., -1./15., 19./30.]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N).astype(np.float64)
         b = np.zeros(N)
         jacobi_ne(A, x, b)
         assert_almost_equal(x, np.array([2./5., 7./5., 4./5.]))
 
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N, dtype=A.dtype)
         b = np.array([10], dtype=A.dtype)
         jacobi_ne(A, x, b)
         assert_almost_equal(x, np.array([5]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N, dtype=A.dtype)
         b = np.array([10, 20, 30], dtype=A.dtype)
         jacobi_ne(A, x, b)
         assert_almost_equal(x, np.array([16./15., 1./15., (9 + 7./15.)]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N, dtype=A.dtype)
         x_copy = x.copy()
         b = np.array([10, 20, 30], dtype=A.dtype)
@@ -504,8 +504,8 @@ class TestRelaxation(TestCase):
 
     def test_gauss_seidel_ne_bsr(self):
         for N in [1, 2, 3, 4, 5, 6, 10]:
-            A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)],
-                      offsets=[0, -1, 1], shape=(N, N), format='csr')
+            A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)],
+                            offsets=[0, -1, 1], shape=(N, N), format='csr')
 
             divisors = [n for n in range(1, N+1) if N % n == 0]
 
@@ -569,56 +569,56 @@ class TestRelaxation(TestCase):
 
     def test_gauss_seidel_ne_csr(self):
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N).astype(np.float64)
         b = np.zeros(N)
         gauss_seidel_ne(A, x, b)
         assert_almost_equal(x, np.array([0]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N).astype(np.float64)
         b = np.zeros(N)
         gauss_seidel_ne(A, x, b)
         assert_almost_equal(x, np.array([4./15., 8./5., 4./5.]))
 
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N, dtype=A.dtype)
         b = np.zeros(N, dtype=A.dtype)
         gauss_seidel_ne(A, x, b, sweep='backward')
         assert_almost_equal(x, np.array([0]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N, dtype=A.dtype)
         b = np.zeros(N, dtype=A.dtype)
         gauss_seidel_ne(A, x, b, sweep='backward')
         assert_almost_equal(x, np.array([2./5., 4./5., 6./5.]))
 
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N, dtype=A.dtype)
         b = np.array([10], dtype=A.dtype)
         gauss_seidel_ne(A, x, b)
         assert_almost_equal(x, np.array([5]))
 
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N, dtype=A.dtype)
         b = np.array([10], dtype=A.dtype)
         gauss_seidel_ne(A, x, b, sweep='backward')
         assert_almost_equal(x, np.array([5]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N, dtype=A.dtype)
         b = np.array([10, 20, 30], dtype=A.dtype)
         gauss_seidel_ne(A, x, b)
@@ -627,8 +627,8 @@ class TestRelaxation(TestCase):
         # forward and backward passes should give same result with
         # x=np.ones(N),b=np.zeros(N)
         N = 100
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.ones(N)
         b = np.zeros(N)
         gauss_seidel_ne(A, x, b, iterations=200, sweep='forward')
@@ -643,8 +643,8 @@ class TestRelaxation(TestCase):
     def test_gauss_seidel_nr_bsr(self):
 
         for N in [1, 2, 3, 4, 5, 6, 10]:
-            A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)],
-                      offsets=[0, -1, 1], shape=(N, N), format='csr')
+            A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)],
+                            offsets=[0, -1, 1], shape=(N, N), format='csr')
 
             divisors = [n for n in range(1, N+1) if N % n == 0]
 
@@ -716,8 +716,8 @@ class TestRelaxation(TestCase):
         # forward and backward passes should give same result with
         # x=np.ones(N),b=np.zeros(N)
         N = 100
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.ones(N)
         b = np.zeros(N)
         gauss_seidel_nr(A, x, b, iterations=200, sweep='forward')
@@ -810,8 +810,8 @@ class TestRelaxation(TestCase):
 class TestComplexRelaxation(TestCase):
     def test_jacobi(self):
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         x = np.arange(N).astype(A.dtype)
         b = np.zeros(N).astype(A.dtype)
@@ -825,8 +825,8 @@ class TestComplexRelaxation(TestCase):
         assert_almost_equal(x, np.array([-3.5]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         x = np.zeros(N).astype(A.dtype)
         b = np.arange(N).astype(A.dtype)
@@ -836,8 +836,8 @@ class TestComplexRelaxation(TestCase):
         assert_almost_equal(x, soln)
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         x = np.arange(N).astype(A.dtype)
         x = x + 1.0j*x
@@ -847,8 +847,8 @@ class TestComplexRelaxation(TestCase):
         assert_almost_equal(x, soln)
 
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         x = np.arange(N).astype(A.dtype)
         b = np.array([10]).astype(A.dtype)
@@ -856,8 +856,8 @@ class TestComplexRelaxation(TestCase):
         assert_almost_equal(x, np.array([2.5 - 2.5j]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         x = np.arange(N).astype(A.dtype)
         x = x + 1.0j*x
@@ -867,8 +867,8 @@ class TestComplexRelaxation(TestCase):
         assert_almost_equal(x, soln)
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         x = np.arange(N).astype(A.dtype)
         x = x + 1.0j*x
@@ -881,8 +881,8 @@ class TestComplexRelaxation(TestCase):
     def test_jacobi_bsr(self):
         cases = []
         for N in [1, 2, 3, 4, 5, 6, 10]:
-            C = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)],
-                      offsets=[0, -1, 1], shape=(N, N), format='csr')
+            C = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)],
+                            offsets=[0, -1, 1], shape=(N, N), format='csr')
             C.data = C.data + 1.0j*1e-3*np.random.rand(C.data.shape[0],)
             cases.append(C)
             cases.append(1.0j*elasticity.linear_elasticity((N, N))[0].tocsr())
@@ -891,7 +891,7 @@ class TestComplexRelaxation(TestCase):
             cases.append(C @ C.T.conjugate())
 
             C = sprand(N*2, N*2, 0.3) + 1.0j*sprand(N*2, N*2, 0.3) +\
-                eye(N*2, N*2)
+                eye_array(N*2, N*2)
             cases.append(C @ C.T.conjugate())
 
         for A in cases:
@@ -913,8 +913,8 @@ class TestComplexRelaxation(TestCase):
         sweeps = ['forward', 'backward', 'symmetric']
         cases = []
         for N in [1, 2, 3, 4, 5, 6, 10]:
-            C = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)],
-                      offsets=[0, -1, 1], shape=(N, N), format='csr')
+            C = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)],
+                            offsets=[0, -1, 1], shape=(N, N), format='csr')
             C.data = C.data + 1.0j*1e-3*np.random.rand(C.data.shape[0],)
             cases.append(C)
             cases.append(1.0j*elasticity.linear_elasticity((N, N))[0].tocsr())
@@ -923,7 +923,7 @@ class TestComplexRelaxation(TestCase):
             cases.append(C @ C.T.conjugate())
 
             C = sprand(N*2, N*2, 0.3) + 1.0j*sprand(N*2, N*2, 0.3) +\
-                eye(N*2, N*2)
+                eye_array(N*2, N*2)
             cases.append(C @ C.T.conjugate())
 
         for A in cases:
@@ -1073,8 +1073,8 @@ class TestComplexRelaxation(TestCase):
 
     def test_gauss_seidel_csr(self):
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         x = np.arange(N).astype(A.dtype)
         x = x + 1.0j*x
@@ -1083,8 +1083,8 @@ class TestComplexRelaxation(TestCase):
         assert_almost_equal(x, np.array([0]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         x = np.arange(N).astype(A.dtype)
         x = x + 1.0j*x
@@ -1095,8 +1095,8 @@ class TestComplexRelaxation(TestCase):
         assert_almost_equal(x, soln)
 
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         x = np.arange(N).astype(A.dtype)
         x = x + 1.0j*x
@@ -1105,8 +1105,8 @@ class TestComplexRelaxation(TestCase):
         assert_almost_equal(x, np.array([0]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         x = np.arange(N).astype(A.dtype)
         x = x + 1.0j*x
@@ -1117,8 +1117,8 @@ class TestComplexRelaxation(TestCase):
         assert_almost_equal(x, soln)
 
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         x = np.arange(N).astype(A.dtype)
         b = np.array([10]).astype(A.dtype)
@@ -1126,8 +1126,8 @@ class TestComplexRelaxation(TestCase):
         assert_almost_equal(x, np.array([2.5 - 2.5j]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         soln = np.array([3.0 - 2.0j, 7.5 - 5.0j, 11.25 - 10.0j])
         x = np.arange(N).astype(A.dtype)
@@ -1139,8 +1139,8 @@ class TestComplexRelaxation(TestCase):
         # forward and backward passes should give same result with
         # x=np.ones(N),b=np.zeros(N)
         N = 100
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         x = np.ones(N).astype(A.dtype)
         x = x + 1.0j*x
@@ -1157,8 +1157,8 @@ class TestComplexRelaxation(TestCase):
 
     def test_jacobi_ne(self):
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         x = np.arange(N).astype(A.dtype)
         b = np.zeros(N).astype(A.dtype)
@@ -1166,8 +1166,8 @@ class TestComplexRelaxation(TestCase):
         assert_almost_equal(x, np.array([0]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         soln = np.array([-1./6., -1./15., 19./30.])
         x = np.zeros(N).astype(A.dtype)
@@ -1177,8 +1177,8 @@ class TestComplexRelaxation(TestCase):
         assert_almost_equal(x, soln)
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         soln = np.array([2./5. + 2.0j/5., 7./5. + 7.0j/5., 4./5. + 4.0j/5.])
         x = np.arange(N).astype(A.dtype)
@@ -1188,8 +1188,8 @@ class TestComplexRelaxation(TestCase):
         assert_almost_equal(x, soln)
 
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         x = np.arange(N).astype(A.dtype)
         b = np.array([10]).astype(A.dtype)
@@ -1197,8 +1197,8 @@ class TestComplexRelaxation(TestCase):
         assert_almost_equal(x, np.array([2.5 - 2.5j]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         soln = np.array([11./15. + 1.0j/15.,
                          11./15. + 31.0j/15,
@@ -1210,8 +1210,8 @@ class TestComplexRelaxation(TestCase):
         assert_almost_equal(x, soln)
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         x = np.arange(N).astype(A.dtype)
         x = x + 1.0j*x
@@ -1227,8 +1227,8 @@ class TestComplexRelaxation(TestCase):
 
     def test_gauss_seidel_ne_bsr(self):
         for N in [1, 2, 3, 4, 5, 6, 10]:
-            A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)],
-                      offsets=[0, -1, 1], shape=(N, N), format='csr')
+            A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)],
+                            offsets=[0, -1, 1], shape=(N, N), format='csr')
             A.data = A.data + 1.0j*1e-3*np.random.rand(A.data.shape[0],)
 
             divisors = [n for n in range(1, N+1) if N % n == 0]
@@ -1301,8 +1301,8 @@ class TestComplexRelaxation(TestCase):
 
     def test_gauss_seidel_ne_csr(self):
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         x = np.arange(N).astype(A.dtype)
         x = x + 1.0j*x
         A.data = A.data + 1.0j*A.data
@@ -1311,8 +1311,8 @@ class TestComplexRelaxation(TestCase):
         assert_almost_equal(x, np.array([0]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         soln = np.array([4./15., 8./5., 4./5.])
         soln = soln + 1.0j*soln
@@ -1323,8 +1323,8 @@ class TestComplexRelaxation(TestCase):
         assert_almost_equal(x, soln)
 
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         x = np.arange(N).astype(A.dtype)
         x = x + 1.0j*x
@@ -1333,8 +1333,8 @@ class TestComplexRelaxation(TestCase):
         assert_almost_equal(x, np.array([0]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         soln = np.array([2./5., 4./5., 6./5.])
         soln = soln + 1.0j*soln
@@ -1345,8 +1345,8 @@ class TestComplexRelaxation(TestCase):
         assert_almost_equal(x, soln)
 
         N = 1
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         x = np.arange(N).astype(A.dtype)
         b = np.array([10]).astype(A.dtype)
@@ -1354,8 +1354,8 @@ class TestComplexRelaxation(TestCase):
         assert_almost_equal(x, np.array([2.5 - 2.5j]))
 
         N = 3
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         soln = np.array([-1./15.+0.6j, 0.6+2.6j, 7.8-6.2j])
         x = np.arange(N).astype(A.dtype)
@@ -1367,8 +1367,8 @@ class TestComplexRelaxation(TestCase):
         # forward and backward passes should give same result with
         # x=np.ones(N),b=np.zeros(N)
         N = 100
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         x = np.ones(N).astype(A.dtype)
         x = x + 1.0j*x
@@ -1386,8 +1386,8 @@ class TestComplexRelaxation(TestCase):
 
     def test_gauss_seidel_nr_bsr(self):
         for N in [1, 2, 3, 4, 5, 6, 10]:
-            A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)],
-                      offsets=[0, -1, 1], shape=(N, N), format='csr')
+            A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)],
+                            offsets=[0, -1, 1], shape=(N, N), format='csr')
             A.data = A.data + 1.0j*1e-3*np.random.rand(A.data.shape[0],)
 
             divisors = [n for n in range(1, N+1) if N % n == 0]
@@ -1463,8 +1463,8 @@ class TestComplexRelaxation(TestCase):
         # forward and backward passes should give same result with
         # x=np.ones(N),b=np.zeros(N)
         N = 100
-        A = diags([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
-                  shape=(N, N), format='csr')
+        A = diags_array([2 * np.ones(N), -np.ones(N), -np.ones(N)], offsets=[0, -1, 1],
+                        shape=(N, N), format='csr')
         A.data = A.data + 1.0j*A.data
         x = np.ones(N).astype(A.dtype)
         x = x + 1.0j*x

--- a/pyamg/relaxation/tests/test_smoothing.py
+++ b/pyamg/relaxation/tests/test_smoothing.py
@@ -109,7 +109,7 @@ class TestSolverMatrix(TestCase):
         Relaxation parameters should change.  This is not checked.
         """
         A = poisson((20,), format='csr')
-        Anew = sparse.identity(A.shape[0], format='csr')
+        Anew = sparse.eye_array(A.shape[0], format='csr')
         register = ['gauss_seidel',
                     'jacobi',
                     'schwarz',

--- a/pyamg/strength.py
+++ b/pyamg/strength.py
@@ -26,7 +26,7 @@ def distance_strength_of_connection(A, V, theta=2.0, relative_drop=True):
 
     Parameters
     ----------
-    A : csr_matrix or bsr_matrix
+    A : csr_array or bsr_array
         Square, sparse matrix in CSR or BSR format
     V : array
         Coordinates of the vertices of the graph of A
@@ -40,7 +40,7 @@ def distance_strength_of_connection(A, V, theta=2.0, relative_drop=True):
 
     Returns
     -------
-    C : csr_matrix
+    C : csr_array
         C(i,j) = distance(point_i, point_j)
         Strength of connection matrix where strength values are
         distances, i.e. the smaller the value, the stronger the connection.
@@ -65,11 +65,11 @@ def distance_strength_of_connection(A, V, theta=2.0, relative_drop=True):
     if sparse.issparse(A) and A.format == 'bsr':
         sn = int(A.shape[0] / A.blocksize[0])
         u = np.ones((A.data.shape[0],))
-        A = sparse.csr_matrix((u, A.indices, A.indptr), shape=(sn, sn))
+        A = sparse.csr_array((u, A.indices, A.indptr), shape=(sn, sn))
 
     if not sparse.issparse(A) or A.format != 'csr':
         warn('Implicit conversion of A to csr', sparse.SparseEfficiencyWarning)
-        A = sparse.csr_matrix(A)
+        A = sparse.csr_array(A)
 
     dim = V.shape[1]
 
@@ -85,7 +85,7 @@ def distance_strength_of_connection(A, V, theta=2.0, relative_drop=True):
     C = np.sqrt(C)
     C[C < 1e-6] = 1e-6
 
-    C = sparse.csr_matrix((C, A.indices.copy(), A.indptr.copy()),
+    C = sparse.csr_array((C, A.indices.copy(), A.indptr.copy()),
                           shape=A.shape)
 
     # Apply drop tolerance
@@ -121,7 +121,7 @@ def classical_strength_of_connection(A, theta=0.1, block=True, norm='abs'):
 
     Parameters
     ----------
-    A : csr_matrix or bsr_matrix
+    A : csr_array or bsr_array
         Square, sparse matrix in CSR or BSR format
     theta : float
         Threshold parameter in [0,1]
@@ -141,7 +141,7 @@ def classical_strength_of_connection(A, theta=0.1, block=True, norm='abs'):
 
     Returns
     -------
-    S : csr_matrix
+    S : csr_array
         Matrix graph defining strong connections.  S[i,j] ~ 1.0 if vertex i
         is strongly influenced by vertex j, or block i is strongly influenced
         by block j if block=True.
@@ -214,7 +214,7 @@ def classical_strength_of_connection(A, theta=0.1, block=True, norm='abs'):
     else:
         if not sparse.issparse(A) or A.format != 'csr':
             warn('Implicit conversion of A to csr', sparse.SparseEfficiencyWarning)
-            A = sparse.csr_matrix(A)
+            A = sparse.csr_array(A)
         data = A.data
         N = A.shape[0]
 
@@ -231,7 +231,7 @@ def classical_strength_of_connection(A, theta=0.1, block=True, norm='abs'):
     else:
         raise ValueError('Unrecognized option for norm for strength.')
 
-    S = sparse.csr_matrix((Sx, Sj, Sp), shape=[N, N])
+    S = sparse.csr_array((Sx, Sj, Sp), shape=[N, N])
 
     # Take magnitude and scale by largest entry
     S.data = np.abs(S.data)
@@ -255,7 +255,7 @@ def symmetric_strength_of_connection(A, theta=0):
 
     Parameters
     ----------
-    A : csr_matrix
+    A : csr_array
         Matrix graph defined in sparse format.  Entry A[i,j] describes the
         strength of edge [i,j]
     theta : float
@@ -263,7 +263,7 @@ def symmetric_strength_of_connection(A, theta=0):
 
     Returns
     -------
-    S : csr_matrix
+    S : csr_array
         Matrix graph defining strong connections.  S[i,j]=1 if vertex i
         is strongly influenced by vertex j.
 
@@ -321,7 +321,7 @@ def symmetric_strength_of_connection(A, theta=0):
         fn = amg_core.symmetric_strength_of_connection
         fn(A.shape[0], theta, A.indptr, A.indices, A.data, Sp, Sj, Sx)
 
-        S = sparse.csr_matrix((Sx, Sj, Sp), shape=A.shape)
+        S = sparse.csr_array((Sx, Sj, Sp), shape=A.shape)
 
     elif sparse.issparse(A) and A.format == 'bsr':
         M, N = A.shape
@@ -332,14 +332,14 @@ def symmetric_strength_of_connection(A, theta=0):
 
         if theta == 0:
             data = np.ones(len(A.indices), dtype=A.dtype)
-            S = sparse.csr_matrix((data, A.indices.copy(), A.indptr.copy()),
+            S = sparse.csr_array((data, A.indices.copy(), A.indptr.copy()),
                                   shape=(int(M / R), int(N / C)))
         else:
             # the strength of connection matrix is based on the
             # Frobenius norms of the blocks
             data = (np.conjugate(A.data) * A.data).reshape(-1, R * C)
             data = np.sqrt(data.sum(axis=1))
-            A = sparse.csr_matrix((data, A.indices, A.indptr),
+            A = sparse.csr_array((data, A.indices, A.indptr),
                                   shape=(int(M / R), int(N / C)))
             return symmetric_strength_of_connection(A, theta)
     else:
@@ -370,7 +370,7 @@ def energy_based_strength_of_connection(A, theta=0.0, k=2):
 
     Returns
     -------
-    S : csr_matrix
+    S : csr_array
         Matrix graph defining strong connections.  The sparsity pattern
         of S matches that of A.  For BSR matrices, S is a reduced strength
         of connection matrix that describes connections between supernodes.
@@ -443,14 +443,14 @@ def energy_based_strength_of_connection(A, theta=0.0, k=2):
     D = A.diagonal()
     Dinv = 1.0 / D
     Dinv[D == 0] = 0.0
-    Dinv = sparse.csc_matrix((Dinv, (np.arange(A.shape[0]),
+    Dinv = sparse.csc_array((Dinv, (np.arange(A.shape[0]),
                                      np.arange(A.shape[1]))), shape=A.shape)
     DinvA = Dinv @ A
     omega = 1.0 / approximate_spectral_radius(DinvA)
     del DinvA
 
     # Approximate A-inverse with k steps of w-Jacobi and a zero initial guess
-    S = sparse.csc_matrix(A.shape, dtype=A.dtype)  # empty matrix
+    S = sparse.csc_array(A.shape, dtype=A.dtype)  # empty matrix
     Id = sparse.eye_array(A.shape[0], A.shape[1], format='csc')
     for _i in range(k + 1):
         S = S + omega * (Dinv @ (Id - A @ S))
@@ -491,7 +491,7 @@ def energy_based_strength_of_connection(A, theta=0.0, k=2):
         Atilde = Atilde.tobsr(blocksize=(numPDEs, numPDEs))
         nblocks = Atilde.indices.shape[0]
         uone = np.ones((nblocks,))
-        Atilde = sparse.csr_matrix((uone, Atilde.indices, Atilde.indptr),
+        Atilde = sparse.csr_array((uone, Atilde.indices, Atilde.indptr),
                                    shape=(int(Atilde.shape[0] / numPDEs),
                                           int(Atilde.shape[1] / numPDEs)))
 
@@ -519,7 +519,7 @@ def evolution_strength_of_connection(A, B=None, epsilon=4.0, k=2,
 
     Parameters
     ----------
-    A : csr_matrix, bsr_matrix
+    A : csr_array, bsr_array
         Sparse NxN matrix
     B : string, array
         If B=None, then the near nullspace vector used is all ones.  If B is
@@ -538,7 +538,7 @@ def evolution_strength_of_connection(A, B=None, epsilon=4.0, k=2,
 
     Returns
     -------
-    Atilde : csr_matrix
+    Atilde : csr_array
         Sparse matrix of strength values
 
     See [2008OlScTu]_ for more details.
@@ -571,7 +571,7 @@ def evolution_strength_of_connection(A, B=None, epsilon=4.0, k=2,
     if proj_type not in ['l2', 'D_A']:
         raise ValueError('proj_type must be "l2" or "D_A"')
     if not sparse.issparse(A) or A.format not in ('csr', 'bsr'):
-        raise TypeError('expected csr_matrix or bsr_matrix')
+        raise TypeError('expected csr_array or bsr_array')
 
     # ====================================================================
     # Format A and B correctly.
@@ -590,7 +590,7 @@ def evolution_strength_of_connection(A, B=None, epsilon=4.0, k=2,
         # Calculate Dinv@A
         if block_flag:
             Dinv = get_block_diag(A, blocksize=numPDEs, inv_flag=True)
-            Dinv = sparse.bsr_matrix((Dinv, np.arange(Dinv.shape[0]),
+            Dinv = sparse.bsr_array((Dinv, np.arange(Dinv.shape[0]),
                                       np.arange(Dinv.shape[0] + 1)),
                                      shape=A.shape)
             Dinv_A = (Dinv @ A).tocsr()
@@ -837,8 +837,8 @@ def evolution_strength_of_connection(A, B=None, epsilon=4.0, k=2,
         CSRdata = np.zeros((n_blocks,))
         amg_core.min_blocks(n_blocks, blocksize,
                             np.ravel(np.asarray(Atilde.data)), CSRdata)
-        # Atilde = sparse.csr_matrix((data, row, col), shape=(*,*))
-        Atilde = sparse.csr_matrix((CSRdata, Atilde.indices, Atilde.indptr),
+        # Atilde = sparse.csr_array((data, row, col), shape=(*,*))
+        Atilde = sparse.csr_array((CSRdata, Atilde.indices, Atilde.indptr),
                                    shape=(int(Atilde.shape[0] / numPDEs),
                                           int(Atilde.shape[1] / numPDEs)))
 
@@ -857,7 +857,7 @@ def relaxation_vectors(A, R, k, alpha):
 
     Parameters
     ----------
-    A : csr_matrix
+    A : csr_array
         Sparse NxN matrix
     alpha : scalar
         Weight for Jacobi
@@ -892,7 +892,7 @@ def affinity_distance(A, alpha=0.5, R=5, k=20, epsilon=4.0):
 
     Parameters
     ----------
-    A : csr_matrix
+    A : csr_array
         Sparse NxN matrix
     alpha : scalar
         Weight for Jacobi
@@ -905,7 +905,7 @@ def affinity_distance(A, alpha=0.5, R=5, k=20, epsilon=4.0):
 
     Returns
     -------
-    C : csr_matrix
+    C : csr_array
         Sparse matrix of strength values
 
     References
@@ -923,7 +923,7 @@ def affinity_distance(A, alpha=0.5, R=5, k=20, epsilon=4.0):
 
     """
     if not sparse.issparse(A) or A.format != 'csr':
-        A = sparse.csr_matrix(A)
+        A = sparse.csr_array(A)
 
     if alpha < 0:
         raise ValueError('expected alpha>0')
@@ -950,7 +950,7 @@ def algebraic_distance(A, alpha=0.5, R=5, k=20, epsilon=2.0, p=2):
 
     Parameters
     ----------
-    A : csr_matrix
+    A : csr_array
         Sparse NxN matrix
     alpha : scalar
         Weight for Jacobi
@@ -965,7 +965,7 @@ def algebraic_distance(A, alpha=0.5, R=5, k=20, epsilon=2.0, p=2):
 
     Returns
     -------
-    C : csr_matrix
+    C : csr_array
         Sparse matrix of strength values
 
     References
@@ -983,7 +983,7 @@ def algebraic_distance(A, alpha=0.5, R=5, k=20, epsilon=2.0, p=2):
 
     """
     if not sparse.issparse(A) or A.format != 'csr':
-        A = sparse.csr_matrix(A)
+        A = sparse.csr_array(A)
 
     if alpha < 0:
         raise ValueError('expected alpha>0')
@@ -1023,7 +1023,7 @@ def distance_measure_common(A, func, alpha, R, k, epsilon):
     (rows, cols) = A.nonzero()
     weak = np.where(rows == cols)[0]
     d[weak] = 0
-    C = sparse.csr_matrix((d, (rows, cols)), shape=A.shape)
+    C = sparse.csr_array((d, (rows, cols)), shape=A.shape)
     C.eliminate_zeros()
 
     # remove weak connections

--- a/pyamg/strength.py
+++ b/pyamg/strength.py
@@ -591,7 +591,8 @@ def evolution_strength_of_connection(A, B=None, epsilon=4.0, k=2,
         # Calculate Dinv@A
         if block_flag:
             Dinv = get_block_diag(A, blocksize=numPDEs, inv_flag=True)
-            Dinv = sparse.bsr_array((Dinv, np.arange(Dinv.shape[0], dtype=Dinv.indptr.dtype),
+            Dinv = sparse.bsr_array((Dinv,
+                                     np.arange(Dinv.shape[0], dtype=Dinv.indptr.dtype),
                                      np.arange(Dinv.shape[1], dtype=Dinv.indptr.dtype)),
                                     shape=A.shape)
             Dinv_A = (Dinv @ A).tocsr()

--- a/pyamg/strength.py
+++ b/pyamg/strength.py
@@ -98,7 +98,7 @@ def distance_strength_of_connection(A, V, theta=2.0, relative_drop=True):
                                                 C.indices, C.data)
     C.eliminate_zeros()
 
-    C = C + sparse.eye(C.shape[0], C.shape[1], format='csr')
+    C = C + sparse.eye_array(C.shape[0], C.shape[1], format='csr')
 
     # Standardized strength values require small values be weak and large
     # values be strong.  So, we invert the distances.
@@ -451,7 +451,7 @@ def energy_based_strength_of_connection(A, theta=0.0, k=2):
 
     # Approximate A-inverse with k steps of w-Jacobi and a zero initial guess
     S = sparse.csc_matrix(A.shape, dtype=A.dtype)  # empty matrix
-    Id = sparse.eye(A.shape[0], A.shape[1], format='csc')
+    Id = sparse.eye_array(A.shape[0], A.shape[1], format='csc')
     for _i in range(k + 1):
         S = S + omega * (Dinv @ (Id - A @ S))
 
@@ -624,9 +624,9 @@ def evolution_strength_of_connection(A, B=None, epsilon=4.0, k=2,
 
     # Calculate D_A for later use in the minimization problem
     if proj_type == 'D_A':
-        D_A = sparse.diags([D], offsets=[0], shape=(dimen, dimen), format='csr')
+        D_A = sparse.diags_array([D], offsets=[0], shape=(dimen, dimen), format='csr')
     else:
-        D_A = sparse.eye(dimen, dimen, format='csr', dtype=A.dtype)
+        D_A = sparse.eye_array(dimen, format='csr', dtype=A.dtype)
 
     # Calculate (I - delta_t Dinv A)^k
     #      In order to later access columns, we calculate the transpose in
@@ -637,7 +637,7 @@ def evolution_strength_of_connection(A, B=None, epsilon=4.0, k=2,
     ninc = k - 2**nsquare
 
     # Calculate one time step
-    Id = sparse.eye(dimen, dimen, format='csr', dtype=A.dtype)
+    Id = sparse.eye_array(dimen, format='csr', dtype=A.dtype)
     Atilde = Id - (1.0 / rho_DinvA) * Dinv_A
     Atilde = Atilde.T.tocsr()
 
@@ -823,7 +823,7 @@ def evolution_strength_of_connection(A, B=None, epsilon=4.0, k=2,
         Atilde = 0.5 * (Atilde + Atilde.T)
 
     # Set diagonal to 1.0, as each point is strongly connected to itself.
-    Id = sparse.eye(dimen, dimen, format='csr')
+    Id = sparse.eye_array(dimen, format='csr')
     Id.data -= Atilde.diagonal()
     Atilde = Atilde + Id
 
@@ -1037,7 +1037,7 @@ def distance_measure_common(A, func, alpha, R, k, epsilon):
     C.data = 1.0 / C.data
 
     # Put an identity on the diagonal
-    C = C + sparse.eye(C.shape[0], C.shape[1], format='csr')
+    C = C + sparse.eye_array(C.shape[0], C.shape[1], format='csr')
 
     # Scale C by the largest magnitude entry in each row
     C = scale_rows_by_largest_entry(C)

--- a/pyamg/tests/test_amg_core_linalg.py
+++ b/pyamg/tests/test_amg_core_linalg.py
@@ -12,12 +12,12 @@ def test_real():
     A0 = A.copy()
 
     # no lumping, threshold 0.0
-    A = sparse.csr_matrix(A0.copy())
+    A = sparse.csr_array(A0.copy())
     amg_core.linalg.filter_matrix_rows(4, 0.0, A.indptr, A.indices, A.data, 0)
     np.testing.assert_array_equal(A.toarray(), A0)
 
     # no lumping, threshold 1.0
-    A = sparse.csr_matrix(A0.copy())
+    A = sparse.csr_array(A0.copy())
     amg_core.linalg.filter_matrix_rows(4, 1.0, A.indptr, A.indices, A.data, 0)
     B = np.array([[1.,  2.,  0.0,  0.],
                   [0.,  2.,  0.0,  3.],
@@ -26,7 +26,7 @@ def test_real():
     np.testing.assert_array_equal(A.toarray(), B)
 
     # lumping, threshold 1.0
-    A = sparse.csr_matrix(A0.copy())
+    A = sparse.csr_array(A0.copy())
     amg_core.linalg.filter_matrix_rows(4, 1.0, A.indptr, A.indices, A.data, True)
     B = np.array([[1.5,  2.0,  0.0,  0.0],
                   [0.0,  4.5,  0.0,  3.0],
@@ -43,12 +43,12 @@ def test_imag():
     A0 = A.copy()
 
     # no lumping, threshold 0.0
-    A = sparse.csr_matrix(A0.copy())
+    A = sparse.csr_array(A0.copy())
     amg_core.linalg.filter_matrix_rows(4, 0.0, A.indptr, A.indices, A.data, 0)
     np.testing.assert_array_equal(A.toarray(), A0)
 
     # no lumping, threshold 1.0
-    A = sparse.csr_matrix(A0.copy())
+    A = sparse.csr_array(A0.copy())
     amg_core.linalg.filter_matrix_rows(4, 1.0, A.indptr, A.indices, A.data, 0)
     B = np.array([[1.,  2.,  0.0,  0.0],
                   [0.,  2.,  0.0,  3.0],
@@ -57,7 +57,7 @@ def test_imag():
     np.testing.assert_array_equal(A.toarray(), B)
 
     # lumping, threshold 1.0
-    A = sparse.csr_matrix(A0.copy())
+    A = sparse.csr_array(A0.copy())
     amg_core.linalg.filter_matrix_rows(4, 1.0, A.indptr, A.indices, A.data, True)
     B = np.array([[1.5,  2.0,  0.0,  0.0],
                   [0.0,  4.5,  0.0,  3.0],
@@ -74,12 +74,12 @@ def test_complex():
     A0 = A.copy()
 
     # no lumping, threshold 0.0
-    A = sparse.csr_matrix(A0.copy())
+    A = sparse.csr_array(A0.copy())
     amg_core.linalg.filter_matrix_rows(4, 0.0, A.indptr, A.indices, A.data, 0)
     np.testing.assert_array_equal(A.toarray(), A0)
 
     # no lumping, threshold 1.0
-    A = sparse.csr_matrix(A0.copy())
+    A = sparse.csr_array(A0.copy())
     amg_core.linalg.filter_matrix_rows(4, 1.0, A.indptr, A.indices, A.data, 0)
     B = np.array([[1. + 3.0j,  0. + 0.0j,  0.0 + 0.0j,  4.1 + 0.0j],
                   [0. + 0.0j,  2. + 0.0j,  0.0 + 0.0j,  3.0 + 0.0j],
@@ -88,7 +88,7 @@ def test_complex():
     np.testing.assert_array_equal(A.toarray(), B)
 
     # lumping, threshold 1.0
-    A = sparse.csr_matrix(A0.copy())
+    A = sparse.csr_array(A0.copy())
     amg_core.linalg.filter_matrix_rows(4, 1.0, A.indptr, A.indices, A.data, True)
     B = np.array([[3.5 + 6.0j,  0.0 + 0.0j,  0.0 + 0.0j,  4.1 + 0.0j],
                   [0.0 + 0.0j,  4.5 + 0.0j,  0.0 + 0.0j,  3.0 + 0.0j],

--- a/pyamg/tests/test_clustering.py
+++ b/pyamg/tests/test_clustering.py
@@ -11,7 +11,7 @@ def canonical_graph(G):
     # convert to expected format
     # - remove diagonal entries
     # - all nonzero values = 1
-    G = sparse.coo_matrix(G)
+    G = sparse.coo_array(G)
 
     mask = G.row != G.col
     G.row = G.row[mask]
@@ -70,7 +70,7 @@ class TestClustering(TestCase):
         G[4, [0, 1, 2, 3, 5]] = 1
         G[5, [1, 2, 4]] = 1
         G[[0, 1, 2, 3, 4, 5], [0, 1, 2, 3, 4, 5]] = [3, 5, 3, 3, 5, 3]
-        G = sparse.csr_matrix(G)
+        G = sparse.csr_array(G)
         cases[0] = (G)
 
         cm = np.array([0, 1, 1, 0, 0, 1], dtype=np.int32)
@@ -144,7 +144,7 @@ class TestClustering(TestCase):
         G[10, [4, 9, 11]] = 1
         G[11, [9, 10]] = 1
         G[np.arange(12), np.arange(12)] = [2, 3, 4, 2, 2, 4, 4, 2, 2, 4, 3, 2]
-        G = sparse.csr_matrix(G)
+        G = sparse.csr_array(G)
         cases.append(G)
 
         cm = np.array([0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 1], dtype=np.int32)
@@ -205,7 +205,7 @@ class TestClustering(TestCase):
         G[9, [5, 8]] = 1
         G[10, [9, 11]] = 1
         G[11, [9]] = 1
-        G = sparse.csr_matrix(G)
+        G = sparse.csr_array(G)
         np.random.seed(1664236979)
         G.data[:] = np.random.rand(len(G.data)) * 2
         cases.append(G)

--- a/pyamg/tests/test_graph.py
+++ b/pyamg/tests/test_graph.py
@@ -16,7 +16,7 @@ def canonical_graph(G):
     # convert to expected format
     # - remove diagonal entries
     # - all nonzero values = 1
-    G = sparse.coo_matrix(G)
+    G = sparse.coo_array(G)
 
     mask = G.row != G.col
     G.row = G.row[mask]
@@ -133,7 +133,7 @@ class TestGraph(TestCase):
                           [1, 2],
                           [4, 3]])
         w = np.array([2, 1, 2, 1, 4, 5, 3, 1], dtype=float)
-        G = sparse.coo_matrix((w, (Edges[:, 0], Edges[:, 1])))
+        G = sparse.coo_array((w, (Edges[:, 0], Edges[:, 1])))
         distances_FROM_seed = np.array([[0.,     1.,     4., 3.,     3.],
                                         [np.inf, 0.,     3., 2.,     2.],
                                         [np.inf, np.inf, 0., np.inf, np.inf],
@@ -211,7 +211,7 @@ class TestVertexColorings(TestCase):
                        [0, 1, 0, 0, 1],
                        [1, 1, 0, 0, 1],
                        [0, 1, 1, 1, 0]])
-        self.G0 = sparse.csr_matrix(G0)
+        self.G0 = sparse.csr_array(G0)
         # make sure graph is symmetric
         assert_equal((self.G0 - self.G0.T).nnz, 0)
 
@@ -224,7 +224,7 @@ class TestVertexColorings(TestCase):
                        [0, 1, 0, 0, 1, 1],
                        [0, 0, 0, 1, 0, 1],
                        [0, 0, 0, 1, 1, 0]])
-        self.G1 = sparse.csr_matrix(G1)
+        self.G1 = sparse.csr_array(G1)
         # make sure graph is symmetric
         assert_equal((self.G1 - self.G1.T).nnz, 0)
 
@@ -264,20 +264,20 @@ def test_breadth_first_search():
 
     BFS = breadth_first_search
 
-    G = sparse.csr_matrix([[0, 1, 0, 0],
-                           [1, 0, 1, 0],
-                           [0, 1, 0, 1],
-                           [0, 0, 1, 0]])
+    G = sparse.csr_array([[0, 1, 0, 0],
+                          [1, 0, 1, 0],
+                          [0, 1, 0, 1],
+                          [0, 0, 1, 0]])
 
     assert_equal(BFS(G, 0)[1], [0, 1, 2, 3])
     assert_equal(BFS(G, 1)[1], [1, 0, 1, 2])
     assert_equal(BFS(G, 2)[1], [2, 1, 0, 1])
     assert_equal(BFS(G, 3)[1], [3, 2, 1, 0])
 
-    G = sparse.csr_matrix([[0, 1, 0, 0],
-                           [1, 0, 1, 0],
-                           [0, 1, 0, 0],
-                           [0, 0, 0, 0]])
+    G = sparse.csr_array([[0, 1, 0, 0],
+                          [1, 0, 1, 0],
+                          [0, 1, 0, 0],
+                          [0, 0, 0, 0]])
 
     assert_equal(BFS(G, 0)[1], [0, 1, 2, -1])
     assert_equal(BFS(G, 1)[1], [1, 0, 1, -1])
@@ -288,55 +288,55 @@ def test_breadth_first_search():
 def test_connected_components():
 
     cases = []
-    cases.append(sparse.csr_matrix([[0, 1, 0, 0],
-                                    [1, 0, 1, 0],
-                                    [0, 1, 0, 1],
-                                    [0, 0, 1, 0]]))
+    cases.append(sparse.csr_array([[0, 1, 0, 0],
+                                   [1, 0, 1, 0],
+                                   [0, 1, 0, 1],
+                                   [0, 0, 1, 0]]))
 
-    cases.append(sparse.csr_matrix([[0, 1, 0, 0],
-                                    [1, 0, 0, 0],
-                                    [0, 0, 0, 1],
-                                    [0, 0, 1, 0]]))
+    cases.append(sparse.csr_array([[0, 1, 0, 0],
+                                   [1, 0, 0, 0],
+                                   [0, 0, 0, 1],
+                                   [0, 0, 1, 0]]))
 
-    cases.append(sparse.csr_matrix([[0, 1, 0, 0],
-                                    [1, 0, 0, 0],
-                                    [0, 0, 0, 0],
-                                    [0, 0, 0, 0]]))
+    cases.append(sparse.csr_array([[0, 1, 0, 0],
+                                   [1, 0, 0, 0],
+                                   [0, 0, 0, 0],
+                                   [0, 0, 0, 0]]))
 
-    cases.append(sparse.csr_matrix([[0, 0, 0, 0],
-                                    [0, 0, 0, 0],
-                                    [0, 0, 0, 0],
-                                    [0, 0, 0, 0]]))
+    cases.append(sparse.csr_array([[0, 0, 0, 0],
+                                   [0, 0, 0, 0],
+                                   [0, 0, 0, 0],
+                                   [0, 0, 0, 0]]))
 
     #  2        5
     #  | \    / |
     #  0--1--3--4
-    cases.append(sparse.csr_matrix([[0, 1, 1, 0, 0, 0],
-                                    [1, 0, 1, 1, 0, 0],
-                                    [1, 1, 0, 0, 0, 0],
-                                    [0, 1, 0, 0, 1, 1],
-                                    [0, 0, 0, 1, 0, 1],
-                                    [0, 0, 0, 1, 1, 0]]))
+    cases.append(sparse.csr_array([[0, 1, 1, 0, 0, 0],
+                                   [1, 0, 1, 1, 0, 0],
+                                   [1, 1, 0, 0, 0, 0],
+                                   [0, 1, 0, 0, 1, 1],
+                                   [0, 0, 0, 1, 0, 1],
+                                   [0, 0, 0, 1, 1, 0]]))
 
     #  2        5
     #  | \    / |
     #  0  1--3--4
-    cases.append(sparse.csr_matrix([[0, 0, 1, 0, 0, 0],
-                                    [0, 0, 1, 1, 0, 0],
-                                    [1, 1, 0, 0, 0, 0],
-                                    [0, 1, 0, 0, 1, 1],
-                                    [0, 0, 0, 1, 0, 1],
-                                    [0, 0, 0, 1, 1, 0]]))
+    cases.append(sparse.csr_array([[0, 0, 1, 0, 0, 0],
+                                   [0, 0, 1, 1, 0, 0],
+                                   [1, 1, 0, 0, 0, 0],
+                                   [0, 1, 0, 0, 1, 1],
+                                   [0, 0, 0, 1, 0, 1],
+                                   [0, 0, 0, 1, 1, 0]]))
 
     #  2        5
     #  | \    / |
     #  0--1  3--4
-    cases.append(sparse.csr_matrix([[0, 1, 1, 0, 0, 0],
-                                    [1, 0, 1, 0, 0, 0],
-                                    [1, 1, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 1, 1],
-                                    [0, 0, 0, 1, 0, 1],
-                                    [0, 0, 0, 1, 1, 0]]))
+    cases.append(sparse.csr_array([[0, 1, 1, 0, 0, 0],
+                                   [1, 0, 1, 0, 0, 0],
+                                   [1, 1, 0, 0, 0, 0],
+                                   [0, 0, 0, 0, 1, 1],
+                                   [0, 0, 0, 1, 0, 1],
+                                   [0, 0, 0, 1, 1, 0]]))
 
     # Compare to reference implementation #
     for G in cases:
@@ -362,55 +362,55 @@ def test_connected_components():
 def test_complex_connected_components():
 
     cases = []
-    cases.append(sparse.csr_matrix([[0, 1, 0, 0],
-                                    [1, 0, 1, 0],
-                                    [0, 1, 0, 1],
-                                    [0, 0, 1, 0]]))
+    cases.append(sparse.csr_array([[0, 1, 0, 0],
+                                   [1, 0, 1, 0],
+                                   [0, 1, 0, 1],
+                                   [0, 0, 1, 0]]))
 
-    cases.append(sparse.csr_matrix([[0, 1, 0, 0],
-                                    [1, 0, 0, 0],
-                                    [0, 0, 0, 1],
-                                    [0, 0, 1, 0]]))
+    cases.append(sparse.csr_array([[0, 1, 0, 0],
+                                   [1, 0, 0, 0],
+                                   [0, 0, 0, 1],
+                                   [0, 0, 1, 0]]))
 
-    cases.append(sparse.csr_matrix([[0, 1, 0, 0],
-                                    [1, 0, 0, 0],
-                                    [0, 0, 0, 0],
-                                    [0, 0, 0, 0]]))
+    cases.append(sparse.csr_array([[0, 1, 0, 0],
+                                   [1, 0, 0, 0],
+                                   [0, 0, 0, 0],
+                                   [0, 0, 0, 0]]))
 
-    cases.append(sparse.csr_matrix([[0, 0, 0, 0],
-                                    [0, 0, 0, 0],
-                                    [0, 0, 0, 0],
-                                    [0, 0, 0, 0]]))
+    cases.append(sparse.csr_array([[0, 0, 0, 0],
+                                   [0, 0, 0, 0],
+                                   [0, 0, 0, 0],
+                                   [0, 0, 0, 0]]))
 
     #  2        5
     #  | \    / |
     #  0--1--3--4
-    cases.append(sparse.csr_matrix([[0, 1, 1, 0, 0, 0],
-                                    [1, 0, 1, 1, 0, 0],
-                                    [1, 1, 0, 0, 0, 0],
-                                    [0, 1, 0, 0, 1, 1],
-                                    [0, 0, 0, 1, 0, 1],
-                                    [0, 0, 0, 1, 1, 0]]))
+    cases.append(sparse.csr_array([[0, 1, 1, 0, 0, 0],
+                                   [1, 0, 1, 1, 0, 0],
+                                   [1, 1, 0, 0, 0, 0],
+                                   [0, 1, 0, 0, 1, 1],
+                                   [0, 0, 0, 1, 0, 1],
+                                   [0, 0, 0, 1, 1, 0]]))
 
     #  2        5
     #  | \    / |
     #  0  1--3--4
-    cases.append(sparse.csr_matrix([[0, 0, 1, 0, 0, 0],
-                                    [0, 0, 1, 1, 0, 0],
-                                    [1, 1, 0, 0, 0, 0],
-                                    [0, 1, 0, 0, 1, 1],
-                                    [0, 0, 0, 1, 0, 1],
-                                    [0, 0, 0, 1, 1, 0]]))
+    cases.append(sparse.csr_array([[0, 0, 1, 0, 0, 0],
+                                   [0, 0, 1, 1, 0, 0],
+                                   [1, 1, 0, 0, 0, 0],
+                                   [0, 1, 0, 0, 1, 1],
+                                   [0, 0, 0, 1, 0, 1],
+                                   [0, 0, 0, 1, 1, 0]]))
 
     #  2        5
     #  | \    / |
     #  0--1  3--4
-    cases.append(sparse.csr_matrix([[0, 1, 1, 0, 0, 0],
-                                    [1, 0, 1, 0, 0, 0],
-                                    [1, 1, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 1, 1],
-                                    [0, 0, 0, 1, 0, 1],
-                                    [0, 0, 0, 1, 1, 0]]))
+    cases.append(sparse.csr_array([[0, 1, 1, 0, 0, 0],
+                                   [1, 0, 1, 0, 0, 0],
+                                   [1, 1, 0, 0, 0, 0],
+                                   [0, 0, 0, 0, 1, 1],
+                                   [0, 0, 0, 1, 0, 1],
+                                   [0, 0, 0, 1, 1, 0]]))
 
     # Create complex data entries
     cases = [G+1.0j*G for G in cases]

--- a/pyamg/tests/test_graph.py
+++ b/pyamg/tests/test_graph.py
@@ -82,7 +82,7 @@ class TestGraph(TestCase):
             for k in [1, 2, 3, 4]:
                 mis = maximal_independent_set(G, k=k)
                 if k > 1:
-                    G = (G + np.eye(G.shape[0]))**k
+                    G = sparse.linalg.matrix_power(G + np.eye(G.shape[0]), k)
                     G = canonical_graph(G)
                 assert_is_mis(G, mis)
 
@@ -131,7 +131,7 @@ class TestGraph(TestCase):
                           [0, 2],
                           [3, 2],
                           [1, 2],
-                          [4, 3]])
+                          [4, 3]], dtype=np.int32)
         w = np.array([2, 1, 2, 1, 4, 5, 3, 1], dtype=float)
         G = sparse.coo_array((w, (Edges[:, 0], Edges[:, 1])))
         distances_FROM_seed = np.array([[0.,     1.,     4., 3.,     3.],

--- a/pyamg/tests/test_multilevel.py
+++ b/pyamg/tests/test_multilevel.py
@@ -18,7 +18,7 @@ class TestMultilevel(TestCase):
     def test_coarse_grid_solver(self):
         cases = []
 
-        cases.append(sparse.csr_matrix(np.diag(np.arange(1, 5, dtype=float))))
+        cases.append(sparse.csr_array(np.diag(np.arange(1, 5, dtype=float))))
         cases.append(poisson((4,), format='csr'))
         cases.append(poisson((4, 4), format='csr'))
 
@@ -94,16 +94,16 @@ class TestMultilevel(TestCase):
         # four levels
         levels = []
         levels.append(MultilevelSolver.Level())
-        levels[0].A = sparse.csr_matrix(np.ones((10, 10)))
-        levels[0].P = sparse.csr_matrix(np.ones((10, 5)))
+        levels[0].A = sparse.csr_array(np.ones((10, 10)))
+        levels[0].P = sparse.csr_array(np.ones((10, 5)))
         levels.append(MultilevelSolver.Level())
-        levels[1].A = sparse.csr_matrix(np.ones((5, 5)))
-        levels[1].P = sparse.csr_matrix(np.ones((5, 3)))
+        levels[1].A = sparse.csr_array(np.ones((5, 5)))
+        levels[1].P = sparse.csr_array(np.ones((5, 3)))
         levels.append(MultilevelSolver.Level())
-        levels[2].A = sparse.csr_matrix(np.ones((3, 3)))
-        levels[2].P = sparse.csr_matrix(np.ones((3, 2)))
+        levels[2].A = sparse.csr_array(np.ones((3, 3)))
+        levels[2].P = sparse.csr_array(np.ones((3, 2)))
         levels.append(MultilevelSolver.Level())
-        levels[3].A = sparse.csr_matrix(np.ones((2, 2)))
+        levels[3].A = sparse.csr_array(np.ones((2, 2)))
 
         # one level hierarchy
         mg = MultilevelSolver(levels[:1])
@@ -138,7 +138,7 @@ class TestComplexMultilevel(TestCase):
     def test_coarse_grid_solver(self):
         cases = []
 
-        cases.append(sparse.csr_matrix(np.diag(np.arange(1, 5))))
+        cases.append(sparse.csr_array(np.diag(np.arange(1, 5))))
         cases.append(poisson((4,), format='csr'))
         cases.append(poisson((4, 4), format='csr'))
 

--- a/pyamg/tests/test_strength.py
+++ b/pyamg/tests/test_strength.py
@@ -161,22 +161,23 @@ class TestStrengthOfConnection(TestCase):
         B = sparse.csr_array(np.array([[1.3, 2.], [2.8, 4.]]))
         A2 = sparse.csr_array(np.array([[1.3, 0.], [0., 4.]]))
         B2 = sparse.csr_array(np.array([[1.3, 0.], [2., 4.]]))
-        mask = sparse.csr_array((np.ones(4), (np.array([0, 0, 1, 1]),
-                                              np.array([0, 1, 0, 1]))), shape=(2, 2))
+        mask = sparse.csr_array((np.ones(4), (np.array([0, 0, 1, 1], dtype=np.int32),
+                                              np.array([0, 1, 0, 1], dtype=np.int32))),
+                                shape=(2, 2))
         cases.append((A, A, mask))
         cases.append((A, B, mask))
         cases.append((A2, A2, mask))
         cases.append((A2, B2, mask))
 
-        mask = sparse.csr_array((np.ones(3), (np.array([0, 0, 1]),
-                                              np.array([0, 1, 1]))), shape=(2, 2))
+        mask = sparse.csr_array((np.ones(3), (np.array([0, 0, 1], dtype=np.int32),
+                                              np.array([0, 1, 1], dtype=np.int32))), shape=(2, 2))
         cases.append((A, A, mask))
         cases.append((A, B, mask))
         cases.append((A2, A2, mask))
         cases.append((A2, B2, mask))
 
-        mask = sparse.csr_array((np.ones(2), (np.array([0, 1]),
-                                              np.array([0, 0]))), shape=(2, 2))
+        mask = sparse.csr_array((np.ones(2), (np.array([0, 1], dtype=np.int32),
+                                              np.array([0, 0], dtype=np.int32))), shape=(2, 2))
         cases.append((A, A, mask))
         cases.append((A, B, mask))
         cases.append((A2, A2, mask))
@@ -513,7 +514,7 @@ class TestComplexStrengthOfConnection(TestCase):
 
         # check if every neighbor is a strong connection
         for i in range(1, A.shape[0]-1):
-            idx = S[i, :]
+            idx = S[[i], :]
             assert set(idx.indices) == {i-1, i+1}
 
 

--- a/pyamg/tests/test_strength.py
+++ b/pyamg/tests/test_strength.py
@@ -170,14 +170,16 @@ class TestStrengthOfConnection(TestCase):
         cases.append((A2, B2, mask))
 
         mask = sparse.csr_array((np.ones(3), (np.array([0, 0, 1], dtype=np.int32),
-                                              np.array([0, 1, 1], dtype=np.int32))), shape=(2, 2))
+                                              np.array([0, 1, 1], dtype=np.int32))),
+                                shape=(2, 2))
         cases.append((A, A, mask))
         cases.append((A, B, mask))
         cases.append((A2, A2, mask))
         cases.append((A2, B2, mask))
 
         mask = sparse.csr_array((np.ones(2), (np.array([0, 1], dtype=np.int32),
-                                              np.array([0, 0], dtype=np.int32))), shape=(2, 2))
+                                              np.array([0, 0], dtype=np.int32))),
+                                shape=(2, 2))
         cases.append((A, A, mask))
         cases.append((A, B, mask))
         cases.append((A2, A2, mask))

--- a/pyamg/tests/test_strength.py
+++ b/pyamg/tests/test_strength.py
@@ -294,8 +294,9 @@ class TestStrengthOfConnection(TestCase):
         # strength stencil
         for N in [3, 6, 7]:
             u = np.ones(N*N)
-            A = sparse.diags([-u, -0.001*u, 2.002*u, -0.001*u, -u],
-                             offsets=[-N, -1, 0, 1, N], shape=(N*N, N*N), format='csr')
+            A = sparse.diags_array([-u, -0.001*u, 2.002*u, -0.001*u, -u],
+                                   offsets=[-N, -1, 0, 1, N], shape=(N*N, N*N),
+                                   format='csr')
             B = np.ones((A.shape[0], 1))
             cases.append({'A': A.copy(), 'B': B.copy(), 'epsilon': 4.0,
                           'k': 2, 'proj': 'l2'})
@@ -354,10 +355,12 @@ class TestStrengthOfConnection(TestCase):
                                         k=2, proj_type='D_A',
                                         symmetrize_measure=False)
         # create scaled A
-        D = sparse.diags([np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
-                         offsets=[0], shape=(A.shape[0], A.shape[0]), format='csr')
-        Dinv = sparse.diags([1.0/np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
-                            offsets=[0], shape=(A.shape[0], A.shape[0]), format='csr')
+        D = sparse.diags_array([np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
+                               offsets=[0], shape=(A.shape[0], A.shape[0]),
+                               format='csr')
+        Dinv = sparse.diags_array([1/np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
+                                  offsets=[0], shape=(A.shape[0], A.shape[0]),
+                                  format='csr')
         np.random.seed(3969802542)  # make results deterministic
         result_scaled = evolution_soc((D@A@D).tobsr(blocksize=(2, 2)),
                                       Dinv@B, epsilon=4.0, k=2,
@@ -456,10 +459,12 @@ class TestComplexStrengthOfConnection(TestCase):
                                         proj_type='D_A',
                                         symmetrize_measure=False)
         # create scaled A
-        D = sparse.diags([np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
-                         offsets=[0], shape=(A.shape[0], A.shape[0]), format='csr')
-        Dinv = sparse.diags([1.0/np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
-                            offsets=[0], shape=(A.shape[0], A.shape[0]), format='csr')
+        D = sparse.diags_array([np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
+                               offsets=[0], shape=(A.shape[0], A.shape[0]),
+                               format='csr')
+        Dinv = sparse.diags_array([1/np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
+                                  offsets=[0], shape=(A.shape[0], A.shape[0]),
+                                  format='csr')
         np.random.seed(743434914)  # make results deterministic
         result_scaled = evolution_soc(D@A@D, Dinv@B, epsilon=4.0, k=2,
                                       proj_type='D_A',
@@ -487,10 +492,12 @@ class TestComplexStrengthOfConnection(TestCase):
                                         proj_type='D_A',
                                         symmetrize_measure=False)
         # create scaled A
-        D = sparse.diags([np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
-                         offsets=[0], shape=(A.shape[0], A.shape[0]), format='csr')
-        Dinv = sparse.diags([1.0/np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
-                            offsets=[0], shape=(A.shape[0], A.shape[0]), format='csr')
+        D = sparse.diags_array([np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
+                               offsets=[0], shape=(A.shape[0], A.shape[0]),
+                               format='csr')
+        Dinv = sparse.diags_array([1/np.arange(A.shape[0], 2*A.shape[0], dtype=float)],
+                                  offsets=[0], shape=(A.shape[0], A.shape[0]),
+                                  format='csr')
         np.random.seed(1944403548)  # make results deterministic
         result_scaled = evolution_soc((D@A@D).tobsr(blocksize=(2, 2)), Dinv@B,
                                       epsilon=4.0, k=2, proj_type='D_A',
@@ -551,7 +558,7 @@ def reference_classical_soc(A, theta, norm='abs'):
     S.data = S.data[mask]
 
     # Add back diagonal
-    D = sparse.eye(S.shape[0], S.shape[0], format='csr', dtype=A.dtype)
+    D = sparse.eye_array(S.shape[0], format='csr', dtype=A.dtype)
     D.data[:] = sparse.csr_matrix(A).diagonal()
     S = S.tocsr() + D
 
@@ -598,7 +605,7 @@ def reference_symmetric_soc(A, theta):
     S.data = S.data[mask]
 
     # Add back diagonal
-    D = sparse.eye(S.shape[0], S.shape[0], format='csr', dtype=A.dtype)
+    D = sparse.eye_array(S.shape[0], format='csr', dtype=A.dtype)
     D.data[:] = sparse.csr_matrix(A).diagonal()
     S = S.tocsr() + D
 
@@ -654,8 +661,8 @@ def reference_evolution_soc(A, B, epsilon=4.0, k=2, proj_type='l2'):
     rho_DinvA = approximate_spectral_radius(Dinv_A)
 
     # Calculate (Atilde^k) naively
-    S = (sparse.eye(dimen, dimen, format='csr') - (1.0/rho_DinvA)*Dinv_A)
-    Atilde = sparse.eye(dimen, dimen, format='csr')
+    S = (sparse.eye_array(dimen, format='csr') - (1.0/rho_DinvA)*Dinv_A)
+    Atilde = sparse.eye_array(dimen, format='csr')
     for _i in range(k):
         Atilde = S @ Atilde
 
@@ -776,7 +783,7 @@ def reference_evolution_soc(A, B, epsilon=4.0, k=2, proj_type='l2'):
     Atilde.data = np.array(np.real(Atilde.data), dtype=float)
 
     # Set diagonal to 1.0, as each point is strongly connected to itself.
-    Id = sparse.eye(dimen, dimen, format='csr')
+    Id = sparse.eye_array(dimen, format='csr')
     Id.data -= Atilde.diagonal()
     Atilde = Atilde + Id
 
@@ -860,7 +867,7 @@ def reference_distance_soc(A, V, theta=2.0, relative_drop=True):
         C.data[rowstart:rowend] = this_row
 
     C.eliminate_zeros()
-    C = C + 2.0*sparse.eye(C.shape[0], C.shape[1], format='csr')
+    C = C + 2.0*sparse.eye_array(C.shape[0], C.shape[1], format='csr')
 
     # Standardized strength values require small values be weak and large
     # values be strong.  So, we invert the distances.

--- a/pyamg/tests/test_strength.py
+++ b/pyamg/tests/test_strength.py
@@ -29,7 +29,7 @@ class TestStrengthOfConnection(TestCase):
         # random matrices
         np.random.seed(222352579)
         for N in [2, 3, 5]:
-            self.cases.append(sparse.csr_matrix(np.random.rand(N, N)))
+            self.cases.append(sparse.csr_array(np.random.rand(N, N)))
 
         # Poisson problems in 1D and 2D
         for N in [2, 3, 5, 7, 10, 11, 19]:
@@ -54,12 +54,12 @@ class TestStrengthOfConnection(TestCase):
         # Test BSR capabilities
         import warnings
         warnings.filterwarnings(action='ignore', message='Implicit conversion*')
-        CSRtest = sparse.csr_matrix(np.array([[4.0,  -1.0, -1.1,  1.0,  0.0, 0.0],
-                                              [-0.9, -1.1, -1.0,  0.0,  9.5, 0.0],
-                                              [-1.9,  4.1,  5.0, -4.0,  0.0, 0.0],
-                                              [0.0,  -0.1, -1.0,  0.0,  0.0, 5.0],
-                                              [0.0,   0.0,  1.0,  0.0, -9.5, 1.0],
-                                              [0.0,   0.0,  0.0, -1.0, -1.0, 1.0]]))
+        CSRtest = sparse.csr_array(np.array([[4.0,  -1.0, -1.1,  1.0,  0.0, 0.0],
+                                             [-0.9, -1.1, -1.0,  0.0,  9.5, 0.0],
+                                             [-1.9,  4.1,  5.0, -4.0,  0.0, 0.0],
+                                             [0.0,  -0.1, -1.0,  0.0,  0.0, 5.0],
+                                             [0.0,   0.0,  1.0,  0.0, -9.5, 1.0],
+                                             [0.0,   0.0,  0.0, -1.0, -1.0, 1.0]]))
         BSRtest = CSRtest.tobsr(blocksize=(2, 2))
 
         # Check that entry equals Frobenius norm of that block,
@@ -147,36 +147,36 @@ class TestStrengthOfConnection(TestCase):
         cases = []
 
         # 1x1 tests
-        A = sparse.csr_matrix(np.array([[1.1]]))
-        B = sparse.csr_matrix(np.array([[1.0]]))
-        A2 = sparse.csr_matrix(np.array([[0.]]))
-        mask = sparse.csr_matrix(np.array([[1.]]))
+        A = sparse.csr_array(np.array([[1.1]]))
+        B = sparse.csr_array(np.array([[1.0]]))
+        A2 = sparse.csr_array(np.array([[0.]]))
+        mask = sparse.csr_array(np.array([[1.]]))
         cases.append((A, A, mask))
         cases.append((A, B, mask))
         cases.append((A, A2, mask))
         cases.append((A2, A2, mask))
 
         # 2x2 tests
-        A = sparse.csr_matrix(np.array([[1., 2.], [2., 4.]]))
-        B = sparse.csr_matrix(np.array([[1.3, 2.], [2.8, 4.]]))
-        A2 = sparse.csr_matrix(np.array([[1.3, 0.], [0., 4.]]))
-        B2 = sparse.csr_matrix(np.array([[1.3, 0.], [2., 4.]]))
-        mask = sparse.csr_matrix((np.ones(4), (np.array([0, 0, 1, 1]),
-                                               np.array([0, 1, 0, 1]))), shape=(2, 2))
+        A = sparse.csr_array(np.array([[1., 2.], [2., 4.]]))
+        B = sparse.csr_array(np.array([[1.3, 2.], [2.8, 4.]]))
+        A2 = sparse.csr_array(np.array([[1.3, 0.], [0., 4.]]))
+        B2 = sparse.csr_array(np.array([[1.3, 0.], [2., 4.]]))
+        mask = sparse.csr_array((np.ones(4), (np.array([0, 0, 1, 1]),
+                                              np.array([0, 1, 0, 1]))), shape=(2, 2))
         cases.append((A, A, mask))
         cases.append((A, B, mask))
         cases.append((A2, A2, mask))
         cases.append((A2, B2, mask))
 
-        mask = sparse.csr_matrix((np.ones(3), (np.array([0, 0, 1]),
-                                               np.array([0, 1, 1]))), shape=(2, 2))
+        mask = sparse.csr_array((np.ones(3), (np.array([0, 0, 1]),
+                                              np.array([0, 1, 1]))), shape=(2, 2))
         cases.append((A, A, mask))
         cases.append((A, B, mask))
         cases.append((A2, A2, mask))
         cases.append((A2, B2, mask))
 
-        mask = sparse.csr_matrix((np.ones(2), (np.array([0, 1]),
-                                               np.array([0, 0]))), shape=(2, 2))
+        mask = sparse.csr_array((np.ones(2), (np.array([0, 1]),
+                                              np.array([0, 0]))), shape=(2, 2))
         cases.append((A, A, mask))
         cases.append((A, B, mask))
         cases.append((A2, A2, mask))
@@ -195,10 +195,10 @@ class TestStrengthOfConnection(TestCase):
         A2[1, :] = 0.0
         A3 = A2.copy()
         A3[:, 1] = 0.0
-        A = sparse.csr_matrix(A)
-        A2 = sparse.csr_matrix(A2)
-        A3 = sparse.csr_matrix(A3)
-        C = sparse.csr_matrix(C)
+        A = sparse.csr_array(A)
+        A2 = sparse.csr_array(A2)
+        A3 = sparse.csr_array(A3)
+        C = sparse.csr_array(C)
 
         mask = A.copy()
         mask.data[:] = 1.0
@@ -231,7 +231,7 @@ class TestStrengthOfConnection(TestCase):
         B.data[1] = 3.5
         B.data[11] = 11.6
         B.data[28] = -3.2
-        C = sparse.csr_matrix(np.zeros(A.shape))
+        C = sparse.csr_array(np.zeros(A.shape))
         mask = A.copy()
         mask.data[:] = 1.0
         cases.append((A, A, mask))
@@ -250,8 +250,8 @@ class TestStrengthOfConnection(TestCase):
         C = A.copy()
         C[1, 0] = 3.1j - 1.3
         C[3, 2] = -10.1j + 9.7
-        A = sparse.csr_matrix(A)
-        C = sparse.csr_matrix(C)
+        A = sparse.csr_array(A)
+        C = sparse.csr_array(C)
 
         mask = A.copy()
         mask.data[:] = 1.0
@@ -378,8 +378,8 @@ class TestComplexStrengthOfConnection(TestCase):
         # random matrices
         np.random.seed(954619597)
         for N in [2, 3, 5]:
-            self.cases.append(sparse.csr_matrix(np.random.rand(N, N))
-                              + sparse.csr_matrix(1.0j*np.random.rand(N, N)))
+            self.cases.append(sparse.csr_array(np.random.rand(N, N))
+                              + sparse.csr_array(1.0j*np.random.rand(N, N)))
 
         # Poisson problems in 1D and 2D
         for N in [2, 3, 5, 7, 10, 11, 19]:
@@ -529,7 +529,7 @@ def reference_classical_soc(A, theta, norm='abs'):
     A connection is strong if,
       | a_ij| >= theta * max_{k != i} |a_ik|
     """
-    S = sparse.coo_matrix(A)
+    S = sparse.coo_array(A)
 
     # remove diagonals
     mask = S.row != S.col
@@ -559,7 +559,7 @@ def reference_classical_soc(A, theta, norm='abs'):
 
     # Add back diagonal
     D = sparse.eye_array(S.shape[0], format='csr', dtype=A.dtype)
-    D.data[:] = sparse.csr_matrix(A).diagonal()
+    D.data[:] = sparse.csr_array(A).diagonal()
     S = S.tocsr() + D
 
     # Strength represents "distance", so take the magnitude
@@ -591,7 +591,7 @@ def reference_symmetric_soc(A, theta):
 
     D = np.abs(A.diagonal())
 
-    S = sparse.coo_matrix(A)
+    S = sparse.coo_array(A)
 
     mask = S.row != S.col
     DD = np.array(D[S.row] * D[S.col]).reshape(-1,)
@@ -606,7 +606,7 @@ def reference_symmetric_soc(A, theta):
 
     # Add back diagonal
     D = sparse.eye_array(S.shape[0], format='csr', dtype=A.dtype)
-    D.data[:] = sparse.csr_matrix(A).diagonal()
+    D.data[:] = sparse.csr_array(A).diagonal()
     S = S.tocsr() + D
 
     # Strength represents "distance", so take the magnitude
@@ -792,13 +792,13 @@ def reference_evolution_soc(A, B, epsilon=4.0, k=2, proj_type='l2'):
     if not csrflag:
         Atilde = Atilde.tobsr(blocksize=(numPDEs, numPDEs))
 
-        # Atilde = sparse.csr_matrix((data, row, col), shape=(*,*))
+        # Atilde = sparse.csr_array((data, row, col), shape=(*,*))
         At = []
         for i in range(Atilde.indices.shape[0]):
             Atmin = Atilde.data[i, :, :][Atilde.data[i, :, :].nonzero()]
             At.append(Atmin.min())
 
-        Atilde = sparse.csr_matrix((np.array(At), Atilde.indices, Atilde.indptr),
+        Atilde = sparse.csr_array((np.array(At), Atilde.indices, Atilde.indptr),
                                    shape=(int(Atilde.shape[0]/numPDEs),
                                           int(Atilde.shape[1]/numPDEs)))
 
@@ -826,8 +826,8 @@ def reference_distance_soc(A, V, theta=2.0, relative_drop=True):
     # deal with the supernode case
     if sparse.issparse(A) and A.format == 'bsr':
         dimen = int(A.shape[0]/A.blocksize[0])
-        C = sparse.csr_matrix((np.ones((A.data.shape[0],)), A.indices, A.indptr),
-                              shape=(dimen, dimen))
+        C = sparse.csr_array((np.ones((A.data.shape[0],)), A.indices, A.indptr),
+                             shape=(dimen, dimen))
     else:
         A = A.tocsr()
         dimen = A.shape[0]

--- a/pyamg/util/bsr_utils.py
+++ b/pyamg/util/bsr_utils.py
@@ -11,7 +11,7 @@ def bsr_getrow(A, i):
 
     Parameters
     ----------
-    A : bsr_matrix
+    A : bsr_array
         Input matrix
     i : int
         Row number
@@ -25,12 +25,12 @@ def bsr_getrow(A, i):
     Examples
     --------
     >>> from numpy import array
-    >>> from scipy.sparse import bsr_matrix
+    >>> from scipy.sparse import bsr_array
     >>> from pyamg.util.bsr_utils import bsr_getrow
     >>> indptr  = array([0,2,3,6])
     >>> indices = array([0,2,2,0,1,2])
     >>> data    = array([1,2,3,4,5,6]).repeat(4).reshape(6,2,2)
-    >>> B = bsr_matrix( (data,indices,indptr), shape=(6,6) )
+    >>> B = bsr_array( (data,indices,indptr), shape=(6,6) )
     >>> Brow = bsr_getrow(B,2)
     >>> print(Brow[1])
     [4 5]
@@ -64,7 +64,7 @@ def bsr_row_setscalar(A, i, x):
 
     Parameters
     ----------
-    A : bsr_matrix
+    A : bsr_array
         Input matrix
     i : int
         Row number
@@ -73,7 +73,7 @@ def bsr_row_setscalar(A, i, x):
 
     Returns
     -------
-    A : bsr_matrix
+    A : bsr_array
         All nonzeros in row i of A have been overwritten with x.
         If x is a vector, the first length(x) nonzeros in row i
         of A have been overwritten with entries from x
@@ -81,12 +81,12 @@ def bsr_row_setscalar(A, i, x):
     Examples
     --------
     >>> from numpy import array
-    >>> from scipy.sparse import bsr_matrix
+    >>> from scipy.sparse import bsr_array
     >>> from pyamg.util.bsr_utils import bsr_row_setscalar
     >>> indptr  = array([0,2,3,6])
     >>> indices = array([0,2,2,0,1,2])
     >>> data    = array([1,2,3,4,5,6]).repeat(4).reshape(6,2,2)
-    >>> B = bsr_matrix( (data,indices,indptr), shape=(6,6) )
+    >>> B = bsr_array( (data,indices,indptr), shape=(6,6) )
     >>> bsr_row_setscalar(B,5,22)
 
     """
@@ -112,7 +112,7 @@ def bsr_row_setvector(A, i, x):
 
     Parameters
     ----------
-    A : bsr_matrix
+    A : bsr_array
         Matrix assumed to be in BSR format
     i : int
         Row number
@@ -121,7 +121,7 @@ def bsr_row_setvector(A, i, x):
 
     Returns
     -------
-    A : bsr_matrix
+    A : bsr_array
         The nonzeros in row i of A have been
         overwritten with entries from x.  x must be same
         length as nonzeros of row i.  This is guaranteed
@@ -131,12 +131,12 @@ def bsr_row_setvector(A, i, x):
     Examples
     --------
     >>> from numpy import array
-    >>> from scipy.sparse import bsr_matrix
+    >>> from scipy.sparse import bsr_array
     >>> from pyamg.util.bsr_utils import bsr_row_setvector
     >>> indptr  = array([0,2,3,6])
     >>> indices = array([0,2,2,0,1,2])
     >>> data    = array([1,2,3,4,5,6]).repeat(4).reshape(6,2,2)
-    >>> B = bsr_matrix( (data,indices,indptr), shape=(6,6) )
+    >>> B = bsr_array( (data,indices,indptr), shape=(6,6) )
     >>> bsr_row_setvector(B,5,array([11,22,33,44,55,66]))
 
     """

--- a/pyamg/util/linalg.py
+++ b/pyamg/util/linalg.py
@@ -55,7 +55,7 @@ def infinity_norm(A):
 
     Parameters
     ----------
-    A : csr_matrix, csc_matrix, sparse, or numpy matrix
+    A : csr_array, csc_array, sparse, or numpy matrix
         Sparse or dense matrix
 
     Returns
@@ -129,7 +129,7 @@ def axpy(x, y, a=1.0):
 #    ----------
 #
 #    A : {dense or sparse matrix}
-#        E.g. csr_matrix, csc_matrix, ndarray, etc.
+#        E.g. csr_array, csc_array, ndarray, etc.
 #    tol : {scalar}
 #        Tolerance of approximation
 #    maxiter : {integer}
@@ -260,7 +260,7 @@ def approximate_spectral_radius(A, tol=0.01, maxiter=15, restart=5,
     Parameters
     ----------
     A : {dense or sparse matrix}
-        E.g. csr_matrix, csc_matrix, ndarray, etc.
+        E.g. csr_array, csc_array, ndarray, etc.
     tol : {scalar}
         Relative tolerance of approximation, i.e., the error divided
         by the approximate spectral radius is compared to tol.
@@ -387,7 +387,7 @@ def condest(A, maxiter=25, symmetric=False):
     Parameters
     ----------
     A   : {dense or sparse matrix}
-        e.g. array, matrix, csr_matrix, ...
+        e.g. array, matrix, csr_array, ...
     maxiter: {int}
         Max number of Arnoldi/Lanczos iterations
     symmetric : {bool}
@@ -439,7 +439,7 @@ def cond(A):
     Parameters
     ----------
     A   : {dense or sparse matrix}
-        e.g. array, matrix, csr_matrix, ...
+        e.g. array, matrix, csr_array, ...
 
     Returns
     -------
@@ -482,7 +482,7 @@ def ishermitian(A, fast_check=True, tol=1e-6, verbose=False):
     Parameters
     ----------
     A   : {dense or sparse matrix}
-        e.g. array, matrix, csr_matrix, ...
+        e.g. array, matrix, csr_array, ...
     fast_check : {bool}
         If True, use the heuristic < Ax, y> = < x, Ay>
         for random vectors x and y to check for conjugate symmetry.

--- a/pyamg/util/linalg.py
+++ b/pyamg/util/linalg.py
@@ -76,12 +76,12 @@ def infinity_norm(A):
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import diags
+    >>> from scipy.sparse import diags_array
     >>> from pyamg.util.linalg import infinity_norm
     >>> n=10
     >>> e = np.ones((n,1)).ravel()
     >>> data = [ -1*e, 2*e, -1*e ]
-    >>> A = diags(data, offsets=[-1, 0, 1], shape=(n,n))
+    >>> A = diags_array(data, offsets=[-1, 0, 1], shape=(n,n))
     >>> print(infinity_norm(A))
     4.0
 
@@ -354,11 +354,9 @@ def approximate_spectral_radius(A, tol=0.01, maxiter=15, restart=5,
             error = H[nvecs, nvecs-1] * evect[-1, max_index]
 
             # error is a fast way of calculating the following line
-            # error2 = ( A - ev[max_index]*sp.mat(
-            #           sp.eye(A.shape[0],A.shape[1])) )*\
-            #           ( sp.mat(sp.hstack(V[:-1]))*\
-            #           evect[:,max_index].reshape(-1,1) )
-            # print(str(error) + "    " + str(sp.linalg.norm(e2)))
+            # error2 = ( A - ev[max_index]*np.eye(A.shape[0],A.shape[1]) )* \
+            #          ( np.mat(np.hstack(V[:-1]))*evect[:,max_index].reshape(-1,1) )
+            # print(str(error) + "    " + str(np.linalg.norm(e2)))
 
             v0 = np.dot(np.hstack(V[:-1]), evect[:, max_index].reshape(-1, 1))
 

--- a/pyamg/util/tests/test_bsr_utils.py
+++ b/pyamg/util/tests/test_bsr_utils.py
@@ -1,6 +1,6 @@
 """Test BSR functions."""
 import numpy as np
-from scipy.sparse import bsr_matrix
+from scipy.sparse import bsr_array
 from pyamg.util.bsr_utils import bsr_getrow, bsr_row_setscalar, bsr_row_setvector
 
 from numpy.testing import TestCase, assert_equal
@@ -11,7 +11,7 @@ class TestBSRUtils(TestCase):
         indptr = np.array([0, 2, 3, 6])
         indices = np.array([0, 2, 2, 0, 1, 2])
         data = np.array([1, 2, 3, 4, 5, 6]).repeat(4).reshape(6, 2, 2)
-        B = bsr_matrix((data, indices, indptr), shape=(6, 6))
+        B = bsr_array((data, indices, indptr), shape=(6, 6))
         r, i = bsr_getrow(B, 2)
         assert_equal(r, np.array([[3], [3]]))
         assert_equal(i, np.array([4, 5]))
@@ -30,8 +30,8 @@ class TestBSRUtils(TestCase):
                           [[5, 5], [22, 22]],
                           [[6, 6], [22, 22]]])
 
-        B2 = bsr_matrix((data2, indices2, indptr2), shape=(6, 6))
-        B = bsr_matrix((data, indices, indptr), shape=(6, 6))
+        B2 = bsr_array((data2, indices2, indptr2), shape=(6, 6))
+        B = bsr_array((data, indices, indptr), shape=(6, 6))
         bsr_row_setscalar(B, 5, 22)
         diff = np.ravel((B - B2).data)
         assert_equal(diff.shape[0], 0)
@@ -50,8 +50,8 @@ class TestBSRUtils(TestCase):
                           [[5, 5], [33, 44]],
                           [[6, 6], [55, 66]]])
 
-        B2 = bsr_matrix((data2, indices2, indptr2), shape=(6, 6))
-        B = bsr_matrix((data, indices, indptr), shape=(6, 6))
+        B2 = bsr_array((data2, indices2, indptr2), shape=(6, 6))
+        B = bsr_array((data, indices, indptr), shape=(6, 6))
         bsr_row_setvector(B, 5, np.array([11, 22, 33, 44, 55, 66]))
         diff = np.ravel((B - B2).data)
         assert_equal(diff.shape[0], 0)

--- a/pyamg/util/tests/test_linalg.py
+++ b/pyamg/util/tests/test_linalg.py
@@ -1,7 +1,7 @@
 """Test internal linalg."""
 import numpy as np
 from scipy import linalg
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 from scipy.linalg import svd, pinv
 
 from numpy.testing import (TestCase, assert_almost_equal, assert_equal,
@@ -46,7 +46,7 @@ class TestLinalg(TestCase):
         # method should be almost exact for small matrices
         for A in cases:
             A = A.astype(float)
-            Asp = csr_matrix(A)
+            Asp = csr_array(A)
 
             [E, V] = linalg.eig(A)
             E = np.abs(E)
@@ -69,7 +69,7 @@ class TestLinalg(TestCase):
         for A in cases:
             A = A + A.transpose()
             A = A.astype(float)
-            Asp = csr_matrix(A)
+            Asp = csr_array(A)
 
             [E, V] = linalg.eig(A)
             E = np.abs(E)
@@ -124,16 +124,16 @@ class TestLinalg(TestCase):
 
     def test_infinity_norm(self):
         A = np.array([[-4]])
-        assert_equal(infinity_norm(csr_matrix(A)), 4)
+        assert_equal(infinity_norm(csr_array(A)), 4)
 
         A = np.array([[1, 0, -5], [-2, 5, 0]])
-        assert_equal(infinity_norm(csr_matrix(A)), 7)
+        assert_equal(infinity_norm(csr_array(A)), 7)
 
         A = np.array([[0, 1], [0, -5]])
-        assert_equal(infinity_norm(csr_matrix(A)), 5)
+        assert_equal(infinity_norm(csr_array(A)), 5)
 
         A = np.array([[1.3, -4.7, 0], [-2.23, 5.5, 0], [9, 0, -2]])
-        assert_equal(infinity_norm(csr_matrix(A)), 11)
+        assert_equal(infinity_norm(csr_array(A)), 11)
 
 
 class TestComplexLinalg(TestCase):
@@ -155,7 +155,7 @@ class TestComplexLinalg(TestCase):
 
         # method should be almost exact for small matrices
         for A in cases:
-            Asp = csr_matrix(A)
+            Asp = csr_array(A)
             [E, _V] = linalg.eig(A)
             E = np.abs(E)
             largest_eig = (E == E.max()).nonzero()[0]
@@ -178,7 +178,7 @@ class TestComplexLinalg(TestCase):
             assert_almost_equal(rayleigh, expected_eig, decimal=4)
 
             AA = A.conj().T.dot(A)
-            AAsp = csr_matrix(AA)
+            AAsp = csr_array(AA)
             [E, _V] = linalg.eig(AA)
             E = np.abs(E)
             largest_eig = (E == E.max()).nonzero()[0]
@@ -204,13 +204,13 @@ class TestComplexLinalg(TestCase):
 
     def test_infinity_norm(self):
         A = np.array([[-4-3.0j]])
-        assert_equal(infinity_norm(csr_matrix(A)), 5.0)
+        assert_equal(infinity_norm(csr_array(A)), 5.0)
 
         A = np.array([[1, 0, 4.0-3.0j], [-2, 5, 0]])
-        assert_equal(infinity_norm(csr_matrix(A)), 7)
+        assert_equal(infinity_norm(csr_array(A)), 7)
 
         A = np.array([[0, 1], [0, -4.0+3.0j]])
-        assert_equal(infinity_norm(csr_matrix(A)), 5.0)
+        assert_equal(infinity_norm(csr_array(A)), 5.0)
 
     def test_cond(self):
         # make tests repeatable
@@ -311,7 +311,7 @@ class TestComplexLinalg(TestCase):
             assert_equal(ishermitian(A, fast_check=True), True)
 
             # csr arrays
-            A = csr_matrix(A)
+            A = csr_array(A)
             assert_equal(ishermitian(A, fast_check=False), True)
             assert_equal(ishermitian(A, fast_check=True), True)
 
@@ -321,7 +321,7 @@ class TestComplexLinalg(TestCase):
             assert_equal(ishermitian(A, fast_check=True), False)
 
             # csr arrays
-            A = csr_matrix(A)
+            A = csr_array(A)
             assert_equal(ishermitian(A, fast_check=False), False)
             assert_equal(ishermitian(A, fast_check=True), False)
 

--- a/pyamg/util/tests/test_utils.py
+++ b/pyamg/util/tests/test_utils.py
@@ -1,6 +1,6 @@
 """Test utils."""
 import numpy as np
-from scipy.sparse import bsr_matrix, csr_matrix, csc_matrix, issparse, diags_array
+from scipy.sparse import bsr_array, csr_array, csc_array, issparse, diags_array
 
 from numpy.testing import (TestCase, assert_equal, assert_almost_equal,
                            assert_array_almost_equal, assert_array_equal)
@@ -21,33 +21,33 @@ class TestUtils(TestCase):
     def test_diag_sparse(self):
         # check sparse -> array
         A = np.array([[-4]])
-        assert_equal(diag_sparse(csr_matrix(A)), [-4])
+        assert_equal(diag_sparse(csr_array(A)), [-4])
 
         A = np.array([[1, 0, -5], [-2, 5, 0]])
-        assert_equal(diag_sparse(csr_matrix(A)), [1, 5])
+        assert_equal(diag_sparse(csr_array(A)), [1, 5])
 
         A = np.array([[0, 1], [0, -5]])
-        assert_equal(diag_sparse(csr_matrix(A)), [0, -5])
+        assert_equal(diag_sparse(csr_array(A)), [0, -5])
 
         A = np.array([[1.3, -4.7, 0], [-2.23, 5.5, 0], [9, 0, -2]])
-        assert_equal(diag_sparse(csr_matrix(A)), [1.3, 5.5, -2])
+        assert_equal(diag_sparse(csr_array(A)), [1.3, 5.5, -2])
 
         # check array -> sparse
         A = np.array([[-4]])
         assert_equal(diag_sparse(np.array([-4])).toarray(),
-                     csr_matrix(A).toarray())
+                     csr_array(A).toarray())
 
         A = np.array([[1, 0], [0, 5]])
         assert_equal(diag_sparse(np.array([1, 5])).toarray(),
-                     csr_matrix(A).toarray())
+                     csr_array(A).toarray())
 
         A = np.array([[0, 0], [0, -5]])
         assert_equal(diag_sparse(np.array([0, -5])).toarray(),
-                     csr_matrix(A).toarray())
+                     csr_array(A).toarray())
 
         A = np.array([[1.3, 0, 0], [0, 5.5, 0], [0, 0, -2]])
         assert_equal(diag_sparse(np.array([1.3, 5.5, -2])).toarray(),
-                     csr_matrix(A).toarray())
+                     csr_array(A).toarray())
 
     def test_scale_rows(self):
         Aorig = np.array([[0.0, 1, 0], [2, 0, 3], [4, 5, 6]])
@@ -55,12 +55,12 @@ class TestUtils(TestCase):
         Ascaled = np.array([[0.0, 7, 0], [16, 0, 24], [36, 45, 54]])
 
         # test CSR
-        A = csr_matrix(Aorig)
+        A = csr_array(Aorig)
         A = scale_rows(A, v)
         assert_equal(A.toarray(), Ascaled)
 
         # test CSC
-        A = csc_matrix(Aorig)
+        A = csc_array(Aorig)
         A = scale_rows(A, v)
         assert_equal(A.toarray(), Ascaled)
 
@@ -70,12 +70,12 @@ class TestUtils(TestCase):
         Ascaled = np.array([[0.0, 7, 0], [16, 0, 24], [36, 45, 54]]).T
 
         # test CSR
-        A = csr_matrix(Aorig)
+        A = csr_array(Aorig)
         A = scale_columns(A, v)
         assert_equal(A.toarray(), Ascaled)
 
         # test CSC
-        A = csc_matrix(Aorig)
+        A = csc_array(Aorig)
         A = scale_columns(A, v)
         assert_equal(A.toarray(), Ascaled)
 
@@ -89,7 +89,7 @@ class TestUtils(TestCase):
                       [6.5, 2.6, 5.7]])
 
         # test csr
-        A = csr_matrix(A)
+        A = csr_array(A)
         cases.append(A)
         P = diag_sparse([1, 0, 1])
         cases.append(P@A@P)
@@ -99,7 +99,7 @@ class TestUtils(TestCase):
         cases.append(P@A@P)
 
         # test csc
-        A = csc_matrix(A)
+        A = csc_array(A)
         cases.append(A)
 
         for A in cases:
@@ -174,7 +174,7 @@ class TestUtils(TestCase):
         del residuals
 
     def test_get_block_diag(self):
-        A = csr_matrix(np.arange(1, 37, dtype=float).reshape(6, 6))
+        A = csr_array(np.arange(1, 37, dtype=float).reshape(6, 6))
         block_diag = get_block_diag(A, blocksize=1, inv_flag=False)
         assert_array_almost_equal(np.ravel(block_diag), A.diagonal())
 
@@ -198,7 +198,7 @@ class TestUtils(TestCase):
                                   decimal=3)
 
         # try singular (1,1) block, a zero (2,2) block and a zero (0,2) block
-        A = bsr_matrix(np.array([1., 2., 3., 4., 0., 0.,
+        A = bsr_array(np.array([1., 2., 3., 4., 0., 0.,
                                  5., 6., 7., 8., 0., 0.,
                                  9., 10., 11., 11., 12., 13.,
                                  14., 15., 16., 16., 18., 19.,
@@ -216,7 +216,7 @@ class TestUtils(TestCase):
                                   decimal=3)
 
         # try with different types of zero blocks
-        A = bsr_matrix(np.array([0., 0., 3., 4., 0., 0.,
+        A = bsr_array(np.array([0., 0., 3., 4., 0., 0.,
                                  0., 0., 7., 8., 0., 0.,
                                  0., 0., 0., 0., 0., 0.,
                                  0., 0., 0., 0., 0., 0.,
@@ -291,73 +291,73 @@ class TestUtils(TestCase):
     def test_filter_operator(self):
         # Basic tests of dimension 1 and 2 problems
         # 1x1
-        A = csr_matrix(np.array([[1.2]]))
-        C = csr_matrix(np.array([[1.]]))
+        A = csr_array(np.array([[1.2]]))
+        C = csr_array(np.array([[1.]]))
         B = np.array([[0.5]])
         Bf = np.array([[1.5]])
         A_filter = filter_operator(A, C, B, Bf).toarray()
         A_known = np.array([[3.0]])
         assert_array_almost_equal(A_known, A_filter)
         # 1x1, but with no entries in C
-        C = csr_matrix(np.array([[0.]]))
+        C = csr_array(np.array([[0.]]))
         A_filter = filter_operator(A, C, B, Bf).toarray()
         A_known = np.array([[0.0]])
         assert_array_almost_equal(A_known, A_filter)
         # 1x1, but with no entries in A
-        A = csr_matrix(np.array([[0.]]))
-        C = csr_matrix(np.array([[1.]]))
+        A = csr_array(np.array([[0.]]))
+        C = csr_array(np.array([[1.]]))
         A_filter = filter_operator(A, C, B, Bf).toarray()
         A_known = np.array([[3.0]])
         assert_array_almost_equal(A_known, A_filter)
 
         # 1x2
-        A = csr_matrix(np.array([[1.2, 1.]]))
-        C = csr_matrix(np.array([[1., 1.]]))
+        A = csr_array(np.array([[1.2, 1.]]))
+        C = csr_array(np.array([[1., 1.]]))
         B = np.array([[0.5], [0.5]])
         Bf = np.array([[1.5]])
         A_filter = filter_operator(A, C, B, Bf).toarray()
         A_known = np.array([[1.6, 1.4]])
         assert_array_almost_equal(A_known, A_filter)
         # 1x2, but sparser
-        C = csr_matrix(np.array([[0., 1.]]))
+        C = csr_array(np.array([[0., 1.]]))
         A_filter = filter_operator(A, C, B, Bf).toarray()
         A_known = np.array([[0., 3.]])
         assert_array_almost_equal(A_known, A_filter)
         # 1x2, but with no entries
-        C = csr_matrix(np.array([[0., 0.]]))
+        C = csr_array(np.array([[0., 0.]]))
         A_filter = filter_operator(A, C, B, Bf).toarray()
         A_known = np.array([[0., 0.]])
         assert_array_almost_equal(A_known, A_filter)
 
         # 2x1
-        A = csr_matrix(np.array([[1.2], [1.]]))
-        C = csr_matrix(np.array([[1.], [1.]]))
+        A = csr_array(np.array([[1.2], [1.]]))
+        C = csr_array(np.array([[1.], [1.]]))
         B = np.array([[0.5]])
         Bf = np.array([[1.5], [0.4]])
         A_filter = filter_operator(A, C, B, Bf).toarray()
         A_known = np.array([[3.], [0.8]])
         assert_array_almost_equal(A_known, A_filter)
         # 2x1, but sparser
-        C = csr_matrix(np.array([[0.], [1.]]))
+        C = csr_array(np.array([[0.], [1.]]))
         A_filter = filter_operator(A, C, B, Bf).toarray()
         A_known = np.array([[0.], [.8]])
         assert_array_almost_equal(A_known, A_filter)
         # 2x1, but with no entries
-        C = csr_matrix(np.array([[0.], [0.]]))
+        C = csr_array(np.array([[0.], [0.]]))
         A_filter = filter_operator(A, C, B, Bf).toarray()
         A_known = np.array([[0.], [0.]])
         assert_array_almost_equal(A_known, A_filter)
 
         # 2x2
-        A = csr_matrix(np.array([[1.2, 1.1], [1., 0.5]]))
-        C = csr_matrix(np.array([[1.2, 1.1], [1., 0.]]))
+        A = csr_array(np.array([[1.2, 1.1], [1., 0.5]]))
+        C = csr_array(np.array([[1.2, 1.1], [1., 0.]]))
         B = np.array([[0.5, 1.0], [0.5, 1.1]])
         Bf = np.array([[0.5, 1.0], [0.5, 1.1]])
         A_filter = filter_operator(A, C, B, Bf).toarray()
         A_known = np.array([[1., 0.], [1.08, 0.]])
         assert_array_almost_equal(A_known, A_filter)
         # 1x2, but sparser
-        C = csr_matrix(np.array([[0., 0.], [1., 0.]]))
+        C = csr_array(np.array([[0., 0.], [1., 0.]]))
         A_filter = filter_operator(A, C, B, Bf).toarray()
         A_known = np.array([[0., 0.], [1.08, 0.]])
         assert_array_almost_equal(A_known, A_filter)
@@ -384,7 +384,7 @@ class TestUtils(TestCase):
                       [0, 0, 1]])
         B = np.ones((3, 1))
         Bf = np.ones((6, 1))
-        A_filter = filter_operator(csr_matrix(A), csr_matrix(C), B, Bf)
+        A_filter = filter_operator(csr_array(A), csr_array(C), B, Bf)
         A_filter = A_filter.toarray()
         A_known = np.array([[0.5, 0.5, 0.],
                             [0.5, 0.5, 0.],
@@ -396,7 +396,7 @@ class TestUtils(TestCase):
         # test two, the constant and linears
         B = np.hstack((B, np.arange(B.shape[0]).reshape(-1, 1)))
         Bf = np.hstack((Bf, np.arange(Bf.shape[0]).reshape(-1, 1)))
-        A_filter = filter_operator(csr_matrix(A), csr_matrix(C), B, Bf)
+        A_filter = filter_operator(csr_array(A), csr_array(C), B, Bf)
         A_filter = A_filter.toarray()
         A_known = np.array([[1., 0., 0.],
                             [0., 1., 0.],
@@ -424,14 +424,14 @@ class TestUtils(TestCase):
         assert_array_almost_equal(A_filter@B, Bf)
 
     def test_scale_T(self):
-        from scipy.sparse import bsr_matrix
+        from scipy.sparse import bsr_array
 
         # Trivially sized tests
         # 1x1
         T = np.array([[1.1]])
         P_I = np.array([[1.0]])
         I_F = np.array([[0.0]])
-        T_scaled = scale_T(bsr_matrix(T), bsr_matrix(P_I), bsr_matrix(I_F))
+        T_scaled = scale_T(bsr_array(T), bsr_array(P_I), bsr_array(I_F))
         T_scaled = T_scaled.toarray()
         T_answer = np.array([[1.0]])
         assert_array_almost_equal(T_answer, T_scaled)
@@ -439,7 +439,7 @@ class TestUtils(TestCase):
         T = np.array([[1.1]])
         P_I = np.array([[0.0]])
         I_F = np.array([[1.0]])
-        T_scaled = scale_T(bsr_matrix(T), bsr_matrix(P_I), bsr_matrix(I_F))
+        T_scaled = scale_T(bsr_array(T), bsr_array(P_I), bsr_array(I_F))
         T_scaled = T_scaled.toarray()
         T_answer = np.array([[1.1]])
         assert_array_almost_equal(T_answer, T_scaled)
@@ -447,7 +447,7 @@ class TestUtils(TestCase):
         T = np.array([[0.0]])
         P_I = np.array([[0.0]])
         I_F = np.array([[1.0]])
-        T_scaled = scale_T(bsr_matrix(T), bsr_matrix(P_I), bsr_matrix(I_F))
+        T_scaled = scale_T(bsr_array(T), bsr_array(P_I), bsr_array(I_F))
         T_scaled = T_scaled.toarray()
         T_answer = np.array([[0.]])
         assert_array_almost_equal(T_answer, T_scaled)
@@ -456,7 +456,7 @@ class TestUtils(TestCase):
         T = np.array([[1.5], [1.2]])
         P_I = np.array([[1.], [0.]])
         I_F = np.array([[0., 0.], [0., 1.]])
-        T_scaled = scale_T(bsr_matrix(T), bsr_matrix(P_I), bsr_matrix(I_F))
+        T_scaled = scale_T(bsr_array(T), bsr_array(P_I), bsr_array(I_F))
         T_scaled = T_scaled.toarray()
         T_answer = np.array([[1.], [0.8]])
         assert_array_almost_equal(T_answer, T_scaled)
@@ -464,7 +464,7 @@ class TestUtils(TestCase):
         T = np.array([[0.], [1.2]])
         P_I = np.array([[1.], [0.]])
         I_F = np.array([[0., 0.], [0., 1.]])
-        T_scaled = scale_T(bsr_matrix(T), bsr_matrix(P_I), bsr_matrix(I_F))
+        T_scaled = scale_T(bsr_array(T), bsr_array(P_I), bsr_array(I_F))
         T_scaled = T_scaled.toarray()
         T_answer = np.array([[1.], [0.]])
         assert_array_almost_equal(T_answer, T_scaled)
@@ -472,7 +472,7 @@ class TestUtils(TestCase):
         T = np.array([[0.], [0.]])
         P_I = np.array([[1.], [0.]])
         I_F = np.array([[0., 0.], [0., 1.]])
-        T_scaled = scale_T(bsr_matrix(T), bsr_matrix(P_I), bsr_matrix(I_F))
+        T_scaled = scale_T(bsr_array(T), bsr_array(P_I), bsr_array(I_F))
         T_scaled = T_scaled.toarray()
         T_answer = np.array([[1.], [0.]])
         assert_array_almost_equal(T_answer, T_scaled)
@@ -480,7 +480,7 @@ class TestUtils(TestCase):
         T = np.array([[0.], [0.]])
         P_I = np.array([[0.], [0.]])
         I_F = np.array([[1., 0.], [0., 1.]])
-        T_scaled = scale_T(bsr_matrix(T), bsr_matrix(P_I), bsr_matrix(I_F))
+        T_scaled = scale_T(bsr_array(T), bsr_array(P_I), bsr_array(I_F))
         T_scaled = T_scaled.toarray()
         T_answer = np.array([[0.], [0.]])
         assert_array_almost_equal(T_answer, T_scaled)
@@ -489,27 +489,27 @@ class TestUtils(TestCase):
         T = np.array([[2., 0.], [1., 1.]])
         P_I = np.array([[1., 0.], [0., 1.]])
         I_F = np.array([[0., 0.], [0., 0.]])
-        T_scaled = scale_T(bsr_matrix(T, blocksize=(1, 1)),
-                           bsr_matrix(P_I, blocksize=(1, 1)),
-                           bsr_matrix(I_F, blocksize=(1, 1))).toarray()
+        T_scaled = scale_T(bsr_array(T, blocksize=(1, 1)),
+                           bsr_array(P_I, blocksize=(1, 1)),
+                           bsr_array(I_F, blocksize=(1, 1))).toarray()
         T_answer = np.array([[1., 0.], [0., 1.]])
         assert_array_almost_equal(T_answer, T_scaled)
 
         T = np.array([[2., 0.], [1., 1.]])
         P_I = np.array([[1., 0.], [0., 1.]])
         I_F = np.array([[0., 0.], [0., 0.]])
-        T_scaled = scale_T(bsr_matrix(T, blocksize=(2, 2)),
-                           bsr_matrix(P_I, blocksize=(2, 2)),
-                           bsr_matrix(I_F, blocksize=(2, 2))).toarray()
+        T_scaled = scale_T(bsr_array(T, blocksize=(2, 2)),
+                           bsr_array(P_I, blocksize=(2, 2)),
+                           bsr_array(I_F, blocksize=(2, 2))).toarray()
         T_answer = np.array([[1., 0.], [0., 1.]])
         assert_array_almost_equal(T_answer, T_scaled)
 
         T = np.array([[2., 0.], [1., 1.]])
         P_I = np.array([[0., 0.], [0., 0.]])
         I_F = np.array([[1., 0.], [0., 1.]])
-        T_scaled = scale_T(bsr_matrix(T, blocksize=(2, 2)),
-                           bsr_matrix(P_I, blocksize=(2, 2)),
-                           bsr_matrix(I_F, blocksize=(2, 2))).toarray()
+        T_scaled = scale_T(bsr_array(T, blocksize=(2, 2)),
+                           bsr_array(P_I, blocksize=(2, 2)),
+                           bsr_array(I_F, blocksize=(2, 2))).toarray()
         T_answer = np.array([[2., 0.], [1., 1.]])
         assert_array_almost_equal(T_answer, T_scaled)
 
@@ -538,7 +538,7 @@ class TestUtils(TestCase):
                              [0., 0.5, 0.],
                              [0., 0., 4.],
                              [0., 0., 1.]])
-        T_scaled = scale_T(bsr_matrix(T), bsr_matrix(P_I), bsr_matrix(I_F))
+        T_scaled = scale_T(bsr_array(T), bsr_array(P_I), bsr_array(I_F))
         T_scaled = T_scaled.toarray()
         assert_array_almost_equal(T_answer, T_scaled)
 
@@ -575,9 +575,9 @@ class TestUtils(TestCase):
                              [0., 0., 0., 1.],
                              [0., 0., -1., 2.],
                              [0., 0., -2., 2.]])
-        T = bsr_matrix(T, blocksize=(2, 2))
-        P_I = bsr_matrix(P_I, blocksize=(2, 2))
-        I_F = bsr_matrix(I_F, blocksize=(2, 2))
+        T = bsr_array(T, blocksize=(2, 2))
+        P_I = bsr_array(P_I, blocksize=(2, 2))
+        I_F = bsr_array(I_F, blocksize=(2, 2))
         T_scaled = scale_T(T, P_I, I_F).toarray()
         assert_array_almost_equal(T_answer, T_scaled)
 
@@ -615,26 +615,26 @@ class TestUtils(TestCase):
                              [0., 0., -1., 2.],
                              [0., 0., -2., 2.]])
         # Cpts = np.array([1, 2])
-        T = bsr_matrix(T, blocksize=(2, 2))
-        P_I = bsr_matrix(P_I, blocksize=(2, 2))
-        I_F = bsr_matrix(I_F, blocksize=(2, 2))
+        T = bsr_array(T, blocksize=(2, 2))
+        P_I = bsr_array(P_I, blocksize=(2, 2))
+        I_F = bsr_array(I_F, blocksize=(2, 2))
         T_scaled = scale_T(T, P_I, I_F).toarray()
         assert_array_almost_equal(T_answer, T_scaled)
 
     def test_get_Cpt_params(self):
         from pyamg.gallery import poisson
-        from scipy.sparse import csr_matrix, bsr_matrix
+        from scipy.sparse import csr_array, bsr_array
 
         # Begin with trivially sized tests
         # 1x1
-        A = csr_matrix(np.array([[1.2]]))
+        A = csr_array(np.array([[1.2]]))
         Cpts = np.array([0])
-        AggOp = csr_matrix(np.array([[1.]]))
+        AggOp = csr_array(np.array([[1.]]))
         T = AggOp.copy().tobsr()
         params = get_Cpt_params(A, Cpts, AggOp, T)
-        I_C = bsr_matrix(np.array([[1.]]), blocksize=(1, 1))
-        I_F = bsr_matrix(np.array([[0.]]), blocksize=(1, 1))
-        P_I = bsr_matrix(np.array([[1.]]), blocksize=(1, 1))
+        I_C = bsr_array(np.array([[1.]]), blocksize=(1, 1))
+        I_F = bsr_array(np.array([[0.]]), blocksize=(1, 1))
+        P_I = bsr_array(np.array([[1.]]), blocksize=(1, 1))
         assert_equal(np.array([0]), params['Cpts'])
         assert_equal(np.array([]), params['Fpts'])
         assert_equal(I_C.indptr, params['I_C'].indptr)
@@ -647,14 +647,14 @@ class TestUtils(TestCase):
         assert_equal(P_I.indices, params['P_I'].indices)
         assert_equal(P_I.data, params['P_I'].data)
 
-        A = csr_matrix(np.array([[1.2]]))
+        A = csr_array(np.array([[1.2]]))
         Cpts = np.array([])
-        AggOp = csr_matrix(np.array([[1.]]))
+        AggOp = csr_array(np.array([[1.]]))
         T = AggOp.copy().tobsr()
         params = get_Cpt_params(A, Cpts, AggOp, T)
-        I_C = bsr_matrix(np.array([[0.]]), blocksize=(1, 1))
-        I_F = bsr_matrix(np.array([[1.]]), blocksize=(1, 1))
-        P_I = bsr_matrix(np.array([[0.]]), blocksize=(1, 1))
+        I_C = bsr_array(np.array([[0.]]), blocksize=(1, 1))
+        I_F = bsr_array(np.array([[1.]]), blocksize=(1, 1))
+        P_I = bsr_array(np.array([[0.]]), blocksize=(1, 1))
         assert_equal(np.array([]), params['Cpts'])
         assert_equal(np.array([0]), params['Fpts'])
         assert_equal(I_C.indptr, params['I_C'].indptr)
@@ -668,14 +668,14 @@ class TestUtils(TestCase):
         assert_equal(P_I.data, params['P_I'].data)
 
         # 2x2
-        A = csr_matrix(np.array([[1., 1.], [1., 1.]]))
+        A = csr_array(np.array([[1., 1.], [1., 1.]]))
         Cpts = np.array([0])
-        AggOp = csr_matrix(np.array([[1.], [1.]]))
+        AggOp = csr_array(np.array([[1.], [1.]]))
         T = AggOp.copy().tobsr()
         params = get_Cpt_params(A, Cpts, AggOp, T)
-        I_C = bsr_matrix(np.array([[1., 0.], [0., 0.]]), blocksize=(1, 1))
-        I_F = bsr_matrix(np.array([[0., 0.], [0., 1.]]), blocksize=(1, 1))
-        P_I = bsr_matrix(np.array([[1.], [0.]]), blocksize=(1, 1))
+        I_C = bsr_array(np.array([[1., 0.], [0., 0.]]), blocksize=(1, 1))
+        I_F = bsr_array(np.array([[0., 0.], [0., 1.]]), blocksize=(1, 1))
+        P_I = bsr_array(np.array([[1.], [0.]]), blocksize=(1, 1))
         assert_equal(np.array([0]), params['Cpts'])
         assert_equal(np.array([1]), params['Fpts'])
         assert_equal(I_C.indptr, params['I_C'].indptr)
@@ -689,12 +689,12 @@ class TestUtils(TestCase):
         assert_equal(P_I.data, params['P_I'].data)
 
         Cpts = np.array([0, 1])
-        AggOp = csr_matrix(np.array([[1., 0], [0., 1.]]))
+        AggOp = csr_array(np.array([[1., 0], [0., 1.]]))
         T = AggOp.copy().tobsr()
         params = get_Cpt_params(A, Cpts, AggOp, T)
-        I_C = bsr_matrix(np.array([[1., 0.], [0., 1.]]), blocksize=(1, 1))
-        I_F = bsr_matrix(np.array([[0., 0.], [0., 0.]]), blocksize=(1, 1))
-        P_I = bsr_matrix(np.array([[1., 0.], [0., 1.]]), blocksize=(1, 1))
+        I_C = bsr_array(np.array([[1., 0.], [0., 1.]]), blocksize=(1, 1))
+        I_F = bsr_array(np.array([[0., 0.], [0., 0.]]), blocksize=(1, 1))
+        P_I = bsr_array(np.array([[1., 0.], [0., 1.]]), blocksize=(1, 1))
         assert_equal(np.array([0, 1]), params['Cpts'])
         assert_equal(np.array([]), params['Fpts'])
         assert_equal(I_C.indptr, params['I_C'].indptr)
@@ -708,12 +708,12 @@ class TestUtils(TestCase):
         assert_equal(P_I.data, params['P_I'].data)
 
         Cpts = np.array([])
-        AggOp = csr_matrix(np.array([[0.], [0.]]))
+        AggOp = csr_array(np.array([[0.], [0.]]))
         T = AggOp.copy().tobsr()
         params = get_Cpt_params(A, Cpts, AggOp, T)
-        I_C = bsr_matrix(np.array([[0., 0.], [0., 0.]]), blocksize=(1, 1))
-        I_F = bsr_matrix(np.array([[1., 0.], [0., 1.]]), blocksize=(1, 1))
-        P_I = bsr_matrix(np.array([[0.], [0.]]), blocksize=(1, 1))
+        I_C = bsr_array(np.array([[0., 0.], [0., 0.]]), blocksize=(1, 1))
+        I_F = bsr_array(np.array([[1., 0.], [0., 1.]]), blocksize=(1, 1))
+        P_I = bsr_array(np.array([[0.], [0.]]), blocksize=(1, 1))
         assert_equal(np.array([]), params['Cpts'])
         assert_equal(np.array([0, 1]), params['Fpts'])
         assert_equal(I_C.indptr, params['I_C'].indptr)
@@ -728,12 +728,12 @@ class TestUtils(TestCase):
 
         A = A.tobsr(blocksize=(2, 2))
         Cpts = np.array([0])
-        AggOp = csr_matrix(np.array([[1.]]))
-        T = bsr_matrix(np.array([[1., 1.], [1., 2.]]), blocksize=(2, 2))
+        AggOp = csr_array(np.array([[1.]]))
+        T = bsr_array(np.array([[1., 1.], [1., 2.]]), blocksize=(2, 2))
         params = get_Cpt_params(A, Cpts, AggOp, T)
-        I_C = bsr_matrix(np.array([[1., 0.], [0., 1.]]), blocksize=(2, 2))
-        I_F = bsr_matrix(np.array([[0., 0.], [0., 0.]]), blocksize=(2, 2))
-        P_I = bsr_matrix(np.array([[1., 0.], [0., 1.]]), blocksize=(2, 2))
+        I_C = bsr_array(np.array([[1., 0.], [0., 1.]]), blocksize=(2, 2))
+        I_F = bsr_array(np.array([[0., 0.], [0., 0.]]), blocksize=(2, 2))
+        P_I = bsr_array(np.array([[1., 0.], [0., 1.]]), blocksize=(2, 2))
         assert_equal(np.array([0, 1]), params['Cpts'])
         assert_equal(np.array([]), params['Fpts'])
         assert_equal(I_C.indptr, params['I_C'].indptr)
@@ -747,12 +747,12 @@ class TestUtils(TestCase):
         assert_equal(P_I.data, params['P_I'].data)
 
         Cpts = np.array([])
-        AggOp = csr_matrix(np.array([[1.]]))
-        T = bsr_matrix(np.array([[1., 1.], [1., 2.]]), blocksize=(2, 2))
+        AggOp = csr_array(np.array([[1.]]))
+        T = bsr_array(np.array([[1., 1.], [1., 2.]]), blocksize=(2, 2))
         params = get_Cpt_params(A, Cpts, AggOp, T)
-        I_C = bsr_matrix(np.array([[0., 0.], [0., 0.]]), blocksize=(2, 2))
-        I_F = bsr_matrix(np.array([[1., 0.], [0., 1.]]), blocksize=(2, 2))
-        P_I = bsr_matrix(np.array([[0., 0.], [0., 0.]]), blocksize=(2, 2))
+        I_C = bsr_array(np.array([[0., 0.], [0., 0.]]), blocksize=(2, 2))
+        I_F = bsr_array(np.array([[1., 0.], [0., 1.]]), blocksize=(2, 2))
+        P_I = bsr_array(np.array([[0., 0.], [0., 0.]]), blocksize=(2, 2))
         assert_equal(np.array([]), params['Cpts'])
         assert_equal(np.array([0, 1]), params['Fpts'])
         assert_equal(I_C.indptr, params['I_C'].indptr)
@@ -778,16 +778,16 @@ class TestUtils(TestCase):
                   [0., 1.],
                   [0., 1.],
                   [0., 1.]])
-        AggOp = csr_matrix(AggOp)
+        AggOp = csr_array(AggOp)
         T = AggOp.copy().tobsr()
 
         # CSR Test
         params = get_Cpt_params(A, Cpts, AggOp, T)
-        I_C = bsr_matrix((np.array([[[1.]], [[1.]]]),
+        I_C = bsr_array((np.array([[[1.]], [[1.]]]),
                           np.array([3, 7]),
                           np.array([0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2])),
                          shape=(10, 10))
-        I_F = bsr_matrix((np.array([[[1.]], [[1.]], [[1.]], [[1.]],
+        I_F = bsr_array((np.array([[[1.]], [[1.]], [[1.]], [[1.]],
                                     [[1.]], [[1.]], [[1.]], [[1.]]]),
                           np.array([0, 1, 2, 4, 5, 6, 8, 9]),
                           np.array([0, 1, 2, 3, 3, 4, 5, 6, 6, 7, 8])),
@@ -802,7 +802,7 @@ class TestUtils(TestCase):
                         [0., 1.],
                         [0., 0.],
                         [0., 0.]])
-        P_I = bsr_matrix(P_I, blocksize=(1, 1))
+        P_I = bsr_array(P_I, blocksize=(1, 1))
         Fpts = np.array([0, 1, 2, 4, 5, 6, 8, 9])
         assert_equal(Cpts, params['Cpts'])
         assert_equal(Fpts, params['Fpts'])
@@ -824,16 +824,16 @@ class TestUtils(TestCase):
                   [1., 0.],
                   [0., 1.],
                   [0., 1.]])
-        AggOp = csr_matrix(AggOp)
+        AggOp = csr_array(AggOp)
         T = np.hstack((T.toarray(), T.toarray()))[:, [0, 2, 1, 3]]
-        T = bsr_matrix(T, blocksize=(2, 2))
+        T = bsr_array(T, blocksize=(2, 2))
         params = get_Cpt_params(A, Cpts, AggOp, T)
-        I_C = bsr_matrix((np.array([[[1., 0.], [0., 1.]],
+        I_C = bsr_array((np.array([[[1., 0.], [0., 1.]],
                                     [[1., 0.], [0., 1.]]]),
                           np.array([1, 3]),
                           np.array([0, 0, 1, 1, 2, 2])),
                          shape=(10, 10))
-        I_F = bsr_matrix((np.array([[[1., 0.], [0., 1.]],
+        I_F = bsr_array((np.array([[[1., 0.], [0., 1.]],
                                     [[1., 0.], [0., 1.]],
                                     [[1., 0.], [0., 1.]]]),
                           np.array([0, 2, 4]),
@@ -849,7 +849,7 @@ class TestUtils(TestCase):
                         [0., 0., 0., 1.],
                         [0., 0., 0., 0.],
                         [0., 0., 0., 0.]])
-        P_I = bsr_matrix(P_I, blocksize=(2, 2))
+        P_I = bsr_array(P_I, blocksize=(2, 2))
         Fpts = np.array([0, 1, 4, 5, 8, 9])
         Cpts = np.array([2, 3, 6, 7])
         assert_equal(Cpts, params['Cpts'])
@@ -868,21 +868,21 @@ class TestUtils(TestCase):
         # Trivially sized tests
         # 1x1x1
         T = np.array([[1.]])
-        T = bsr_matrix(T, blocksize=(1, 1))
+        T = bsr_array(T, blocksize=(1, 1))
         B = np.array([[1.]])
         BtBinv = compute_BtBinv(B, T)
         answer = np.array([[[1.]]])
         assert_array_almost_equal(BtBinv, answer)
 
         T = np.array([[1.]])
-        T = bsr_matrix(T, blocksize=(1, 1))
+        T = bsr_array(T, blocksize=(1, 1))
         B = np.array([[0.]])
         BtBinv = compute_BtBinv(B, T)
         answer = np.array([[[0.]]])
         assert_array_almost_equal(BtBinv, answer)
 
         T = np.array([[1.]])
-        T = bsr_matrix(T, blocksize=(1, 1))
+        T = bsr_array(T, blocksize=(1, 1))
         B = np.array([[0.5]])
         BtBinv = compute_BtBinv(B, T)
         answer = np.array([[[4.]]])
@@ -890,21 +890,21 @@ class TestUtils(TestCase):
 
         # 2x1x1
         T = np.array([[1., 0.], [1., 1.]])
-        T = bsr_matrix(T, blocksize=(1, 1))
+        T = bsr_array(T, blocksize=(1, 1))
         B = np.array([[1.], [1.]])
         BtBinv = compute_BtBinv(B, T)
         answer = np.array([[[1.]], [[0.5]]])
         assert_array_almost_equal(BtBinv, answer)
 
         T = np.array([[1., 0.], [1., 1.]])
-        T = bsr_matrix(T, blocksize=(1, 1))
+        T = bsr_array(T, blocksize=(1, 1))
         B = np.array([[0.], [1.]])
         BtBinv = compute_BtBinv(B, T)
         answer = np.array([[[0.]], [[1.]]])
         assert_array_almost_equal(BtBinv, answer)
 
         T = np.array([[1., 0.], [1., 1.]])
-        T = bsr_matrix(T, blocksize=(2, 2))
+        T = bsr_array(T, blocksize=(2, 2))
         B = np.array([[0.], [2.]])
         BtBinv = compute_BtBinv(B, T)
         answer = np.array([[[0.25]]])
@@ -912,7 +912,7 @@ class TestUtils(TestCase):
 
         T = np.array([[1., 0.], [1., 0.],
                       [0., .5], [0., .25]])
-        T = bsr_matrix(T, blocksize=(1, 1))
+        T = bsr_array(T, blocksize=(1, 1))
         B = np.array([[1.], [2.]])
         BtBinv = compute_BtBinv(B, T)
         answer = np.array([[[1.]], [[1.]],
@@ -920,7 +920,7 @@ class TestUtils(TestCase):
         assert_array_almost_equal(BtBinv, answer)
 
         T = np.array([[1., 0.], [0., .25]])
-        T = bsr_matrix(T, blocksize=(1, 1))
+        T = bsr_array(T, blocksize=(1, 1))
         B = np.array([[1., 1.], [2., 1.]])
         BtBinv = compute_BtBinv(B, T)
         answer = np.array([[[0.25, 0.25], [0.25, 0.25]],
@@ -928,7 +928,7 @@ class TestUtils(TestCase):
         assert_array_almost_equal(BtBinv, answer)
 
         T = np.array([[1., 0.], [0., .25]])
-        T = bsr_matrix(T, blocksize=(2, 2))
+        T = bsr_array(T, blocksize=(2, 2))
         B = np.array([[1., 1.], [1., 1.]])
         BtBinv = compute_BtBinv(B, T)
         answer = np.array([[[0.125, 0.125],
@@ -940,7 +940,7 @@ class TestUtils(TestCase):
                       [1., 1., 0., 0.],
                       [0., 0., 0.5, 0.5],
                       [0., 0., 0.25, 0.25]])
-        T = bsr_matrix(T, blocksize=(2, 2))
+        T = bsr_array(T, blocksize=(2, 2))
         B = np.array([[1., 1.], [1., 2.], [1., 1.], [1., 3.]])
         BtBinv = compute_BtBinv(B, T)
         answer = np.array([[[5., -3.], [-3., 2.]],
@@ -996,7 +996,7 @@ class TestUtils(TestCase):
 
     def test_filter_matrix_rows(self):
         from pyamg.util.utils import filter_matrix_rows
-        A = csr_matrix(np.array([[0.24, -0.5, 0., 0.],
+        A = csr_array(np.array([[0.24, -0.5, 0., 0.],
                                  [1., 1., 0.49, 0.],
                                  [0., -0.5, 1., -0.5]]))
 
@@ -1022,7 +1022,7 @@ class TestUtils(TestCase):
 
     def test_filter_matrix_columns(self):
         from pyamg.util.utils import filter_matrix_columns
-        A = csr_matrix(np.array([[0.24, 1., 0.],
+        A = csr_array(np.array([[0.24, 1., 0.],
                                  [-0.5, 1., -0.5],
                                  [0., 0.49, 1.],
                                  [0., 0., -0.5]]))
@@ -1035,7 +1035,7 @@ class TestUtils(TestCase):
 
     def test_truncate_rows(self):
         from pyamg.util.utils import truncate_rows
-        A = csr_matrix(np.array([[-0.24, -0.5, 0., 0.],
+        A = csr_array(np.array([[-0.24, -0.5, 0., 0.],
                                  [1., -1.1, 0.49, 0.1],
                                  [0., 0.4, 1., 0.5]]))
         Acopy = A.copy()
@@ -1091,26 +1091,26 @@ class TestComplexUtils(TestCase):
     def test_diag_sparse(self):
         # check sparse -> array
         A = np.array([[-4-4.0j]])
-        assert_equal(diag_sparse(csr_matrix(A)), [-4-4.0j])
+        assert_equal(diag_sparse(csr_array(A)), [-4-4.0j])
 
         A = np.array([[1, 0, -5], [-2, 5-2.0j, 0]])
-        assert_equal(diag_sparse(csr_matrix(A)), [1, 5-2.0j])
+        assert_equal(diag_sparse(csr_array(A)), [1, 5-2.0j])
 
         # check array -> sparse
         A = np.array([[-4+1.0j]])
         assert_equal(diag_sparse(np.array([-4+1.0j])).toarray(),
-                     csr_matrix(A).toarray())
+                     csr_array(A).toarray())
 
         A = np.array([[1, 0], [0, 5-2.0j]])
         assert_equal(diag_sparse(np.array([1, 5-2.0j])).toarray(),
-                     csr_matrix(A).toarray())
+                     csr_array(A).toarray())
 
     def test_symmetric_rescaling(self):
         cases = []
         A = np.array([[5.5+1.0j, 3.5, 4.8],
                       [2., 9.9, 0.5-2.0j],
                       [6.5, 2.6, 5.7+1.0j]])
-        A = csr_matrix(A)
+        A = csr_array(A)
         cases.append(A)
         P = diag_sparse([1, 0, 1.0j])
         cases.append(P@A@P)
@@ -1156,8 +1156,8 @@ class TestComplexUtils(TestCase):
         for i in range(1, 6):
             A = np.random.rand(i, i)
             Ai = A + 1.0j*np.random.rand(i, i)
-            cases.append(csr_matrix(A))
-            cases.append(csr_matrix(Ai))
+            cases.append(csr_array(A))
+            cases.append(csr_array(Ai))
 
         for A in cases:
             D_A = get_diagonal(A, norm_eq=False, inv=False)
@@ -1205,7 +1205,7 @@ class TestComplexUtils(TestCase):
         w = 1.2
         x = np.ones((5, 1))
         y = np.random.rand(3, 2)
-        z = csr_matrix(np.random.rand(2, 2))
+        z = csr_array(np.random.rand(2, 2))
         inlist = [w, x, y, z]
 
         out = to_type(complex, inlist)
@@ -1221,7 +1221,7 @@ class TestComplexUtils(TestCase):
         w = 1.2
         x = np.ones((5, 1))
         y = np.random.rand(3, 2)
-        z = csr_matrix(np.random.rand(2, 2))
+        z = csr_array(np.random.rand(2, 2))
         inlist = [w, x, y, z]
 
         out = type_prep(complex, inlist)
@@ -1243,7 +1243,7 @@ class TestComplexUtils(TestCase):
                       [0, 1, 0], [0, 0, 1], [0, 0, 1]])
         B = np.ones((3, 1)) + 0.j
         Bf = np.ones((6, 1)) + 1.0j * np.ones((6, 1))
-        A_filter = filter_operator(csr_matrix(A), csr_matrix(C), B, Bf)
+        A_filter = filter_operator(csr_array(A), csr_array(C), B, Bf)
         A_filter = A_filter.toarray()
         A_known = np.array([[0.5+0.5j, 0.5+0.5j, 0.0+0.j],
                             [0.5+0.5j, 0.5+0.5j, 0.0+0.j],
@@ -1260,7 +1260,7 @@ class TestComplexUtils(TestCase):
         ww = np.arange(Bf.shape[0]).reshape(-1, 1) +\
             1.0j*np.arange(Bf.shape[0]).reshape(-1, 1)
         Bf = np.hstack((Bf, ww))
-        A_filter = filter_operator(csr_matrix(A), csr_matrix(C), B, Bf)
+        A_filter = filter_operator(csr_array(A), csr_array(C), B, Bf)
         A_filter = A_filter.toarray()
         A_known = np.array([[1.0+1.j, 0.0+0.j, 0.0+0.j],
                             [0.0+0.j, 1.0+1.j, 0.0+0.j],
@@ -1296,7 +1296,7 @@ class TestComplexUtils(TestCase):
                         [0., 0., 0., 1., 0., 0.],
                         [0., 0., 0., 0., 1., 0.],
                         [0., 0., 0., 0., 0., 0.]])
-        T_scaled = scale_T(bsr_matrix(T), bsr_matrix(P_I), bsr_matrix(I_F))
+        T_scaled = scale_T(bsr_array(T), bsr_array(P_I), bsr_array(I_F))
         T_scaled = T_scaled.toarray()
         assert_array_almost_equal(T_answer, T_scaled)
 
@@ -1333,9 +1333,9 @@ class TestComplexUtils(TestCase):
                              [0.0+0.j, 0.0+0.j, 0.0+0.j, 1.0+0.j],
                              [0.0+0.j, 0.0+0.j, 0.0-0.5j, 1.0+0.j],
                              [0.0+0.j, 0.0+0.j, 0.0-0.5j, 1.0+0.j]])
-        T = bsr_matrix(T, blocksize=(2, 2))
-        P_I = bsr_matrix(P_I, blocksize=(2, 2))
-        I_F = bsr_matrix(I_F, blocksize=(2, 2))
+        T = bsr_array(T, blocksize=(2, 2))
+        P_I = bsr_array(P_I, blocksize=(2, 2))
+        I_F = bsr_array(I_F, blocksize=(2, 2))
         T_scaled = scale_T(T, P_I, I_F).toarray()
         assert_array_almost_equal(T_answer, T_scaled)
 
@@ -1343,7 +1343,7 @@ class TestComplexUtils(TestCase):
         # Simple CSR test
         T = np.array([[1.j, 0.], [1., 0.],
                       [0., .5], [0., .25]])
-        T = bsr_matrix(T, blocksize=(1, 1))
+        T = bsr_array(T, blocksize=(1, 1))
         B = np.array([[1.+1.j], [2.j]])
         BtBinv = compute_BtBinv(B, T)
         answer = np.array([[[0.50+0.j]], [[0.50+0.j]],
@@ -1355,7 +1355,7 @@ class TestComplexUtils(TestCase):
                       [1., 0., 0., 1.],
                       [0., 0., 0.5, 0.],
                       [0., 0., 0.25, 0.]])
-        T = bsr_matrix(T, blocksize=(2, 2))
+        T = bsr_array(T, blocksize=(2, 2))
         B = np.array([[1.j, 1.], [1.j, 3.], [1.j, 4.], [1.j, 2.]])
         BtBinv = compute_BtBinv(B, T)
         answer = np.array([[[1.5+0.j, 0.0+0.5j], [0.0-0.5j, 0.2+0.j]],

--- a/pyamg/util/tests/test_utils.py
+++ b/pyamg/util/tests/test_utils.py
@@ -1,6 +1,6 @@
 """Test utils."""
 import numpy as np
-from scipy.sparse import bsr_matrix, csr_matrix, csc_matrix, issparse, diags
+from scipy.sparse import bsr_matrix, csr_matrix, csc_matrix, issparse, diags_array
 
 from numpy.testing import (TestCase, assert_equal, assert_almost_equal,
                            assert_array_almost_equal, assert_array_equal)
@@ -117,7 +117,7 @@ class TestUtils(TestCase):
         # case 1
         e = np.ones((5, 1)).ravel()
         data = [-1*e, 2*e, -1*e]
-        A = diags(data, offsets=[-1, 0, 1], shape=(5, 5), format='csr')
+        A = diags_array(data, offsets=[-1, 0, 1], shape=(5, 5), format='csr')
         B = e.copy().reshape(-1, 1)
         DAD_answer = np.array([[1., -0.5, 0., 0., 0.],
                                [-0.5, 1., -0.5, 0., 0.],
@@ -1131,7 +1131,7 @@ class TestComplexUtils(TestCase):
         # case 1
         e = 1.0j*np.ones((5, 1)).ravel()
         data = [-1*e, 2*e, -1*e]
-        A = 1.0j * diags(data, offsets=[-1, 0, 1], shape=(5, 5), format='csr')
+        A = 1.0j * diags_array(data, offsets=[-1, 0, 1], shape=(5, 5), format='csr')
         B = e.copy().reshape(-1, 1)
         DAD_answer = np.array([[1., -0.5, 0., 0., 0.],
                                [-0.5, 1., -0.5, 0., 0.],

--- a/pyamg/util/utils.py
+++ b/pyamg/util/utils.py
@@ -115,8 +115,9 @@ def diag_sparse(A):
     if np.ndim(A) != 1:
         raise ValueError('input diagonal array expected to be 1d')
 
-    return csr_array((np.asarray(A), np.arange(len(A)),
-                       np.arange(len(A)+1)), (len(A), len(A)))
+    N = len(A)
+    return csr_array((np.asarray(A), np.arange(N, dtype=np.int32),
+                      np.arange(N+1, dtype=np.int32)), shape=(N, N))
 
 
 def scale_rows(A, v, copy=True):
@@ -450,7 +451,7 @@ def type_prep(upcast_type, varlist):
     --------
     >>> import numpy as np
     >>> from pyamg.util.utils import type_prep
-    >>> from scipy.sparse.sputils import upcast
+    >>> from scipy.sparse._sputils import upcast
     >>> x = np.ones((5,1))
     >>> y = 2.0j*np.ones((5,1))
     >>> z = 2.3
@@ -490,7 +491,7 @@ def to_type(upcast_type, varlist):
     --------
     >>> import numpy as np
     >>> from pyamg.util.utils import to_type
-    >>> from scipy.sparse.sputils import upcast
+    >>> from scipy.sparse._sputils import upcast
     >>> x = np.ones((5,1))
     >>> y = 2.0j*np.ones((5,1))
     >>> varlist = to_type(upcast(x.dtype, y.dtype), [x, y])
@@ -1458,7 +1459,7 @@ def get_Cpt_params(A, Cnodes, AggOp, T):
     else:
         blocksize = 1
         Cpts = Cnodes
-    Cpts = np.array(Cpts, dtype=int)
+    Cpts = np.array(Cpts, dtype=np.int32)
 
     # More input checking
     if Cpts.shape[0] != T.shape[1]:
@@ -1589,7 +1590,7 @@ def compute_BtBinv(B, C):
     amg_core.calc_BtB(NullDim, Nnodes, cols_per_block,
                       np.ravel(np.asarray(Bsq)),
                       BsqCols, np.ravel(np.asarray(BtBinv)),
-                      C.indptr, C.indices)
+                      C.indptr.astype(np.int32), C.indices.astype(np.int32))
 
     # Invert each block of BtBinv, noting that amg_core.calc_BtB(...) returns
     # values in column-major form, thus necessitating the deep transpose
@@ -2182,7 +2183,7 @@ def scale_block_inverse(A, blocksize):
     N_block = A.shape[0] / blocksize
     Dinv = get_block_diag(A=A, blocksize=blocksize, inv_flag=True)
     scale = bsr_array((Dinv, np.arange(0, N_block), np.arange(0, N_block+1)),
-                       blocksize=[blocksize, blocksize], shape=A.shape)
+                      blocksize=[blocksize, blocksize], shape=A.shape)
     return scale @ A, scale
 
 

--- a/pyamg/util/utils.py
+++ b/pyamg/util/utils.py
@@ -3,7 +3,8 @@
 from warnings import warn
 
 import numpy as np
-from scipy.sparse import issparse, csr_matrix, csc_matrix, bsr_matrix, coo_matrix, eye
+from scipy.sparse import (issparse, eye_array,
+                          csr_matrix, csc_matrix, bsr_matrix, coo_matrix,)
 from scipy.linalg import eigvals
 
 # pylint: disable=no-name-in-module
@@ -49,14 +50,14 @@ def profile_solver(ml, accel=None, **kwargs):
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import diags
+    >>> from scipy.sparse import diags_array
     >>> from scipy.sparse.linalg import cg
     >>> from pyamg.classical import ruge_stuben_solver
     >>> from pyamg.util.utils import profile_solver
     >>> n=100
     >>> e = np.ones((n,1)).ravel()
     >>> data = [ -1*e, 2*e, -1*e ]
-    >>> A = diags(data, offsets=[-1,0,1], shape=(n,n), format='csr')
+    >>> A = diags_array(data, offsets=[-1,0,1], shape=(n,n), format='csr')
     >>> b = A @ np.ones(A.shape[0])
     >>> ml = ruge_stuben_solver(A, max_coarse=10)
     >>> res = profile_solver(ml,accel=cg)
@@ -151,12 +152,12 @@ def scale_rows(A, v, copy=True):
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import diags
+    >>> from scipy.sparse import diags_array
     >>> from pyamg.util.utils import scale_rows
     >>> n=5
     >>> e = np.ones((n,1)).ravel()
     >>> data = [ -1*e, 2*e, -1*e ]
-    >>> A = diags(data, offsets=[-1, 0, 1], shape=(n,n-1), format='csr')
+    >>> A = diags_array(data, offsets=[-1, 0, 1], shape=(n,n-1), format='csr')
     >>> B = scale_rows(A, 5 * np.ones((A.shape[0], 1)))
 
     """
@@ -224,12 +225,12 @@ def scale_columns(A, v, copy=True):
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import diags
+    >>> from scipy.sparse import diags_array
     >>> from pyamg.util.utils import scale_columns
     >>> n=5
     >>> e = np.ones((n,1)).ravel()
     >>> data = [ -1*e, 2*e, -1*e ]
-    >>> A = diags(data, offsets=[-1, 0, 1], shape=(n,n-1), format='csr')
+    >>> A = diags_array(data, offsets=[-1, 0, 1], shape=(n,n-1), format='csr')
     >>> print(scale_columns(A, 5 * np.ones((A.shape[1], 1))).toarray())
     [[10. -5.  0.  0.]
      [-5. 10. -5.  0.]
@@ -305,12 +306,12 @@ def symmetric_rescaling(A, copy=True):
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import diags
+    >>> from scipy.sparse import diags_array
     >>> from pyamg.util.utils import symmetric_rescaling
     >>> n=5
     >>> e = np.ones((n,1)).ravel()
     >>> data = [ -1*e, 2*e, -1*e ]
-    >>> A = diags(data, offsets=[-1, 0, 1], shape=(n,n), format='csr')
+    >>> A = diags_array(data, offsets=[-1, 0, 1], shape=(n,n), format='csr')
     >>> Ds, Dsi, DAD = symmetric_rescaling(A)
     >>> print(DAD.toarray())
     [[ 1.  -0.5  0.   0.   0. ]
@@ -379,12 +380,12 @@ def symmetric_rescaling_sa(A, B, BH=None):
     Examples
     --------
     >>> import numpy as np
-    >>> from scipy.sparse import diags
+    >>> from scipy.sparse import diags_array
     >>> from pyamg.util.utils import symmetric_rescaling_sa
     >>> n=5
     >>> e = np.ones((n,1)).ravel()
     >>> data = [ -1*e, 2*e, -1*e ]
-    >>> A = diags(data, offsets=[-1, 0, 1], shape=(n,n), format='csr')
+    >>> A = diags_array(data, offsets=[-1, 0, 1], shape=(n,n), format='csr')
     >>> B = e.copy().reshape(-1,1)
     >>> [DAD, DB, DBH] = symmetric_rescaling_sa(A,B,BH=None)
     >>> print(DAD.toarray())
@@ -1471,7 +1472,7 @@ def get_Cpt_params(A, Cnodes, AggOp, T):
 
     # Create two maps, one for F points and one for C points
     ncoarse = T.shape[1]
-    I_C = eye(A.shape[0], A.shape[1], format='csr')
+    I_C = eye_array(A.shape[0], A.shape[1], format='csr')
     I_F = I_C.copy()
     I_F.data[Cpts] = 0.0
     I_F.eliminate_zeros()
@@ -1661,7 +1662,7 @@ def eliminate_diag_dom_nodes(A, C, theta=1.02):
         diag_dom_rows = diag_dom_rows == bsize
 
     # Replace these rows/cols in # C with rows/cols of the identity.
-    Id = eye(C.shape[0], C.shape[1], format='csr')
+    Id = eye_array(C.shape[0], C.shape[1], format='csr')
     Id.data[diag_dom_rows] = 0.0
     C = Id @ C @ Id
     Id.data[diag_dom_rows] = 1.0

--- a/pyamg/vis/tests/test_vis.py
+++ b/pyamg/vis/tests/test_vis.py
@@ -3,7 +3,7 @@
 import tempfile
 import os
 
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_array
 from numpy import array, ones, uint32
 
 from numpy.testing import TestCase
@@ -49,7 +49,7 @@ class TestVis(TestCase):
         col = array([1, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1])
         data = ones((1, 12), dtype=uint32).ravel()
 
-        AggOp = csr_matrix((data, (row, col)), shape=(12, 2))
+        AggOp = csr_array((data, (row, col)), shape=(12, 2))
 
         vis_aggregate_groups(V=V, E2V=E2V, AggOp=AggOp, mesh_type='tri',
                              fname=self.file_name)
@@ -102,7 +102,7 @@ class TestVis(TestCase):
                      1, 3, 4, 0, 0, 0, 2, 4, 4])
         data = ones((1, 18), dtype=uint32).ravel()
 
-        AggOp = csr_matrix((data, (row, col)), shape=(18, 5))
+        AggOp = csr_array((data, (row, col)), shape=(18, 5))
 
         vis_aggregate_groups(V=V, E2V=E2V, AggOp=AggOp, mesh_type='tri',
                              fname=self.file_name)

--- a/pyamg/vis/vis_coarse.py
+++ b/pyamg/vis/vis_coarse.py
@@ -10,7 +10,7 @@ vis_aggregate_groups: visualize aggregation through groupins of edges, elements
 
 import warnings
 import numpy as np
-from scipy.sparse import csr_matrix, coo_matrix, triu
+from scipy.sparse import csr_array, coo_array, triu
 from .vtk_writer import write_basic_mesh, write_vtu
 
 
@@ -26,7 +26,7 @@ def vis_aggregate_groups(V, E2V, AggOp, mesh_type,
         coordinate array (N x D)
     E2V : {array}
         element index array (Nel x Nelnodes)
-    AggOp : {csr_matrix}
+    AggOp : {csr_array}
         sparse matrix for the aggregate-vertex relationship (N x Nagg)
     mesh_type : {string}
         type of elements: vertex, tri, quad, tet, hex (all 3d)
@@ -74,7 +74,7 @@ def vis_aggregate_groups(V, E2V, AggOp, mesh_type,
         raise ValueError(f'Unknown mesh_type={mesh_type}')
     key = map_type_to_key[mesh_type]
 
-    AggOp = csr_matrix(AggOp)
+    AggOp = csr_array(AggOp)
 
     # remove elements with dirichlet BCs
     if E2V.max() >= AggOp.shape[0]:
@@ -111,7 +111,7 @@ def vis_aggregate_groups(V, E2V, AggOp, mesh_type,
     data = np.ones((len(col),))
     if len(row) != len(col):
         raise ValueError('Problem constructing vertex-to-vertex map')
-    V2V = coo_matrix((data, (row, col)), shape=(E2V.shape[0], E2V.max()+1))
+    V2V = coo_array((data, (row, col)), shape=(E2V.shape[0], E2V.max()+1))
     V2V = V2V.T @ V2V
     V2V = triu(V2V, 1).tocoo()
 


### PR DESCRIPTION
Migrate to sparray:
- use sparray construction methods, 
- replace removed methods, 
- change from `*_matrix` to`*_array`,
- add dtype to e.g. `np.arange` to ensure `int32` index dtypes for the extension function calls

The commits are split into 3 parts if that is easier to review (probably isn't).
- update to new functions and replace removed methods
- change `*_matrix` to `*_array`
- fix the dtype errors and a couple others: 
    - Integer indexing works in SciPy 1.15, but not 1.11-1.14. Used the older workaround: `S[:, [i]]` instead of `S[:, i]`. 
    - Convert `_**k` to `sparse.linalg.matrix_power(_, k)` --not sure why I missed that in pass 1 PR.]

I think this checks all boxes in #429 except the bullet at the end which says "tests to confirm". I can help with that but not sure what you had in mind.

**Reason for dtype stuff:**
The extension code works with sparse index dtype `int32`. And that worked fine with spmatrix even when construction used `int64` index dtype because spmatrix chooses the index dtype based on **values** in the index arrays.  With sparray (and the Numpy 2.x changes) the dtype is selected based on **dtype only** -- not values. So e.g. `np.arange()` defaults to `int64` instead of selecting type based on values. Similarly `csr_array` chooses the index `dtype` based on the `dtype` of the input index arrays... not on their values. So we have to be more careful with setting `row` and `col` dtypes. There are a lot of changes like `np.arange(6, dtype=np.int32)` to enable the `csr_array`s to work with `amg_core` extension code. 