### PR TITLE
fix int32; fix sparse slice

### DIFF
--- a/docs/logo/pyamg_logo.py
+++ b/docs/logo/pyamg_logo.py
@@ -46,7 +46,7 @@ def plotaggs(AggOp, V, E, G,
             todraw.append(newobj)
 
         for i in aggids:                                   # for each point in the aggregate
-            nbrs = G[i, :].col                             # get the neighbors in the graph
+            nbrs = G[[i], :].indices                       # get the neighbors in the graph
 
             for j1 in nbrs:                                # for each neighbor
                 found = False                              # mark if triangle is found

--- a/docs/logo/pyamg_logo.py
+++ b/docs/logo/pyamg_logo.py
@@ -5,7 +5,7 @@ from scipy.io import loadmat
 import matplotlib as mplt
 import matplotlib.pyplot as plt
 import shapely.geometry as sg
-from shapely.ops import cascaded_union
+from shapely.ops import unary_union
 
 import pyamg
 from pyamg.gallery.fem import Mesh, gradgradform
@@ -46,7 +46,7 @@ def plotaggs(AggOp, V, E, G,
             todraw.append(newobj)
 
         for i in aggids:                                   # for each point in the aggregate
-            nbrs = G[i, :].indices                         # get the neighbors in the graph
+            nbrs = G[i, :].col                             # get the neighbors in the graph
 
             for j1 in nbrs:                                # for each neighbor
                 found = False                              # mark if triangle is found
@@ -63,7 +63,7 @@ def plotaggs(AggOp, V, E, G,
                     newobj = sg.LineString(coords)         # add a line object to the list
                     todraw.append(newobj)
 
-        todraw = cascaded_union(todraw)                    # union objects in the aggregate
+        todraw = unary_union(todraw)                    # union objects in the aggregate
         todraw = todraw.buffer(0.1)                        # expand to smooth
         todraw = todraw.buffer(-0.05)                      # then contract
 

--- a/pyamg/aggregation/aggregate.py
+++ b/pyamg/aggregation/aggregate.py
@@ -44,7 +44,7 @@ def standard_aggregation(C):
     array([[1, 0],
            [1, 0],
            [0, 1],
-           [0, 1]], dtype=int8)
+           [0, 1]], dtype=int32)
     >>> A = csr_array([[1,0,0],[0,1,1],[0,1,1]])
     >>> A.toarray()                      # first vertex is isolated
     array([[1, 0, 0],
@@ -53,7 +53,7 @@ def standard_aggregation(C):
     >>> standard_aggregation(A)[0].toarray() # one aggregate
     array([[0],
            [1],
-           [1]], dtype=int8)
+           [1]], dtype=int32)
 
     """
     if not sparse.issparse(C) or C.format != 'csr':
@@ -137,7 +137,7 @@ def naive_aggregation(C):
     array([[1, 0],
            [1, 0],
            [0, 1],
-           [0, 1]], dtype=int8)
+           [0, 1]], dtype=int32)
     >>> A = csr_array([[1,0,0],[0,1,1],[0,1,1]])
     >>> A.toarray()                      # first vertex is isolated
     array([[1, 0, 0],
@@ -146,7 +146,7 @@ def naive_aggregation(C):
     >>> naive_aggregation(A)[0].toarray() # two aggregates
     array([[1, 0],
            [0, 1],
-           [0, 1]], dtype=int8)
+           [0, 1]], dtype=int32)
 
     """
     if not sparse.issparse(C) or C.format != 'csr':
@@ -215,12 +215,12 @@ def pairwise_aggregation(A, matchings=2, theta=0.25,
     array([[1, 0],
            [1, 0],
            [0, 1],
-           [0, 1]], dtype=int8)
+           [0, 1]], dtype=int32)
     >>> pairwise_aggregation(A, matchings=2)[0].toarray() # one aggregate
     array([[1],
            [1],
            [1],
-           [1]], dtype=int8)
+           [1]], dtype=int32)
 
     See Also
     --------
@@ -362,7 +362,7 @@ def lloyd_aggregation(C, ratio=0.03, distance='unit', maxiter=10):
     array([[1],
            [1],
            [1],
-           [1]], dtype=int8)
+           [1]], dtype=int32)
     >>> # more seeding for two aggregates
     >>> Agg = lloyd_aggregation(A,ratio=0.5)[0].toarray()
 

--- a/pyamg/aggregation/aggregate.py
+++ b/pyamg/aggregation/aggregate.py
@@ -76,7 +76,7 @@ def standard_aggregation(C):
     # no nodes aggregated
     if num_aggregates == 0:
         # return all zero matrix and no Cpts
-        return sparse.csr_array((num_rows, 1), dtype='int8'), \
+        return sparse.csr_array((num_rows, 1), dtype=np.int32), \
             np.array([], dtype=index_type)
 
     shape = (num_rows, num_aggregates)
@@ -86,12 +86,12 @@ def standard_aggregation(C):
         mask = Tj != -1
         row = np.arange(num_rows, dtype=index_type)[mask]
         col = Tj[mask]
-        data = np.ones(len(col), dtype='int8')
+        data = np.ones(len(col), dtype=np.int32)
         return sparse.coo_array((data, (row, col)), shape=shape).tocsr(), Cpts
 
     # all nodes aggregated
     Tp = np.arange(num_rows+1, dtype=index_type)
-    Tx = np.ones(len(Tj), dtype='int8')
+    Tx = np.ones(len(Tj), dtype=np.int32)
     return sparse.csr_array((Tx, Tj, Tp), shape=shape), Cpts
 
 
@@ -169,12 +169,12 @@ def naive_aggregation(C):
 
     if num_aggregates == 0:
         # all zero matrix
-        return sparse.csr_array((num_rows, 1), dtype='int8'), Cpts
+        return sparse.csr_array((num_rows, 1), dtype=np.int32), Cpts
 
     shape = (num_rows, num_aggregates)
     # all nodes aggregated
     Tp = np.arange(num_rows+1, dtype=index_type)
-    Tx = np.ones(len(Tj), dtype='int8')
+    Tx = np.ones(len(Tj), dtype=np.int32)
     return sparse.csr_array((Tx, Tj, Tp), shape=shape), Cpts
 
 
@@ -270,18 +270,18 @@ def pairwise_aggregation(A, matchings=2, theta=0.25,
         # Construct sparse T
         if num_aggregates == 0:
             # all zero matrix
-            T_temp = sparse.csr_array((num_rows, 1), dtype='int8')
+            T_temp = sparse.csr_array((num_rows, 1), dtype=np.int32)
             warn('No pairwise aggregates found, T = 0.')
         else:
             shape = (num_rows, num_aggregates)
             Tp = np.arange(num_rows+1, dtype=index_type)
             # If A is not BSR
             if not sparse.issparse(A) or A.format != 'bsr':
-                Tx = np.ones(len(Tj), dtype='int8')
+                Tx = np.ones(len(Tj), dtype=np.int32)
                 T_temp = sparse.csr_array((Tx, Tj, Tp), shape=shape)
             else:
                 shape = (shape[0]*A.blocksize[0], shape[1]*A.blocksize[1])
-                Tx = np.array(len(Tj)*[np.identity(A.blocksize[0])], dtype='int8')
+                Tx = np.array(len(Tj)*[np.identity(A.blocksize[0])], dtype=np.int32)
                 T_temp = sparse.bsr_array((Tx, Tj, Tp), blocksize=A.blocksize, shape=shape)
 
         # Form aggregation matrix, need to make sure is CSR/BSR
@@ -399,7 +399,7 @@ def lloyd_aggregation(C, ratio=0.03, distance='unit', maxiter=10):
 
     row = (clusters >= 0).nonzero()[0].astype(C.indices.dtype)
     col = clusters[row]
-    data = np.ones(len(row), dtype='int8')
+    data = np.ones(len(row), dtype=np.int32)
     AggOp = sparse.coo_array((data, (row, col)),
                               shape=(G.shape[0], num_seeds)).tocsr()
     return AggOp, seeds

--- a/pyamg/classical/split.py
+++ b/pyamg/classical/split.py
@@ -423,7 +423,7 @@ def _preprocess(S, coloring_method=None):
         raise ValueError(f'expected square matrix, shape={S.shape}')
 
     N = S.shape[0]
-    S = csr_array((np.ones(S.nnz, dtype='int8'), S.indices, S.indptr),
+    S = csr_array((np.ones(S.nnz, dtype=np.int32), S.indices, S.indptr),
                    shape=(N, N))
     T = S.T.tocsr()  # transpose S for efficient column access
 

--- a/pyamg/gallery/fem.py
+++ b/pyamg/gallery/fem.py
@@ -679,11 +679,11 @@ def gradgradform(mesh, kappa=None, f=None, degree=1):
     # allocate sparse matrix arrays
     m = 3 if degree == 1 else 6
     AA = np.zeros((ne, m**2))
-    IA = np.zeros((ne, m**2), dtype=int)
-    JA = np.zeros((ne, m**2), dtype=int)
+    IA = np.zeros((ne, m**2), dtype=np.int32)
+    JA = np.zeros((ne, m**2), dtype=np.int32)
     bb = np.zeros((ne, m))
-    ib = np.zeros((ne, m), dtype=int)
-    jb = np.zeros((ne, m), dtype=int)
+    ib = np.zeros((ne, m), dtype=np.int32)
+    jb = np.zeros((ne, m), dtype=np.int32)
 
     # Assemble A and b
     for ei in range(0, ne):

--- a/pyamg/gallery/tests/test_fem.py
+++ b/pyamg/gallery/tests/test_fem.py
@@ -321,5 +321,5 @@ def test_gradgrad_kappa():
 
     res = []
     ml = smoothed_aggregation_solver(A, max_coarse=10)
-    x = ml.solve(b, tol=1e-8, residuals=res)
-    assert res[-1] < 1e-6 
+    _ = ml.solve(b, tol=1e-8, residuals=res)
+    assert res[-1] < 1e-6

--- a/pyamg/gallery/tests/test_fem.py
+++ b/pyamg/gallery/tests/test_fem.py
@@ -3,6 +3,7 @@ import os
 import numpy as np
 import scipy.sparse.linalg as sla
 from pyamg.gallery import fem, regular_triangle_mesh
+from pyamg import smoothed_aggregation_solver
 
 test_dir = os.path.split(__file__)[0]
 base_dir = os.path.split(test_dir)[0]
@@ -317,3 +318,8 @@ def test_gradgrad_kappa():
     uex = uexact(mesh.X, mesh.Y)
     assert fem.l2norm(u - uex, mesh) < 1e-2
     assert np.abs(u - uex).max() < 1e-2
+
+    res = []
+    ml = smoothed_aggregation_solver(A, max_coarse=10)
+    x = ml.solve(b, tol=1e-8, residuals=res)
+    assert res[-1] < 1e-6 


### PR DESCRIPTION
In moving to sparse arrays, this PR fixes to issues:
1. a few dangling `int` vs `int32` casts.  Eventually we should instantiate `int64` for everything so it's not an issue.
2. slicing needs `A[[i],:]` (CSR array) rather than `A[i,:]` (COO array)