### PR TITLE
fix incorrect setuptools_scm usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "setuptools.build_meta"
 requires = [
     "setuptools>=42",
-    "setuptools_scm[toml]==8.3.0",
+    "setuptools_scm[toml]>=7.0.0",
     "pybind11>=2.8.0",
     "wheel",
 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,5 @@
 [metadata]
 name = pyamg
-version = attr: pyamg.__version__
 description = PyAMG: Algebraic Multigrid Solvers in Python
 long_description = file: README.md
 long_description_content_type = text/markdown


### PR DESCRIPTION
Remove the redundant `version` attribute from `setup.cfg` since `setuptools_scm` is used for versioning.  Using `setuptools_scm` to write the version to a file and simultaneosly reading it from that file (rather than taking it directly from `setuptools_scm`) is an "antipattern" and it is broken with modern `setuptools_scm` versions.

See https://github.com/pypa/setuptools-scm/issues/1216